### PR TITLE
S7 protocol: full refactor, threading architecture, and unified PLC state panel

### DIFF
--- a/ConfigFiles/connection/connection.yaml
+++ b/ConfigFiles/connection/connection.yaml
@@ -1,7 +1,7 @@
 connection_file_version: 1.0
 
 # -- Connection info --
-ip: "192.168.0.150:102"
+ip: "192.168.0.1:102"
 connection_protocol: "S7"
 plc_rack: 0
 plc_slot: 1
@@ -11,66 +11,38 @@ max_retries_attempts: 3
 polling_interval_ms: 100
 writing_timeout_ms: 5000
 commit_timeout_ms: 5000
-
-# -- Header DB --
-header_db_number: 1
-magic_number_offset: 0
-word_order_offset: 2
-protocol_version_offset: 4
-
-managing_db_number_offset: 6
-
-int_db_number_offset: 8
-float_db_number_offset: 10
-string_db_number_offset: 12
-execution_db_number_offset: 14
-
-header_db_total_size: 16
+keep_alive_interval_ms: 5000
 
 # -- Managing DB --
-managing_db_number: 2
-pc_status_offset: 0
-pc_transaction_id_offset: 2
-pc_checksum_int_offset: 6
-pc_checksum_float_offset: 10
-pc_checksum_string_offset: 14
-pc_recipe_lines_offset: 18
-plc_status_offset: 22
-plc_error_offset: 24
-plc_stored_id_offset: 26
-plc_checksum_int_offset: 30
-plc_checksum_float_offset: 34
-plc_checksum_string_offset: 38
-
-managing_db_total_size: 42
-managing_pc_data_size: 22
+managing_db_number: 995
+committed_offset: 0
+recipe_lines_offset: 4
+managing_db_total_size: 6
 
 # -- Int DB --
-int_db_number: 3
+int_db_number: 997
 int_db_total_capacity_offset: 0
-int_db_current_size_offset: 2
-int_db_data_offset: 4
+int_db_current_size_offset: 4
+int_db_data_offset: 8
 
 # -- Float DB --
-float_db_number: 4
+float_db_number: 998
 float_db_total_capacity_offset: 0
-float_db_current_size_offset: 2
-float_db_data_offset: 4
+float_db_current_size_offset: 4
+float_db_data_offset: 8
 
 # -- String DB --
-string_db_number: 5
+string_db_number: 999
 string_db_total_capacity_offset: 0
-string_db_current_size_offset: 2
-string_db_data_offset: 4
+string_db_current_size_offset: 4
+string_db_data_offset: 8
 
 # -- Execution DB --
-execution_db_number: 6
+execution_db_number: 996
 recipe_active_offset: 0
 actual_line_offset: 2
 step_current_time_offset: 6
-
 for_loop_count1_offset: 10
 for_loop_count2_offset: 14
 for_loop_count3_offset: 18
-
 execution_db_total_size: 22

--- a/SemiStep/Application/Program.cs
+++ b/SemiStep/Application/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System.Globalization;
 
+using Avalonia.ReactiveUI;
+
 using ClipBoard;
 
 using Config.Facade;
@@ -15,6 +17,8 @@ using FluentResults;
 
 using Microsoft.Extensions.DependencyInjection;
 
+using ReactiveUI;
+
 using S7;
 
 using Serilog;
@@ -29,37 +33,31 @@ public static class Program
 	private const string ConfigDir = @"C:\DISTR\Config\Semistep";
 	private const string LogFilePath = @"C:\DISTR\Logs\semistep.log";
 
-	public static async Task Main()
+	[STAThread]
+	public static void Main()
 	{
+		// Must be set before any DI singleton is resolved: ReactiveCommand captures
+		// RxApp.MainThreadScheduler at construction time. If set after DI build,
+		// commands capture DefaultScheduler and CanExecute fires off the UI thread.
+		RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
 		CreateLogger(LogFilePath);
 
 		try
 		{
-			var result = await ConfigFacade.LoadAndValidateAsync(ConfigDir);
+			var outcome = Task.Run(StartupAsync).GetAwaiter().GetResult();
 
-			if (result.IsFailed)
+			if (outcome.Errors is not null)
 			{
-				var errors = result.Errors.Select(e => e.Message).ToList();
-				Log.Error("Application startup failed: configuration loading produced {ErrorCount} error(s)", errors.Count);
-				App.RunErrorWindow(errors);
-				return;
+				App.RunErrorWindow(outcome.Errors);
 			}
-
-			var services =
-				new ServiceCollection()
-					.AddSingleton(result.Value)
-					.AddRecipe()
-					.AddDomain()
-					.AddS7()
-					.AddCsv()
-					.AddClipboard()
-					.AddUi();
-
-			var provider = services.BuildServiceProvider();
-
-			InitializeServices(provider);
-
-			App.Run(provider);
+			else if (outcome.Provider is not null)
+			{
+				App.Run(outcome.Provider);
+			}
+			else
+			{
+				App.RunErrorWindow(["Application startup failed: unknown error"]);
+			}
 		}
 		catch (Exception ex)
 		{
@@ -67,8 +65,39 @@ public static class Program
 		}
 		finally
 		{
-			await Log.CloseAndFlushAsync();
+			Log.CloseAndFlushAsync().GetAwaiter().GetResult();
 		}
+	}
+
+	private static async Task<(IServiceProvider? Provider, IReadOnlyList<string>? Errors)> StartupAsync()
+	{
+		var result = await ConfigFacade.LoadAndValidateAsync(ConfigDir);
+
+		if (result.IsFailed)
+		{
+			var errors = result.Errors.Select(e => e.Message).ToList();
+			Log.Error(
+				"Application startup failed: configuration loading produced {ErrorCount} error(s)",
+				errors.Count);
+
+			return (null, errors);
+		}
+
+		var services =
+			new ServiceCollection()
+				.AddSingleton(result.Value)
+				.AddRecipe()
+				.AddDomain()
+				.AddS7()
+				.AddCsv()
+				.AddClipboard()
+				.AddUi();
+
+		var provider = services.BuildServiceProvider();
+
+		InitializeServices(provider);
+
+		return (provider, null);
 	}
 
 	private static void InitializeServices(IServiceProvider provider)
@@ -121,8 +150,9 @@ public static class Program
 
 			return true;
 		}
-		catch
+		catch (Exception ex)
 		{
+			Console.Error.WriteLine($"Failed to create log directory for '{filePath}': {ex.Message}. File logging is disabled.");
 			return false;
 		}
 	}

--- a/SemiStep/Application/Program.cs
+++ b/SemiStep/Application/Program.cs
@@ -1,7 +1,5 @@
 ﻿using System.Globalization;
 
-using Avalonia.ReactiveUI;
-
 using ClipBoard;
 
 using Config.Facade;
@@ -17,14 +15,11 @@ using FluentResults;
 
 using Microsoft.Extensions.DependencyInjection;
 
-using ReactiveUI;
-
 using S7;
 
 using Serilog;
 
 using UI;
-using UI.Coordinator;
 
 namespace Application;
 
@@ -36,10 +31,6 @@ public static class Program
 	[STAThread]
 	public static void Main()
 	{
-		// Must be set before any DI singleton is resolved: ReactiveCommand captures
-		// RxApp.MainThreadScheduler at construction time. If set after DI build,
-		// commands capture DefaultScheduler and CanExecute fires off the UI thread.
-		RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
 		CreateLogger(LogFilePath);
 
 		try
@@ -93,20 +84,7 @@ public static class Program
 				.AddClipboard()
 				.AddUi();
 
-		var provider = services.BuildServiceProvider();
-
-		InitializeServices(provider);
-
-		return (provider, null);
-	}
-
-	private static void InitializeServices(IServiceProvider provider)
-	{
-		var domainFacade = provider.GetRequiredService<DomainFacade>();
-		domainFacade.Initialize();
-
-		var coordinator = provider.GetRequiredService<RecipeMutationCoordinator>();
-		coordinator.Initialize();
+		return (services.BuildServiceProvider(), null);
 	}
 
 	private static void CreateLogger(string logFilePath)

--- a/SemiStep/Domain/Domain.csproj
+++ b/SemiStep/Domain/Domain.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5"/>
     <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="System.Reactive" Version="6.0.1"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/SemiStep/Domain/Domain.csproj
+++ b/SemiStep/Domain/Domain.csproj
@@ -3,7 +3,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5"/>
     <PackageReference Include="Serilog" Version="4.3.1" />
-    <PackageReference Include="System.Reactive" Version="6.0.1"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/SemiStep/Domain/DomainDi.cs
+++ b/SemiStep/Domain/DomainDi.cs
@@ -19,7 +19,6 @@ public static class DomainDi
 		services.AddSingleton<RecipeHistoryManager>();
 		services.AddSingleton<ImportedRecipeValidator>();
 		services.AddSingleton(sp => new DomainFacade(
-			sp.GetRequiredService<AppConfiguration>(),
 			sp.GetRequiredService<ConfigRegistry>(),
 			sp.GetRequiredService<ICoreService>(),
 			sp.GetRequiredService<RecipeStateManager>(),

--- a/SemiStep/Domain/Facade/DomainFacade.cs
+++ b/SemiStep/Domain/Facade/DomainFacade.cs
@@ -16,25 +16,19 @@ namespace Domain.Facade;
 
 public sealed class DomainFacade : IDisposable
 {
-	private readonly AppConfiguration _appConfiguration;
 	private readonly IClipboardService _clipboardService;
-	private readonly ConfigRegistry _configRegistry;
 	private readonly IS7Service _connectionService;
 	private readonly ICoreService _coreService;
 	private readonly ICsvService _csvService;
 	private readonly RecipeHistoryManager _historyManager;
 	private readonly ImportedRecipeValidator _importedRecipeValidator;
-	private readonly IPropertyParser _propertyParser;
 	private readonly RecipeStateManager _stateManager;
 	private readonly IPlcSyncService _syncService;
-	private Action<PlcConnectionState>? _connectionStateChangedRelay;
-
+	private readonly PlcLifecycleManager _plcLifecycleManager;
+	private readonly RecipeEditService _editService;
 	private bool _disposed;
-	private bool _isSyncEnabled;
-	private Recipe? _pendingPlcRecipe;
 
 	internal DomainFacade(
-		AppConfiguration appConfiguration,
 		ConfigRegistry configRegistry,
 		ICoreService coreService,
 		RecipeStateManager stateManager,
@@ -46,8 +40,6 @@ public sealed class DomainFacade : IDisposable
 		IPropertyParser propertyParser,
 		IPlcSyncService syncService)
 	{
-		_appConfiguration = appConfiguration;
-		_configRegistry = configRegistry;
 		_coreService = coreService;
 		_stateManager = stateManager;
 		_historyManager = historyManager;
@@ -55,8 +47,22 @@ public sealed class DomainFacade : IDisposable
 		_connectionService = connectionService;
 		_clipboardService = clipboardService;
 		_importedRecipeValidator = importedRecipeValidator;
-		_propertyParser = propertyParser;
 		_syncService = syncService;
+		_plcLifecycleManager = new PlcLifecycleManager(
+			connectionService,
+			coreService,
+			historyManager,
+			stateManager,
+			syncService,
+			(local, plc) => PlcRecipeConflictDetected?.Invoke(local, plc));
+		_editService = new RecipeEditService(
+			coreService,
+			stateManager,
+			historyManager,
+			propertyParser,
+			configRegistry,
+			syncService,
+			() => _plcLifecycleManager.IsSyncEnabled);
 	}
 
 	public Recipe CurrentRecipe => _stateManager.Current;
@@ -68,14 +74,17 @@ public sealed class DomainFacade : IDisposable
 	public bool CanUndo => _historyManager.CanUndo;
 	public bool CanRedo => _historyManager.CanRedo;
 
-	public bool IsSyncEnabled => _isSyncEnabled;
+	public bool IsSyncEnabled => _plcLifecycleManager.IsSyncEnabled;
 	public bool IsConnected => _connectionService.IsConnected;
 	public bool IsRecipeActive => _connectionService.IsRecipeActive;
 	public IObservable<PlcExecutionInfo> ExecutionState => _connectionService.ExecutionState;
 
 	public PlcSyncStatus SyncStatus => _syncService.Status;
-	public string? SyncLastError => _syncService.LastError;
 	public DateTimeOffset? LastSyncTime => _syncService.LastSyncTime;
+
+	public IObservable<Result<PlcSessionSnapshot>> PlcState => _syncService.PlcState;
+
+	public event Action<Recipe, Recipe>? PlcRecipeConflictDetected;
 
 	public void Dispose()
 	{
@@ -85,11 +94,7 @@ public sealed class DomainFacade : IDisposable
 		}
 
 		_disposed = true;
-
-		if (_connectionStateChangedRelay is not null)
-		{
-			_connectionService.StateChanged -= _connectionStateChangedRelay;
-		}
+		_plcLifecycleManager.Dispose();
 	}
 
 	public static CellState GetCellState(GridColumnDefinition column, ActionDefinition action)
@@ -100,85 +105,42 @@ public sealed class DomainFacade : IDisposable
 	public void Initialize()
 	{
 		SetNewRecipe();
-
-		_connectionStateChangedRelay = state =>
-		{
-			ConnectionStateChanged?.Invoke(state);
-
-			if (state == PlcConnectionState.Disconnected && _isSyncEnabled)
-			{
-				_syncService.Reset();
-			}
-			else if (state == PlcConnectionState.Connected && _isSyncEnabled)
-			{
-				_ = PerformReconnectReconciliationAsync().ContinueWith(
-					t => Log.Error(t.Exception, "Unhandled error in reconnect reconciliation"),
-					TaskContinuationOptions.OnlyOnFaulted);
-			}
-		};
-		_connectionService.StateChanged += _connectionStateChangedRelay;
+		_plcLifecycleManager.Initialize();
 	}
 
 	public Result AppendStep(int actionId)
 	{
-		var snapshot = _coreService.AppendStep(CurrentRecipe, actionId);
-
-		return ApplyIfSucceeded(snapshot);
+		return _editService.AppendStep(actionId);
 	}
 
 	public Result InsertStep(int index, int actionId)
 	{
-		var snapshot = _coreService.InsertStep(CurrentRecipe, index, actionId);
-
-		return ApplyIfSucceeded(snapshot);
+		return _editService.InsertStep(index, actionId);
 	}
 
 	public Result RemoveStep(int index)
 	{
-		var snapshot = _coreService.RemoveStep(CurrentRecipe, index);
-
-		return ApplyIfSucceeded(snapshot);
+		return _editService.RemoveStep(index);
 	}
 
 	public Result InsertSteps(int startIndex, IReadOnlyList<Step> steps)
 	{
-		var snapshot = _coreService.InsertSteps(CurrentRecipe, startIndex, steps);
-
-		return ApplyIfSucceeded(snapshot);
+		return _editService.InsertSteps(startIndex, steps);
 	}
 
 	public Result RemoveSteps(IReadOnlyList<int> indices)
 	{
-		var snapshot = _coreService.RemoveSteps(CurrentRecipe, indices);
-
-		return ApplyIfSucceeded(snapshot);
+		return _editService.RemoveSteps(indices);
 	}
 
 	public Result ChangeStepAction(int stepIndex, int newActionId)
 	{
-		var snapshot = _coreService.ChangeStepAction(CurrentRecipe, stepIndex, newActionId);
-
-		return ApplyIfSucceeded(snapshot);
+		return _editService.ChangeStepAction(stepIndex, newActionId);
 	}
 
 	public Result UpdateStepProperty(int stepIndex, string columnKey, string value)
 	{
-		var propertyResult = ResolvePropertyDefinition(stepIndex, columnKey);
-		if (propertyResult.IsFailed)
-		{
-			return propertyResult.ToResult();
-		}
-
-		var parseResult = _propertyParser.Parse(value, propertyResult.Value);
-		if (parseResult.IsFailed)
-		{
-			return parseResult.ToResult();
-		}
-
-		var snapshot = _coreService.UpdateStepProperty(
-			CurrentRecipe, stepIndex, columnKey, parseResult.Value);
-
-		return ApplyIfSucceeded(snapshot);
+		return _editService.UpdateStepProperty(stepIndex, columnKey, value);
 	}
 
 	public Result Undo()
@@ -197,7 +159,7 @@ public sealed class DomainFacade : IDisposable
 			return snapshot.ToResult();
 		}
 
-		if (_isSyncEnabled)
+		if (IsSyncEnabled)
 		{
 			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
 		}
@@ -221,7 +183,7 @@ public sealed class DomainFacade : IDisposable
 			return snapshot.ToResult();
 		}
 
-		if (_isSyncEnabled)
+		if (IsSyncEnabled)
 		{
 			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
 		}
@@ -229,9 +191,7 @@ public sealed class DomainFacade : IDisposable
 		return Result.Ok().WithReasons(snapshot.Reasons);
 	}
 
-	public async Task<Result> LoadRecipeAsync(
-		string filePath,
-		CancellationToken ct = default)
+	public async Task<Result> LoadRecipeAsync(string filePath, CancellationToken ct = default)
 	{
 		var loadResult = await _csvService.LoadAsync(filePath, ct);
 		if (loadResult.IsFailed)
@@ -255,7 +215,7 @@ public sealed class DomainFacade : IDisposable
 			return snapshot.ToResult();
 		}
 
-		if (_isSyncEnabled)
+		if (IsSyncEnabled)
 		{
 			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
 		}
@@ -263,9 +223,7 @@ public sealed class DomainFacade : IDisposable
 		return Result.Ok().WithReasons(snapshot.Reasons);
 	}
 
-	public async Task SaveRecipeAsync(
-		string filePath,
-		CancellationToken ct = default)
+	public async Task SaveRecipeAsync(string filePath, CancellationToken ct = default)
 	{
 		await _csvService.SaveAsync(_stateManager.Current, filePath, ct);
 		_stateManager.MarkSaved();
@@ -274,39 +232,6 @@ public sealed class DomainFacade : IDisposable
 	public void MarkSaved()
 	{
 		_stateManager.MarkSaved();
-	}
-
-	private Result ApplyIfSucceeded(Result<RecipeSnapshot> snapshot)
-	{
-		if (snapshot.IsFailed)
-		{
-			return snapshot.ToResult();
-		}
-
-		_historyManager.Push(_stateManager.Current);
-		_stateManager.Update(snapshot);
-
-		if (_isSyncEnabled)
-		{
-			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
-		}
-
-		return Result.Ok().WithReasons(snapshot.Reasons);
-	}
-
-	private Result<PropertyTypeDefinition> ResolvePropertyDefinition(
-		int stepIndex,
-		string columnKey)
-	{
-		var recipe = _stateManager.Current;
-
-		var validationResult = ValidateStepIndex(stepIndex);
-		if (validationResult.IsFailed)
-		{
-			return validationResult.ToResult<PropertyTypeDefinition>();
-		}
-
-		return _configRegistry.ResolvePropertyType(recipe, stepIndex, columnKey);
 	}
 
 	public string SerializeStepsForClipboard(IReadOnlyList<Step> steps)
@@ -333,48 +258,14 @@ public sealed class DomainFacade : IDisposable
 		return result;
 	}
 
-	public string? LastConnectionError { get; private set; }
-
-	public event Action<PlcConnectionState>? ConnectionStateChanged;
-	public event Action<Recipe, Recipe>? PlcRecipeConflictDetected;
-
 	public async Task<Result> EnableSync(PlcConfiguration config)
 	{
-		if (_isSyncEnabled)
-		{
-			return Result.Ok();
-		}
-
-		try
-		{
-			LastConnectionError = null;
-			_isSyncEnabled = true;
-			await _connectionService.ConnectAsync(config.Connection);
-		}
-		catch (Exception ex)
-		{
-			_isSyncEnabled = false;
-			LastConnectionError = ex.Message;
-			Log.Warning("PLC connection failed: {Message}", ex.Message);
-			return Result.Fail(ex.Message);
-		}
-
-		return Result.Ok();
+		return await _plcLifecycleManager.EnableSync(config);
 	}
 
 	public async Task DisableSync()
 	{
-		_isSyncEnabled = false;
-		_syncService.Reset();
-
-		try
-		{
-			await _connectionService.DisconnectAsync();
-		}
-		catch (Exception ex)
-		{
-			Log.Warning("Error while disconnecting from PLC: {Message}", ex.Message);
-		}
+		await _plcLifecycleManager.DisableSync();
 	}
 
 	public async Task<Result> LoadRecipeFromPlcAsync(CancellationToken ct = default)
@@ -400,7 +291,7 @@ public sealed class DomainFacade : IDisposable
 			return snapshot.ToResult();
 		}
 
-		if (_isSyncEnabled)
+		if (IsSyncEnabled)
 		{
 			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
 		}
@@ -410,18 +301,7 @@ public sealed class DomainFacade : IDisposable
 
 	public void ResolveConflict(bool keepLocal)
 	{
-		if (keepLocal)
-		{
-			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
-		}
-		else
-		{
-			if (_pendingPlcRecipe is not null)
-			{
-				LoadPlcRecipeIntoState(_pendingPlcRecipe);
-				_pendingPlcRecipe = null;
-			}
-		}
+		_plcLifecycleManager.ResolveConflict(keepLocal, _stateManager);
 	}
 
 	public void SetNewRecipe()
@@ -436,82 +316,6 @@ public sealed class DomainFacade : IDisposable
 		{
 			Log.Warning("Empty recipe analysis unexpectedly failed: {Errors}",
 				string.Join("; ", snapshot.Errors.Select(e => e.Message)));
-		}
-	}
-
-	private Result ValidateStepIndex(int stepIndex)
-	{
-		var recipe = _stateManager.Current;
-		if (stepIndex < 0 || stepIndex >= recipe.Steps.Count)
-		{
-			return Result.Fail($"Step index {stepIndex} is out of range for recipe with {recipe.Steps.Count} steps");
-		}
-		return Result.Ok();
-	}
-
-	private async Task PerformReconnectReconciliationAsync(CancellationToken ct = default)
-	{
-		var managingAreaResult = await _connectionService.ReadManagingAreaAsync(ct);
-		if (managingAreaResult.IsFailed)
-		{
-			Log.Warning(
-				"Could not read managing area during reconnect reconciliation: {Errors}",
-				string.Join("; ", managingAreaResult.Errors.Select(e => e.Message)));
-			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
-			return;
-		}
-
-		if (!managingAreaResult.Value.Committed)
-		{
-			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
-			return;
-		}
-
-		var plcRecipeResult = await _connectionService.ReadRecipeFromPlcAsync(ct);
-		if (plcRecipeResult.IsFailed)
-		{
-			Log.Warning(
-				"Could not read PLC recipe during reconciliation: {Errors}",
-				string.Join("; ", plcRecipeResult.Errors.Select(e => e.Message)));
-			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
-			return;
-		}
-
-		var plcRecipe = plcRecipeResult.Value;
-		var localRecipe = _stateManager.Current;
-
-		if (localRecipe.Steps.Count == 0 && plcRecipe.Steps.Count > 0)
-		{
-			LoadPlcRecipeIntoState(plcRecipe);
-			return;
-		}
-
-		if (plcRecipe.Steps.Count > 0 && !localRecipe.Equals(plcRecipe))
-		{
-			_pendingPlcRecipe = plcRecipe;
-			PlcRecipeConflictDetected?.Invoke(localRecipe, plcRecipe);
-			return;
-		}
-
-		_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
-	}
-
-	private void LoadPlcRecipeIntoState(Recipe recipe)
-	{
-		_historyManager.Clear();
-		var snapshot = _coreService.AnalyzeRecipe(recipe);
-		_stateManager.Update(snapshot);
-
-		if (snapshot.IsFailed)
-		{
-			Log.Warning(
-				"PLC recipe analysis produced errors: {Errors}",
-				string.Join("; ", snapshot.Errors.Select(e => e.Message)));
-		}
-
-		if (_isSyncEnabled)
-		{
-			_syncService.NotifyRecipeChanged(_stateManager.Current, _stateManager.IsValid);
 		}
 	}
 }

--- a/SemiStep/Domain/Facade/DomainFacade.cs
+++ b/SemiStep/Domain/Facade/DomainFacade.cs
@@ -103,7 +103,7 @@ public sealed class DomainFacade : IDisposable
 
 		_connectionStateChangedRelay = state =>
 		{
-			ConnectionStateChanged?.Invoke();
+			ConnectionStateChanged?.Invoke(state);
 
 			if (state == PlcConnectionState.Disconnected && _isSyncEnabled)
 			{
@@ -335,7 +335,7 @@ public sealed class DomainFacade : IDisposable
 
 	public string? LastConnectionError { get; private set; }
 
-	public event Action? ConnectionStateChanged;
+	public event Action<PlcConnectionState>? ConnectionStateChanged;
 	public event Action<Recipe, Recipe>? PlcRecipeConflictDetected;
 
 	public async Task<Result> EnableSync(PlcConfiguration config)

--- a/SemiStep/Domain/Facade/DomainFacade.cs
+++ b/SemiStep/Domain/Facade/DomainFacade.cs
@@ -355,7 +355,7 @@ public sealed class DomainFacade : IDisposable
 		{
 			_isSyncEnabled = false;
 			LastConnectionError = ex.Message;
-			Log.Warning(ex, "PLC connection failed during sync enable");
+			Log.Warning("PLC connection failed: {Message}", ex.Message);
 			return Result.Fail(ex.Message);
 		}
 
@@ -373,7 +373,7 @@ public sealed class DomainFacade : IDisposable
 		}
 		catch (Exception ex)
 		{
-			Log.Warning(ex, "Error while disconnecting PLC during sync disable");
+			Log.Warning("Error while disconnecting from PLC: {Message}", ex.Message);
 		}
 	}
 

--- a/SemiStep/Domain/Facade/PlcLifecycleManager.cs
+++ b/SemiStep/Domain/Facade/PlcLifecycleManager.cs
@@ -1,0 +1,193 @@
+﻿using Domain.State;
+
+using FluentResults;
+
+using Serilog;
+
+using TypesShared.Core;
+using TypesShared.Domain;
+using TypesShared.Plc;
+
+namespace Domain.Facade;
+
+/// <summary>
+/// Manages PLC connection lifecycle and sync-related reconciliation on behalf of <see cref="DomainFacade"/>.
+/// </summary>
+internal sealed class PlcLifecycleManager(
+	IS7Service connectionService,
+	ICoreService coreService,
+	RecipeHistoryManager historyManager,
+	RecipeStateManager stateManager,
+	IPlcSyncService syncService,
+	Action<Recipe, Recipe> raiseConflictDetected)
+	: IDisposable
+{
+	private Action<PlcConnectionState>? _connectionStateHandler;
+	private bool _disposed;
+	private bool _isSyncEnabled;
+	private Recipe? _pendingPlcRecipe;
+
+	public bool IsSyncEnabled => _isSyncEnabled;
+
+	public void Initialize()
+	{
+		_connectionStateHandler = state =>
+		{
+			if (state == PlcConnectionState.Disconnected && _isSyncEnabled)
+			{
+				syncService.Reset();
+			}
+			else if (state == PlcConnectionState.Connected && _isSyncEnabled)
+			{
+				_ = PerformReconnectReconciliationAsync().ContinueWith(
+					t => Log.Error(t.Exception, "Unhandled error in reconnect reconciliation"),
+					TaskContinuationOptions.OnlyOnFaulted);
+			}
+
+			syncService.UpdateConnectionState(state);
+		};
+		connectionService.StateChanged += _connectionStateHandler;
+	}
+
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		_disposed = true;
+
+		if (_connectionStateHandler is not null)
+		{
+			connectionService.StateChanged -= _connectionStateHandler;
+		}
+	}
+
+	public async Task<Result> EnableSync(PlcConfiguration config)
+	{
+		if (_isSyncEnabled)
+		{
+			return Result.Ok();
+		}
+
+		try
+		{
+			_isSyncEnabled = true;
+			syncService.SetSyncEnabled(true);
+			await connectionService.ConnectAsync(config.Connection);
+		}
+		catch (Exception ex)
+		{
+			_isSyncEnabled = false;
+			syncService.SetSyncEnabled(false);
+			Log.Warning("PLC connection failed: {Message}", ex.Message);
+			return Result.Fail(ex.Message);
+		}
+
+		return Result.Ok();
+	}
+
+	public async Task DisableSync()
+	{
+		_isSyncEnabled = false;
+		syncService.SetSyncEnabled(false);
+		syncService.Reset();
+
+		try
+		{
+			await connectionService.DisconnectAsync();
+		}
+		catch (Exception ex)
+		{
+			Log.Warning("Error while disconnecting from PLC: {Message}", ex.Message);
+		}
+	}
+
+	public void ResolveConflict(bool keepLocal, RecipeStateManager stateManager)
+	{
+		if (keepLocal)
+		{
+			syncService.NotifyRecipeChanged(stateManager.Current, stateManager.IsValid);
+		}
+		else
+		{
+			if (_pendingPlcRecipe is not null)
+			{
+				LoadPlcRecipeIntoState(_pendingPlcRecipe);
+				_pendingPlcRecipe = null;
+			}
+		}
+	}
+
+	private async Task PerformReconnectReconciliationAsync(CancellationToken ct = default)
+	{
+		var managingAreaResult = await connectionService.ReadManagingAreaAsync(ct);
+		if (managingAreaResult.IsFailed)
+		{
+			Log.Warning(
+				"Could not read managing area during reconnect reconciliation: {Errors}",
+				string.Join("; ", managingAreaResult.Errors.Select(e => e.Message)));
+			NotifyLocalRecipe();
+			return;
+		}
+
+		if (!managingAreaResult.Value.Committed)
+		{
+			NotifyLocalRecipe();
+			return;
+		}
+
+		var plcRecipeResult = await connectionService.ReadRecipeFromPlcAsync(ct);
+		if (plcRecipeResult.IsFailed)
+		{
+			Log.Warning(
+				"Could not read PLC recipe during reconciliation: {Errors}",
+				string.Join("; ", plcRecipeResult.Errors.Select(e => e.Message)));
+			NotifyLocalRecipe();
+			return;
+		}
+
+		var plcRecipe = plcRecipeResult.Value;
+		var localRecipe = stateManager.Current;
+
+		if (localRecipe.Steps.Count == 0 && plcRecipe.Steps.Count > 0)
+		{
+			LoadPlcRecipeIntoState(plcRecipe);
+			return;
+		}
+
+		if (plcRecipe.Steps.Count > 0 && !localRecipe.Equals(plcRecipe))
+		{
+			_pendingPlcRecipe = plcRecipe;
+			raiseConflictDetected(localRecipe, plcRecipe);
+			return;
+		}
+
+		NotifyLocalRecipe();
+	}
+
+	private void NotifyLocalRecipe()
+	{
+		syncService.NotifyRecipeChanged(stateManager.Current, stateManager.IsValid);
+	}
+
+	private void LoadPlcRecipeIntoState(Recipe recipe)
+	{
+		historyManager.Clear();
+		var snapshot = coreService.AnalyzeRecipe(recipe);
+		stateManager.Update(snapshot);
+
+		if (snapshot.IsFailed)
+		{
+			Log.Warning(
+				"PLC recipe analysis produced errors: {Errors}",
+				string.Join("; ", snapshot.Errors.Select(e => e.Message)));
+		}
+
+		if (_isSyncEnabled)
+		{
+			syncService.NotifyRecipeChanged(stateManager.Current, stateManager.IsValid);
+		}
+	}
+}

--- a/SemiStep/Domain/Facade/PlcLifecycleManager.cs
+++ b/SemiStep/Domain/Facade/PlcLifecycleManager.cs
@@ -31,21 +31,7 @@ internal sealed class PlcLifecycleManager(
 
 	public void Initialize()
 	{
-		_connectionStateHandler = state =>
-		{
-			if (state == PlcConnectionState.Disconnected && _isSyncEnabled)
-			{
-				syncService.Reset();
-			}
-			else if (state == PlcConnectionState.Connected && _isSyncEnabled)
-			{
-				_ = PerformReconnectReconciliationAsync().ContinueWith(
-					t => Log.Error(t.Exception, "Unhandled error in reconnect reconciliation"),
-					TaskContinuationOptions.OnlyOnFaulted);
-			}
-
-			syncService.UpdateConnectionState(state);
-		};
+		_connectionStateHandler = OnConnectionStateChanged;
 		connectionService.StateChanged += _connectionStateHandler;
 	}
 
@@ -117,6 +103,22 @@ internal sealed class PlcLifecycleManager(
 				LoadPlcRecipeIntoState(_pendingPlcRecipe);
 				_pendingPlcRecipe = null;
 			}
+		}
+	}
+
+	private void OnConnectionStateChanged(PlcConnectionState state)
+	{
+		syncService.UpdateConnectionState(state);
+
+		if (state == PlcConnectionState.Disconnected && _isSyncEnabled)
+		{
+			syncService.Reset();
+		}
+		else if (state == PlcConnectionState.Connected && _isSyncEnabled)
+		{
+			_ = PerformReconnectReconciliationAsync().ContinueWith(
+				t => Log.Error(t.Exception, "Unhandled error in reconnect reconciliation"),
+				TaskContinuationOptions.OnlyOnFaulted);
 		}
 	}
 

--- a/SemiStep/Domain/Facade/RecipeEditService.cs
+++ b/SemiStep/Domain/Facade/RecipeEditService.cs
@@ -1,0 +1,123 @@
+﻿using Domain.State;
+
+using FluentResults;
+
+using TypesShared.Config;
+using TypesShared.Core;
+using TypesShared.Domain;
+
+namespace Domain.Facade;
+
+/// <summary>
+/// Handles recipe mutation operations: append, insert, remove, change action, update property.
+/// </summary>
+internal sealed class RecipeEditService(
+	ICoreService coreService,
+	RecipeStateManager stateManager,
+	RecipeHistoryManager historyManager,
+	IPropertyParser propertyParser,
+	ConfigRegistry configRegistry,
+	IPlcSyncService syncService,
+	Func<bool> isSyncEnabled)
+{
+	public Result AppendStep(int actionId)
+	{
+		var snapshot = coreService.AppendStep(stateManager.Current, actionId);
+
+		return ApplyIfSucceeded(snapshot);
+	}
+
+	public Result InsertStep(int index, int actionId)
+	{
+		var snapshot = coreService.InsertStep(stateManager.Current, index, actionId);
+
+		return ApplyIfSucceeded(snapshot);
+	}
+
+	public Result RemoveStep(int index)
+	{
+		var snapshot = coreService.RemoveStep(stateManager.Current, index);
+
+		return ApplyIfSucceeded(snapshot);
+	}
+
+	public Result InsertSteps(int startIndex, IReadOnlyList<Step> steps)
+	{
+		var snapshot = coreService.InsertSteps(stateManager.Current, startIndex, steps);
+
+		return ApplyIfSucceeded(snapshot);
+	}
+
+	public Result RemoveSteps(IReadOnlyList<int> indices)
+	{
+		var snapshot = coreService.RemoveSteps(stateManager.Current, indices);
+
+		return ApplyIfSucceeded(snapshot);
+	}
+
+	public Result ChangeStepAction(int stepIndex, int newActionId)
+	{
+		var snapshot = coreService.ChangeStepAction(stateManager.Current, stepIndex, newActionId);
+
+		return ApplyIfSucceeded(snapshot);
+	}
+
+	public Result UpdateStepProperty(int stepIndex, string columnKey, string value)
+	{
+		var propertyResult = ResolvePropertyDefinition(stepIndex, columnKey);
+		if (propertyResult.IsFailed)
+		{
+			return propertyResult.ToResult();
+		}
+
+		var parseResult = propertyParser.Parse(value, propertyResult.Value);
+		if (parseResult.IsFailed)
+		{
+			return parseResult.ToResult();
+		}
+
+		var snapshot = coreService.UpdateStepProperty(
+			stateManager.Current, stepIndex, columnKey, parseResult.Value);
+
+		return ApplyIfSucceeded(snapshot);
+	}
+
+	private Result ApplyIfSucceeded(Result<RecipeSnapshot> snapshot)
+	{
+		if (snapshot.IsFailed)
+		{
+			return snapshot.ToResult();
+		}
+
+		historyManager.Push(stateManager.Current);
+		stateManager.Update(snapshot);
+
+		if (isSyncEnabled())
+		{
+			syncService.NotifyRecipeChanged(stateManager.Current, stateManager.IsValid);
+		}
+
+		return Result.Ok().WithReasons(snapshot.Reasons);
+	}
+
+	private Result<PropertyTypeDefinition> ResolvePropertyDefinition(int stepIndex, string columnKey)
+	{
+		var validationResult = ValidateStepIndex(stepIndex);
+		if (validationResult.IsFailed)
+		{
+			return validationResult.ToResult<PropertyTypeDefinition>();
+		}
+
+		return configRegistry.ResolvePropertyType(stateManager.Current, stepIndex, columnKey);
+	}
+
+	private Result ValidateStepIndex(int stepIndex)
+	{
+		var recipe = stateManager.Current;
+		if (stepIndex < 0 || stepIndex >= recipe.Steps.Count)
+		{
+			return Result.Fail($"Step index {stepIndex} is out of range for recipe with {recipe.Steps.Count} steps");
+		}
+		return Result.Ok();
+	}
+}

--- a/SemiStep/S7/Facade/S7Service.cs
+++ b/SemiStep/S7/Facade/S7Service.cs
@@ -17,6 +17,9 @@ internal sealed class S7Service(
 	PlcConfiguration plcConfiguration)
 	: IS7Service
 {
+	private static readonly TimeSpan _reconnectInitialDelay = TimeSpan.FromSeconds(1);
+	private static readonly TimeSpan _reconnectMaxDelay = TimeSpan.FromSeconds(30);
+
 	private readonly Lock _stateLock = new();
 	private PlcConnectionState _state = PlcConnectionState.Disconnected;
 	private bool _autoReconnectEnabled;
@@ -112,29 +115,23 @@ internal sealed class S7Service(
 
 	public async Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync(CancellationToken ct = default)
 	{
-		try
+		var result = await transactionExecutor.ReadManagingAreaAsync(ct);
+		if (result.IsFailed)
 		{
-			var state = await transactionExecutor.ReadManagingAreaAsync(ct);
-			return Result.Ok(new PlcManagingAreaState(state.Committed, state.RecipeLines));
+			Log.Warning("Failed to read managing area from PLC: {Reason}", result.Errors[0].Message);
+			return result.ToResult<PlcManagingAreaState>();
 		}
-		catch (Exception ex)
-		{
-			Log.Warning(ex, "Failed to read managing area from PLC");
-			return Result.Fail(ex.Message);
-		}
+		return result;
 	}
 
 	public async Task<Result<Recipe>> ReadRecipeFromPlcAsync(CancellationToken ct = default)
 	{
-		try
+		var result = await transactionExecutor.ReadRecipeFromPlcAsync(ct);
+		if (result.IsFailed)
 		{
-			return await transactionExecutor.ReadRecipeFromPlcAsync(ct);
+			Log.Warning("Failed to read recipe from PLC: {Reason}", result.Errors[0].Message);
 		}
-		catch (Exception ex)
-		{
-			Log.Warning(ex, "Failed to read recipe from PLC");
-			return Result.Fail(ex.Message);
-		}
+		return result;
 	}
 
 	internal void OnConnectionLost()
@@ -236,7 +233,7 @@ internal sealed class S7Service(
 			}
 			catch (Exception ex)
 			{
-				Log.Warning(ex, "Keep-alive probe failed, connection assumed lost");
+				Log.Warning("Keep-alive probe failed, connection assumed lost: {Message}", ex.Message);
 				OnConnectionLost();
 
 				return;
@@ -275,8 +272,7 @@ internal sealed class S7Service(
 
 	private async Task ReconnectLoopAsync(CancellationToken ct)
 	{
-		var delay = TimeSpan.FromSeconds(1);
-		var maxDelay = TimeSpan.FromSeconds(30);
+		var delay = _reconnectInitialDelay;
 
 		while (!ct.IsCancellationRequested && _autoReconnectEnabled)
 		{
@@ -298,8 +294,8 @@ internal sealed class S7Service(
 			}
 			catch (Exception ex)
 			{
-				Log.Warning(ex, "Reconnection attempt failed, retrying in {Delay}s", delay.TotalSeconds);
-				delay = TimeSpan.FromSeconds(Math.Min(delay.TotalSeconds * 2, maxDelay.TotalSeconds));
+				Log.Warning("Reconnection attempt failed, retrying in {Delay}s: {Message}", delay.TotalSeconds, ex.Message);
+				delay = TimeSpan.FromSeconds(Math.Min(delay.TotalSeconds * 2, _reconnectMaxDelay.TotalSeconds));
 			}
 		}
 	}

--- a/SemiStep/S7/Protocol/ManagingAreaState.cs
+++ b/SemiStep/S7/Protocol/ManagingAreaState.cs
@@ -1,5 +1,0 @@
-﻿namespace S7.Protocol;
-
-internal sealed record ManagingAreaState(
-	bool Committed,
-	int RecipeLines);

--- a/SemiStep/S7/Protocol/NotConnectedError.cs
+++ b/SemiStep/S7/Protocol/NotConnectedError.cs
@@ -1,0 +1,5 @@
+﻿using FluentResults;
+
+namespace S7.Protocol;
+
+internal sealed class NotConnectedError(string message) : Error(message);

--- a/SemiStep/S7/Protocol/PlcExecutionState.cs
+++ b/SemiStep/S7/Protocol/PlcExecutionState.cs
@@ -1,9 +1,0 @@
-﻿namespace S7.Protocol;
-
-internal sealed record PlcExecutionState(
-	bool RecipeActive,
-	int ActualLine,
-	float StepCurrentTime,
-	int ForLoopCount1,
-	int ForLoopCount2,
-	int ForLoopCount3);

--- a/SemiStep/S7/Protocol/PlcNotConnectedException.cs
+++ b/SemiStep/S7/Protocol/PlcNotConnectedException.cs
@@ -1,3 +1,0 @@
-﻿namespace S7.Protocol;
-
-internal sealed class PlcNotConnectedException(string message) : Exception(message);

--- a/SemiStep/S7/S7Driver.cs
+++ b/SemiStep/S7/S7Driver.cs
@@ -20,11 +20,10 @@ internal sealed class S7Driver : IS7Driver
 
 	public async Task ConnectAsync(PlcConnectionSettings settings, CancellationToken ct = default)
 	{
-		var endpoint = $"{settings.IpAddress}:{settings.Port}";
-
 		_plc = new Plc(
 			CpuType.S71500,
-			endpoint,
+			settings.IpAddress,
+			settings.Port,
 			(short)settings.Rack,
 			(short)settings.Slot);
 

--- a/SemiStep/S7/Serialization/ExecutionStateCodec.cs
+++ b/SemiStep/S7/Serialization/ExecutionStateCodec.cs
@@ -1,29 +1,85 @@
 ﻿using System.Buffers.Binary;
 
-using S7.Protocol;
+using FluentResults;
 
+using TypesShared.Plc;
 using TypesShared.Plc.Memory;
 
 namespace S7.Serialization;
 
-internal sealed class ExecutionStateCodec(ExecutionDbLayout layout)
+internal sealed class ExecutionStateCodec
 {
-	public PlcExecutionState Decode(byte[] data)
+	private readonly ExecutionDbLayout _layout;
+
+	public ExecutionStateCodec(ExecutionDbLayout layout)
 	{
-		if (data.Length < layout.TotalSize)
+		if (layout.TotalSize < layout.RecipeActiveOffset + 2)
 		{
 			throw new ArgumentException(
-				$"Data length {data.Length} is less than expected {layout.TotalSize}");
+				$"ExecutionDbLayout.TotalSize ({layout.TotalSize}) must be at least " +
+				$"RecipeActiveOffset ({layout.RecipeActiveOffset}) + 2 bytes",
+				nameof(layout));
 		}
 
-		return new PlcExecutionState(
-			RecipeActive: data[layout.RecipeActiveOffset] != 0 ||
-						  data[layout.RecipeActiveOffset + 1] != 0,
-			ActualLine: BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(layout.ActualLineOffset)),
+		if (layout.TotalSize < layout.ActualLineOffset + sizeof(int))
+		{
+			throw new ArgumentException(
+				$"ExecutionDbLayout.TotalSize ({layout.TotalSize}) must be at least " +
+				$"ActualLineOffset ({layout.ActualLineOffset}) + 4 bytes",
+				nameof(layout));
+		}
+
+		if (layout.TotalSize < layout.StepCurrentTimeOffset + sizeof(int))
+		{
+			throw new ArgumentException(
+				$"ExecutionDbLayout.TotalSize ({layout.TotalSize}) must be at least " +
+				$"StepCurrentTimeOffset ({layout.StepCurrentTimeOffset}) + 4 bytes",
+				nameof(layout));
+		}
+
+		if (layout.TotalSize < layout.ForLoopCount1Offset + sizeof(int))
+		{
+			throw new ArgumentException(
+				$"ExecutionDbLayout.TotalSize ({layout.TotalSize}) must be at least " +
+				$"ForLoopCount1Offset ({layout.ForLoopCount1Offset}) + 4 bytes",
+				nameof(layout));
+		}
+
+		if (layout.TotalSize < layout.ForLoopCount2Offset + sizeof(int))
+		{
+			throw new ArgumentException(
+				$"ExecutionDbLayout.TotalSize ({layout.TotalSize}) must be at least " +
+				$"ForLoopCount2Offset ({layout.ForLoopCount2Offset}) + 4 bytes",
+				nameof(layout));
+		}
+
+		if (layout.TotalSize < layout.ForLoopCount3Offset + sizeof(int))
+		{
+			throw new ArgumentException(
+				$"ExecutionDbLayout.TotalSize ({layout.TotalSize}) must be at least " +
+				$"ForLoopCount3Offset ({layout.ForLoopCount3Offset}) + 4 bytes",
+				nameof(layout));
+		}
+
+		_layout = layout;
+	}
+
+	public Result<PlcExecutionInfo> Decode(byte[] data)
+	{
+		if (data.Length < _layout.TotalSize)
+		{
+			return Result.Fail(
+				$"Execution state data length {data.Length} is less than expected {_layout.TotalSize}");
+		}
+
+		return Result.Ok(new PlcExecutionInfo(
+			RecipeActive: data[_layout.RecipeActiveOffset] != 0 ||
+						  data[_layout.RecipeActiveOffset + 1] != 0,
+			ActualLine: BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(_layout.ActualLineOffset)),
 			StepCurrentTime: BitConverter.Int32BitsToSingle(
-				BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(layout.StepCurrentTimeOffset))),
-			ForLoopCount1: BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(layout.ForLoopCount1Offset)),
-			ForLoopCount2: BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(layout.ForLoopCount2Offset)),
-			ForLoopCount3: BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(layout.ForLoopCount3Offset)));
+				BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(_layout.StepCurrentTimeOffset))),
+			ForLoopCount1: BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(_layout.ForLoopCount1Offset)),
+			ForLoopCount2: BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(_layout.ForLoopCount2Offset)),
+			ForLoopCount3: BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(_layout.ForLoopCount3Offset))));
 	}
 }

--- a/SemiStep/S7/Serialization/ManagingAreaCodec.cs
+++ b/SemiStep/S7/Serialization/ManagingAreaCodec.cs
@@ -1,16 +1,43 @@
 ﻿using System.Buffers.Binary;
 
+using FluentResults;
+
 using S7.Protocol;
 
+using TypesShared.Plc;
 using TypesShared.Plc.Memory;
 
 namespace S7.Serialization;
 
-internal sealed class ManagingAreaCodec
+internal sealed class ManagingAreaCodec(ManagingDbLayout layout)
 {
-	private readonly ManagingDbLayout _layout;
+	private readonly ManagingDbLayout _layout = Validate(layout);
 
-	public ManagingAreaCodec(ManagingDbLayout layout)
+	public Result<PlcManagingAreaState> Decode(byte[] data)
+	{
+		if (data.Length < _layout.TotalSize)
+		{
+			return Result.Fail(
+				$"Data length {data.Length} is less than expected {_layout.TotalSize}");
+		}
+
+		var committed = data[_layout.CommittedOffset] != 0;
+		var recipeLines = BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(_layout.RecipeLinesOffset));
+
+		return Result.Ok(new PlcManagingAreaState(committed, recipeLines));
+	}
+
+	public byte[] EncodePcData(ManagingAreaPcData data)
+	{
+		var bytes = new byte[_layout.TotalSize];
+
+		bytes[_layout.CommittedOffset] = data.Committed ? (byte)0x01 : (byte)0x00;
+		BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(_layout.RecipeLinesOffset), data.RecipeLines);
+
+		return bytes;
+	}
+
+	private static ManagingDbLayout Validate(ManagingDbLayout layout)
 	{
 		if (layout.TotalSize < layout.RecipeLinesOffset + sizeof(int))
 		{
@@ -28,30 +55,6 @@ internal sealed class ManagingAreaCodec
 				nameof(layout));
 		}
 
-		_layout = layout;
-	}
-
-	public ManagingAreaState Decode(byte[] data)
-	{
-		if (data.Length < _layout.TotalSize)
-		{
-			throw new ArgumentException(
-				$"Data length {data.Length} is less than expected {_layout.TotalSize}");
-		}
-
-		var committed = data[_layout.CommittedOffset] != 0;
-		var recipeLines = BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(_layout.RecipeLinesOffset));
-
-		return new ManagingAreaState(committed, recipeLines);
-	}
-
-	public byte[] EncodePcData(ManagingAreaPcData data)
-	{
-		var bytes = new byte[_layout.TotalSize];
-
-		bytes[_layout.CommittedOffset] = data.Committed ? (byte)0x01 : (byte)0x00;
-		BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(_layout.RecipeLinesOffset), data.RecipeLines);
-
-		return bytes;
+		return layout;
 	}
 }

--- a/SemiStep/S7/Serialization/RecipeConverter.cs
+++ b/SemiStep/S7/Serialization/RecipeConverter.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Immutable;
 
+using FluentResults;
+
 using TypesShared.Config;
 using TypesShared.Core;
 using TypesShared.Plc;
@@ -8,11 +10,11 @@ namespace S7.Serialization;
 
 internal sealed class RecipeConverter(ConfigRegistry configRegistry)
 {
-	public PlcRecipeData FromRecipe(Recipe recipe)
+	public Result<PlcRecipeData> FromRecipe(Recipe recipe)
 	{
 		if (recipe.StepCount == 0)
 		{
-			return PlcRecipeData.Empty;
+			return Result.Ok(PlcRecipeData.Empty);
 		}
 
 		var intValues = new List<int>();
@@ -21,21 +23,25 @@ internal sealed class RecipeConverter(ConfigRegistry configRegistry)
 
 		foreach (var step in recipe.Steps)
 		{
-			SerialiseStep(step, intValues, floatValues, stringValues);
+			var stepResult = SerialiseStep(step, intValues, floatValues, stringValues);
+			if (stepResult.IsFailed)
+			{
+				return stepResult.ToResult<PlcRecipeData>();
+			}
 		}
 
-		return new PlcRecipeData(
+		return Result.Ok(new PlcRecipeData(
 			IntValues: intValues.ToArray(),
 			FloatValues: floatValues.ToArray(),
 			StringValues: stringValues.ToArray(),
-			StepCount: recipe.StepCount);
+			StepCount: recipe.StepCount));
 	}
 
-	public Recipe ToRecipe(PlcRecipeData data)
+	public Result<Recipe> ToRecipe(PlcRecipeData data)
 	{
 		if (data.StepCount == 0)
 		{
-			return Recipe.Empty;
+			return Result.Ok(Recipe.Empty);
 		}
 
 		var intIndex = 0;
@@ -46,13 +52,19 @@ internal sealed class RecipeConverter(ConfigRegistry configRegistry)
 
 		for (var stepIndex = 0; stepIndex < data.StepCount; stepIndex++)
 		{
-			steps.Add(DeserialiseStep(stepIndex, data, ref intIndex, ref floatIndex, ref stringIndex));
+			var stepResult = DeserialiseStep(stepIndex, data, ref intIndex, ref floatIndex, ref stringIndex);
+			if (stepResult.IsFailed)
+			{
+				return stepResult.ToResult<Recipe>();
+			}
+
+			steps.Add(stepResult.Value);
 		}
 
-		return new Recipe(steps.ToImmutableList());
+		return Result.Ok(new Recipe(steps.ToImmutableList()));
 	}
 
-	private void SerialiseStep(
+	private Result SerialiseStep(
 		Step step,
 		List<int> intValues,
 		List<float> floatValues,
@@ -60,16 +72,26 @@ internal sealed class RecipeConverter(ConfigRegistry configRegistry)
 	{
 		intValues.Add(step.ActionKey);
 
-		var action = ResolveAction(step.ActionKey);
+		var actionResult = ResolveAction(step.ActionKey);
+		if (actionResult.IsFailed)
+		{
+			return actionResult.ToResult();
+		}
 
-		foreach (var propertyDef in action.Properties)
+		foreach (var propertyDef in actionResult.Value.Properties)
 		{
 			step.Properties.TryGetValue(new PropertyId(propertyDef.Key), out var value);
-			SerialiseProperty(propertyDef, value, intValues, floatValues, stringValues);
+			var propertyResult = SerialiseProperty(propertyDef, value, intValues, floatValues, stringValues);
+			if (propertyResult.IsFailed)
+			{
+				return propertyResult;
+			}
 		}
+
+		return Result.Ok();
 	}
 
-	private Step DeserialiseStep(
+	private Result<Step> DeserialiseStep(
 		int stepIndex,
 		PlcRecipeData data,
 		ref int intIndex,
@@ -78,37 +100,53 @@ internal sealed class RecipeConverter(ConfigRegistry configRegistry)
 	{
 		if (intIndex >= data.IntValues.Length)
 		{
-			throw new InvalidOperationException(
+			return Result.Fail(
 				$"Insufficient int values at step {stepIndex}: expected ActionKey but reached end of array");
 		}
 
 		var actionKey = data.IntValues[intIndex++];
-		var action = ResolveAction(actionKey);
+		var actionResult = ResolveAction(actionKey);
+		if (actionResult.IsFailed)
+		{
+			return actionResult.ToResult<Step>();
+		}
 
 		var properties = ImmutableDictionary.CreateBuilder<PropertyId, PropertyValue>();
 
-		foreach (var propertyDef in action.Properties)
+		foreach (var propertyDef in actionResult.Value.Properties)
 		{
-			var value = DeserialiseProperty(propertyDef, stepIndex, data, ref intIndex, ref floatIndex, ref stringIndex);
-			properties.Add(new PropertyId(propertyDef.Key), value);
+			var propertyResult = DeserialiseProperty(
+				propertyDef, stepIndex, data, ref intIndex, ref floatIndex, ref stringIndex);
+			if (propertyResult.IsFailed)
+			{
+				return propertyResult.ToResult<Step>();
+			}
+
+			properties.Add(new PropertyId(propertyDef.Key), propertyResult.Value);
 		}
 
-		return new Step(actionKey, properties.ToImmutable());
+		return Result.Ok(new Step(actionKey, properties.ToImmutable()));
 	}
 
-	private void SerialiseProperty(
+	private Result SerialiseProperty(
 		ActionPropertyDefinition propertyDef,
 		PropertyValue? value,
 		List<int> intValues,
 		List<float> floatValues,
 		List<string> stringValues)
 	{
-		var propertyType = ResolvePropertyType(propertyDef);
+		var propertyTypeResult = ResolvePropertyType(propertyDef);
+		if (propertyTypeResult.IsFailed)
+		{
+			return propertyTypeResult.ToResult();
+		}
+
+		var propertyType = propertyTypeResult.Value;
 
 		if (value is null)
 		{
 			AppendDefaultValue(propertyType, intValues, floatValues, stringValues);
-			return;
+			return Result.Ok();
 		}
 
 		switch (propertyType)
@@ -123,9 +161,11 @@ internal sealed class RecipeConverter(ConfigRegistry configRegistry)
 				stringValues.Add(value.AsString());
 				break;
 		}
+
+		return Result.Ok();
 	}
 
-	private PropertyValue DeserialiseProperty(
+	private Result<PropertyValue> DeserialiseProperty(
 		ActionPropertyDefinition propertyDef,
 		int stepIndex,
 		PlcRecipeData data,
@@ -133,61 +173,64 @@ internal sealed class RecipeConverter(ConfigRegistry configRegistry)
 		ref int floatIndex,
 		ref int stringIndex)
 	{
-		var propertyType = ResolvePropertyType(propertyDef);
+		var propertyTypeResult = ResolvePropertyType(propertyDef);
+		if (propertyTypeResult.IsFailed)
+		{
+			return propertyTypeResult.ToResult<PropertyValue>();
+		}
 
-		switch (propertyType)
+		switch (propertyTypeResult.Value)
 		{
 			case PropertyType.Int:
 				if (intIndex >= data.IntValues.Length)
 				{
-					throw new InvalidOperationException(
+					return Result.Fail(
 						$"Insufficient int values at step {stepIndex}, column '{propertyDef.Key}'");
 				}
-				return PropertyValue.FromInt(data.IntValues[intIndex++]);
+				return Result.Ok(PropertyValue.FromInt(data.IntValues[intIndex++]));
 
 			case PropertyType.Float:
 				if (floatIndex >= data.FloatValues.Length)
 				{
-					throw new InvalidOperationException(
+					return Result.Fail(
 						$"Insufficient float values at step {stepIndex}, column '{propertyDef.Key}'");
 				}
-				return PropertyValue.FromFloat(data.FloatValues[floatIndex++]);
+				return Result.Ok(PropertyValue.FromFloat(data.FloatValues[floatIndex++]));
 
 			case PropertyType.String:
 				if (stringIndex >= data.StringValues.Length)
 				{
-					throw new InvalidOperationException(
+					return Result.Fail(
 						$"Insufficient string values at step {stepIndex}, column '{propertyDef.Key}'");
 				}
-				return PropertyValue.FromString(data.StringValues[stringIndex++]);
+				return Result.Ok(PropertyValue.FromString(data.StringValues[stringIndex++]));
 
 			default:
-				throw new InvalidOperationException($"Unknown property type: {propertyType}");
+				return Result.Fail($"Unknown property type: {propertyTypeResult.Value}");
 		}
 	}
 
-	private PropertyType ResolvePropertyType(ActionPropertyDefinition propertyDef)
+	private Result<PropertyType> ResolvePropertyType(ActionPropertyDefinition propertyDef)
 	{
 		var propertyDefResult = configRegistry.GetProperty(propertyDef.PropertyTypeId);
 		if (propertyDefResult.IsFailed)
 		{
-			throw new InvalidOperationException(
+			return Result.Fail(
 				$"Property type '{propertyDef.PropertyTypeId}' not found in configuration registry");
 		}
 
-		return PropertyTypeMapping.FromSystemType(propertyDefResult.Value.SystemType);
+		return Result.Ok(PropertyTypeMapping.FromSystemType(propertyDefResult.Value.SystemType));
 	}
 
-	private ActionDefinition ResolveAction(int actionKey)
+	private Result<ActionDefinition> ResolveAction(int actionKey)
 	{
 		var actionResult = configRegistry.GetAction(actionKey);
 		if (actionResult.IsFailed)
 		{
-			throw new InvalidOperationException(
-				$"Action with key {actionKey} not found in configuration registry");
+			return Result.Fail($"Action with key {actionKey} not found in configuration registry");
 		}
 
-		return actionResult.Value;
+		return Result.Ok(actionResult.Value);
 	}
 
 	private static void AppendDefaultValue(

--- a/SemiStep/S7/Sync/PlcExecutionMonitor.cs
+++ b/SemiStep/S7/Sync/PlcExecutionMonitor.cs
@@ -17,6 +17,8 @@ internal sealed class PlcExecutionMonitor(
 	Action onConnectionLost)
 	: IDisposable
 {
+	private static readonly TimeSpan _stopTimeout = TimeSpan.FromSeconds(5);
+
 	private readonly Subject<PlcExecutionInfo> _subject = new();
 
 	private volatile PlcExecutionInfo _lastKnown = PlcExecutionInfo.Empty;
@@ -37,18 +39,13 @@ internal sealed class PlcExecutionMonitor(
 
 	public void Stop()
 	{
-		_pollCts?.Cancel();
-		_pollCts?.Dispose();
-		_pollCts = null;
-
-		var taskToWait = _pollTask;
-		_pollTask = null;
+		var taskToWait = CancelAndDetachPollTask();
 
 		// Skip the wait if Stop() is being called from within the poll loop itself
 		// (e.g. via onConnectionLost callback), to avoid deadlock.
 		if (taskToWait is not null && taskToWait.Id != Task.CurrentId)
 		{
-			taskToWait.Wait(TimeSpan.FromSeconds(5));
+			taskToWait.Wait(_stopTimeout);
 		}
 
 		PublishAndTrack(PlcExecutionInfo.Empty);
@@ -56,18 +53,13 @@ internal sealed class PlcExecutionMonitor(
 
 	public async Task StopAsync()
 	{
-		_pollCts?.Cancel();
-		_pollCts?.Dispose();
-		_pollCts = null;
-
-		var taskToWait = _pollTask;
-		_pollTask = null;
+		var taskToWait = CancelAndDetachPollTask();
 
 		if (taskToWait is not null)
 		{
 			try
 			{
-				await taskToWait.WaitAsync(TimeSpan.FromSeconds(5));
+				await taskToWait.WaitAsync(_stopTimeout);
 			}
 			catch (TimeoutException)
 			{
@@ -83,6 +75,18 @@ internal sealed class PlcExecutionMonitor(
 		Stop();
 		_subject.OnCompleted();
 		_subject.Dispose();
+	}
+
+	private Task? CancelAndDetachPollTask()
+	{
+		_pollCts?.Cancel();
+		_pollCts?.Dispose();
+		_pollCts = null;
+
+		var taskToWait = _pollTask;
+		_pollTask = null;
+
+		return taskToWait;
 	}
 
 	private void PublishAndTrack(PlcExecutionInfo info)
@@ -110,13 +114,12 @@ internal sealed class PlcExecutionMonitor(
 						{
 							onConnectionLost();
 						}
-					}
-					else
-					{
-						Log.Warning("Execution monitor poll error: {Message}", result.Errors[0].Message);
+
+						return;
 					}
 
-					return;
+					Log.Warning("Execution monitor poll error: {Message}", result.Errors[0].Message);
+					continue;
 				}
 
 				PublishAndTrack(result.Value);

--- a/SemiStep/S7/Sync/PlcExecutionMonitor.cs
+++ b/SemiStep/S7/Sync/PlcExecutionMonitor.cs
@@ -1,4 +1,7 @@
-﻿using System.Reactive.Subjects;
+﻿using System.Linq;
+using System.Reactive.Subjects;
+
+using FluentResults;
 
 using S7.Protocol;
 
@@ -95,37 +98,32 @@ internal sealed class PlcExecutionMonitor(
 			try
 			{
 				await Task.Delay(protocolSettings.PollingIntervalMs, ct);
+				var result = await transactionExecutor.ReadExecutionStateAsync(ct);
 
-				var state = await transactionExecutor.ReadExecutionStateAsync(ct);
+				if (result.IsFailed)
+				{
+					if (result.Errors.OfType<NotConnectedError>().Any())
+					{
+						Log.Debug("Execution monitor stopping: PLC not connected");
 
-				var info = new PlcExecutionInfo(
-					RecipeActive: state.RecipeActive,
-					ActualLine: state.ActualLine,
-					StepCurrentTime: state.StepCurrentTime,
-					ForLoopCount1: state.ForLoopCount1,
-					ForLoopCount2: state.ForLoopCount2,
-					ForLoopCount3: state.ForLoopCount3);
+						if (!(_pollCts?.IsCancellationRequested ?? true))
+						{
+							onConnectionLost();
+						}
+					}
+					else
+					{
+						Log.Warning("Execution monitor poll error: {Message}", result.Errors[0].Message);
+					}
 
-				PublishAndTrack(info);
+					return;
+				}
+
+				PublishAndTrack(result.Value);
 			}
 			catch (OperationCanceledException)
 			{
 				return;
-			}
-			catch (PlcNotConnectedException)
-			{
-				Log.Debug("Execution monitor stopping: PLC not connected");
-
-				if (!(_pollCts?.IsCancellationRequested ?? true))
-				{
-					onConnectionLost();
-				}
-
-				return;
-			}
-			catch (Exception ex)
-			{
-				Log.Warning(ex, "Unexpected error in execution monitor poll loop");
 			}
 		}
 	}

--- a/SemiStep/S7/Sync/PlcRecipeDataComparer.cs
+++ b/SemiStep/S7/Sync/PlcRecipeDataComparer.cs
@@ -1,0 +1,56 @@
+﻿using TypesShared.Plc;
+
+namespace S7.Sync;
+
+internal static class PlcRecipeDataComparer
+{
+	// Floats are serialised to raw IEEE 754 bytes, written to the PLC, and read back without
+	// any arithmetic transformation. The round-trip is byte-exact, so bit-exact equality is
+	// the correct comparison here — not an epsilon-based approximation.
+	// BitConverter.SingleToInt32Bits is used rather than == to correctly handle NaN payloads
+	// and distinguish +0 from -0 (different IEEE-754 bit patterns).
+	internal static bool DataMatchesExpected(PlcRecipeData actual, PlcRecipeData expected)
+	{
+		if (actual.IntValues.Length != expected.IntValues.Length)
+		{
+			return false;
+		}
+
+		if (actual.FloatValues.Length != expected.FloatValues.Length)
+		{
+			return false;
+		}
+
+		if (actual.StringValues.Length != expected.StringValues.Length)
+		{
+			return false;
+		}
+
+		for (var i = 0; i < expected.IntValues.Length; i++)
+		{
+			if (actual.IntValues[i] != expected.IntValues[i])
+			{
+				return false;
+			}
+		}
+
+		for (var i = 0; i < expected.FloatValues.Length; i++)
+		{
+			if (BitConverter.SingleToInt32Bits(actual.FloatValues[i]) !=
+				BitConverter.SingleToInt32Bits(expected.FloatValues[i]))
+			{
+				return false;
+			}
+		}
+
+		for (var i = 0; i < expected.StringValues.Length; i++)
+		{
+			if (actual.StringValues[i] != expected.StringValues[i])
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/SemiStep/S7/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/S7/Sync/PlcSyncCoordinator.cs
@@ -18,7 +18,7 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 	private readonly PlcSyncExecutor _executor;
 
 	private PlcConnectionState _connectionState = PlcConnectionState.Disconnected;
-	private bool _disposed;
+	private volatile bool _disposed;
 	private bool _isSyncEnabled;
 	private DateTimeOffset? _lastSyncTime;
 	private PlcSyncStatus _status = PlcSyncStatus.Idle;
@@ -119,12 +119,16 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 
 	public void Dispose()
 	{
-		if (_disposed)
+		lock (_lock)
 		{
-			return;
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
 		}
 
-		_disposed = true;
 		_executor.Dispose();
 		_subject.OnCompleted();
 		_subject.Dispose();
@@ -146,19 +150,26 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 		PlcSyncStatus status;
 		bool isSyncEnabled;
 		string? errorMessage;
+		bool disposed;
 
 		lock (_lock)
 		{
+			disposed = _disposed;
 			status = _status;
 			isSyncEnabled = _isSyncEnabled;
 			errorMessage = _executor.PendingErrorMessage;
+		}
+
+		if (disposed)
+		{
+			return;
 		}
 
 		var snapshot = new PlcSessionSnapshot(connectionState, status, isSyncEnabled);
 
 		if (status == PlcSyncStatus.Failed)
 		{
-			_subject.OnNext(
+			TryPublish(
 				Result.Fail<PlcSessionSnapshot>(new Error(errorMessage ?? "Sync failed"))
 					.WithValue(snapshot));
 			return;
@@ -166,12 +177,20 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 
 		if (status == PlcSyncStatus.Disconnected && isSyncEnabled)
 		{
-			_subject.OnNext(
+			TryPublish(
 				Result.Fail<PlcSessionSnapshot>(new Error("PLC connection lost"))
 					.WithValue(snapshot));
 			return;
 		}
 
-		_subject.OnNext(Result.Ok(snapshot));
+		TryPublish(Result.Ok(snapshot));
+	}
+
+	private void TryPublish(Result<PlcSessionSnapshot> result)
+	{
+		if (!_disposed)
+		{
+			_subject.OnNext(result);
+		}
 	}
 }

--- a/SemiStep/S7/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/S7/Sync/PlcSyncCoordinator.cs
@@ -201,6 +201,7 @@ internal sealed class PlcSyncCoordinator(
 			catch (Exception ex)
 			{
 				Log.Error(ex, "Unhandled exception in sync task");
+				LastError = ex.Message;
 				Status = PlcSyncStatus.Failed;
 			}
 		}, ct);
@@ -232,10 +233,10 @@ internal sealed class PlcSyncCoordinator(
 		if (activeResult.IsFailed)
 		{
 			var isDisconnected = activeResult.Errors.OfType<NotConnectedError>().Any();
-			Status = PlcSyncStatus.Failed;
 			LastError = isDisconnected
 				? "Not connected to PLC"
 				: activeResult.Errors[0].Message;
+			Status = PlcSyncStatus.Failed;
 
 			if (isDisconnected)
 			{
@@ -247,21 +248,21 @@ internal sealed class PlcSyncCoordinator(
 
 		if (activeResult.Value)
 		{
-			Status = PlcSyncStatus.Failed;
 			LastError = "Recipe is being executed on PLC";
+			Status = PlcSyncStatus.Failed;
 			Log.Warning("Sync blocked: recipe is being executed on PLC");
 
 			return;
 		}
 
-		Status = PlcSyncStatus.Syncing;
 		LastError = null;
+		Status = PlcSyncStatus.Syncing;
 
 		var writeResult = await transactionExecutor.WriteRecipeWithRetryAsync(snapshotToSync, ct);
 		if (writeResult.IsFailed)
 		{
-			Status = PlcSyncStatus.Failed;
 			LastError = writeResult.Errors[0].Message;
+			Status = PlcSyncStatus.Failed;
 			if (!writeResult.Errors.OfType<NotConnectedError>().Any())
 			{
 				Log.Error("Sync failed: {Message}", writeResult.Errors[0].Message);
@@ -271,8 +272,8 @@ internal sealed class PlcSyncCoordinator(
 		}
 
 		LastSyncTime = DateTimeOffset.UtcNow;
-		Status = PlcSyncStatus.Synced;
 		LastError = null;
+		Status = PlcSyncStatus.Synced;
 
 		lock (_lock)
 		{

--- a/SemiStep/S7/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/S7/Sync/PlcSyncCoordinator.cs
@@ -1,4 +1,8 @@
-﻿using S7.Protocol;
+﻿using System.Linq;
+
+using FluentResults;
+
+using S7.Protocol;
 
 using Serilog;
 
@@ -194,6 +198,11 @@ internal sealed class PlcSyncCoordinator(
 			catch (OperationCanceledException)
 			{
 			}
+			catch (Exception ex)
+			{
+				Log.Error(ex, "Unhandled exception in sync task");
+				Status = PlcSyncStatus.Failed;
+			}
 		}, ct);
 	}
 
@@ -219,53 +228,58 @@ internal sealed class PlcSyncCoordinator(
 			return;
 		}
 
-		try
+		var activeResult = await transactionExecutor.IsRecipeActiveAsync(ct);
+		if (activeResult.IsFailed)
 		{
-			var isRecipeActive = await transactionExecutor.IsRecipeActiveAsync(ct);
-			if (isRecipeActive)
-			{
-				Status = PlcSyncStatus.Failed;
-				LastError = "Recipe is being executed on PLC";
-				Log.Warning("Sync blocked: recipe is being executed on PLC");
+			var isDisconnected = activeResult.Errors.OfType<NotConnectedError>().Any();
+			Status = PlcSyncStatus.Failed;
+			LastError = isDisconnected
+				? "Not connected to PLC"
+				: activeResult.Errors[0].Message;
 
-				return;
+			if (isDisconnected)
+			{
+				Log.Warning("Sync blocked: not connected to PLC");
 			}
 
-			Status = PlcSyncStatus.Syncing;
-			LastError = null;
-
-			await transactionExecutor.WriteRecipeWithRetryAsync(snapshotToSync, ct);
-
-			LastSyncTime = DateTimeOffset.UtcNow;
-			Status = PlcSyncStatus.Synced;
-			LastError = null;
+			return;
 		}
-		catch (PlcNotConnectedException)
+
+		if (activeResult.Value)
 		{
 			Status = PlcSyncStatus.Failed;
-			LastError = "Not connected to PLC";
+			LastError = "Recipe is being executed on PLC";
+			Log.Warning("Sync blocked: recipe is being executed on PLC");
+
+			return;
 		}
-		catch (Exception ex) when (ex is not OperationCanceledException)
+
+		Status = PlcSyncStatus.Syncing;
+		LastError = null;
+
+		var writeResult = await transactionExecutor.WriteRecipeWithRetryAsync(snapshotToSync, ct);
+		if (writeResult.IsFailed)
 		{
 			Status = PlcSyncStatus.Failed;
-			LastError = ex.Message;
-			Log.Error(ex, "Unexpected error during sync");
-		}
-		finally
-		{
-			Recipe? nextSnapshot;
-			lock (_lock)
+			LastError = writeResult.Errors[0].Message;
+			if (!writeResult.Errors.OfType<NotConnectedError>().Any())
 			{
-				nextSnapshot = _pendingSnapshot;
+				Log.Error("Sync failed: {Message}", writeResult.Errors[0].Message);
 			}
 
-			if (nextSnapshot is not null && !_disposed)
+			return;
+		}
+
+		LastSyncTime = DateTimeOffset.UtcNow;
+		Status = PlcSyncStatus.Synced;
+		LastError = null;
+
+		lock (_lock)
+		{
+			if (_pendingSnapshot is not null && !_disposed)
 			{
 				Log.Debug("Changes occurred during sync, starting new debounce");
-				lock (_lock)
-				{
-					StartDebounce();
-				}
+				StartDebounce();
 			}
 		}
 	}

--- a/SemiStep/S7/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/S7/Sync/PlcSyncCoordinator.cs
@@ -1,10 +1,8 @@
-﻿using System.Linq;
+﻿using System.Reactive.Subjects;
 
 using FluentResults;
 
 using S7.Protocol;
-
-using Serilog;
 
 using TypesShared.Core;
 using TypesShared.Domain;
@@ -12,21 +10,28 @@ using TypesShared.Plc;
 
 namespace S7.Sync;
 
-internal sealed class PlcSyncCoordinator(
-	PlcTransactionExecutor transactionExecutor,
-	IS7Service connectionService)
-	: IPlcSyncService, IDisposable
+internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 {
-	private const int DebounceDelayMs = 1000;
 	private readonly Lock _lock = new();
+	private readonly BehaviorSubject<Result<PlcSessionSnapshot>> _subject = new(
+		PlcSessionSnapshot.InitialState);
+	private readonly PlcSyncExecutor _executor;
 
-	private CancellationTokenSource? _debounceCts;
+	private PlcConnectionState _connectionState = PlcConnectionState.Disconnected;
 	private bool _disposed;
-	private string? _lastError;
+	private bool _isSyncEnabled;
 	private DateTimeOffset? _lastSyncTime;
-	private Recipe? _pendingSnapshot;
 	private PlcSyncStatus _status = PlcSyncStatus.Idle;
-	private Task? _syncTask;
+
+	public PlcSyncCoordinator(PlcTransactionExecutor transactionExecutor, IS7Service connectionService)
+	{
+		_executor = new PlcSyncExecutor(
+			transactionExecutor,
+			connectionService,
+			_lock,
+			status => Status = status,
+			time => LastSyncTime = time);
+	}
 
 	public PlcSyncStatus Status
 	{
@@ -39,6 +44,7 @@ internal sealed class PlcSyncCoordinator(
 		}
 		private set
 		{
+			PlcConnectionState connectionStateSnapshot;
 			lock (_lock)
 			{
 				if (_status == value)
@@ -46,29 +52,11 @@ internal sealed class PlcSyncCoordinator(
 					return;
 				}
 				_status = value;
+				connectionStateSnapshot = _connectionState;
 			}
-			// value is captured before leaving the lock. StatusChanged is raised outside the
-			// lock intentionally: subscribers must not re-enter the lock on the same thread.
-			StatusChanged?.Invoke(value);
-		}
-	}
-
-	public string? LastError
-	{
-		get
-		{
-			lock (_lock)
-			{
-				return _lastError;
-			}
-		}
-		private set
-		{
-			lock (_lock)
-			{
-				_lastError = value;
-			}
-			ErrorChanged?.Invoke(value);
+			// Status and connectionState are both captured inside the lock, ensuring
+			// the snapshot represents a consistent point in time.
+			PublishSnapshot(connectionStateSnapshot);
 		}
 	}
 
@@ -90,8 +78,7 @@ internal sealed class PlcSyncCoordinator(
 		}
 	}
 
-	public event Action<PlcSyncStatus>? StatusChanged;
-	public event Action<string?>? ErrorChanged;
+	public IObservable<Result<PlcSessionSnapshot>> PlcState => _subject;
 
 	public void NotifyRecipeChanged(Recipe recipe, bool isValid)
 	{
@@ -102,15 +89,32 @@ internal sealed class PlcSyncCoordinator(
 
 		if (!isValid)
 		{
-			lock (_lock)
-			{
-				_pendingSnapshot = null;
-			}
+			_executor.ClearPendingSnapshot();
 			Status = PlcSyncStatus.OutOfSync;
 			return;
 		}
 
-		OnRecipeChanged(recipe);
+		_executor.OnRecipeChanged(recipe);
+	}
+
+	public void SetSyncEnabled(bool value)
+	{
+		PlcConnectionState connectionStateSnapshot;
+		lock (_lock)
+		{
+			_isSyncEnabled = value;
+			connectionStateSnapshot = _connectionState;
+		}
+		PublishSnapshot(connectionStateSnapshot);
+	}
+
+	public void UpdateConnectionState(PlcConnectionState state)
+	{
+		lock (_lock)
+		{
+			_connectionState = state;
+		}
+		PublishSnapshot(state);
 	}
 
 	public void Dispose()
@@ -121,167 +125,53 @@ internal sealed class PlcSyncCoordinator(
 		}
 
 		_disposed = true;
-		_debounceCts?.Cancel();
-		_debounceCts?.Dispose();
+		_executor.Dispose();
+		_subject.OnCompleted();
+		_subject.Dispose();
 	}
 
 	public void Reset()
 	{
-		lock (_lock)
-		{
-			_debounceCts?.Cancel();
-			_debounceCts?.Dispose();
-			_debounceCts = null;
-			_pendingSnapshot = null;
-		}
-
-		LastError = null;
+		_executor.Reset();
 		Status = PlcSyncStatus.Disconnected;
 	}
 
 	public async Task WaitForPendingSyncAsync(CancellationToken ct = default)
 	{
-		Task? taskToWait;
-		lock (_lock)
-		{
-			taskToWait = _syncTask;
-		}
-
-		if (taskToWait is not null)
-		{
-			try
-			{
-				await taskToWait.WaitAsync(ct);
-			}
-			catch (OperationCanceledException)
-			{
-			}
-		}
+		await _executor.WaitForPendingSyncAsync(ct);
 	}
 
-	private void OnRecipeChanged(Recipe recipe)
+	private void PublishSnapshot(PlcConnectionState connectionState)
 	{
-		if (_disposed)
-		{
-			return;
-		}
+		PlcSyncStatus status;
+		bool isSyncEnabled;
+		string? errorMessage;
 
 		lock (_lock)
 		{
-			_pendingSnapshot = recipe;
-
-			if (_syncTask is not null && !_syncTask.IsCompleted)
-			{
-				Log.Debug("Sync in progress, queueing new snapshot");
-
-				return;
-			}
-
-			StartDebounce();
-		}
-	}
-
-	private void StartDebounce()
-	{
-		_debounceCts?.Cancel();
-		_debounceCts?.Dispose();
-		_debounceCts = new CancellationTokenSource();
-
-		var ct = _debounceCts.Token;
-		_syncTask = Task.Run(async () =>
-		{
-			try
-			{
-				await Task.Delay(DebounceDelayMs, ct);
-				await ExecuteSyncAsync(ct);
-			}
-			catch (OperationCanceledException)
-			{
-			}
-			catch (Exception ex)
-			{
-				Log.Error(ex, "Unhandled exception in sync task");
-				LastError = ex.Message;
-				Status = PlcSyncStatus.Failed;
-			}
-		}, ct);
-	}
-
-	private async Task ExecuteSyncAsync(CancellationToken ct)
-	{
-		Recipe? snapshotToSync;
-		lock (_lock)
-		{
-			snapshotToSync = _pendingSnapshot;
-			_pendingSnapshot = null;
+			status = _status;
+			isSyncEnabled = _isSyncEnabled;
+			errorMessage = _executor.PendingErrorMessage;
 		}
 
-		if (snapshotToSync is null)
+		var snapshot = new PlcSessionSnapshot(connectionState, status, isSyncEnabled);
+
+		if (status == PlcSyncStatus.Failed)
 		{
+			_subject.OnNext(
+				Result.Fail<PlcSessionSnapshot>(new Error(errorMessage ?? "Sync failed"))
+					.WithValue(snapshot));
 			return;
 		}
 
-		if (!connectionService.IsConnected)
+		if (status == PlcSyncStatus.Disconnected && isSyncEnabled)
 		{
-			Log.Debug("Skipping sync: not connected to PLC");
-			Status = PlcSyncStatus.Disconnected;
-
+			_subject.OnNext(
+				Result.Fail<PlcSessionSnapshot>(new Error("PLC connection lost"))
+					.WithValue(snapshot));
 			return;
 		}
 
-		var activeResult = await transactionExecutor.IsRecipeActiveAsync(ct);
-		if (activeResult.IsFailed)
-		{
-			var isDisconnected = activeResult.Errors.OfType<NotConnectedError>().Any();
-			LastError = isDisconnected
-				? "Not connected to PLC"
-				: activeResult.Errors[0].Message;
-			Status = PlcSyncStatus.Failed;
-
-			if (isDisconnected)
-			{
-				Log.Warning("Sync blocked: not connected to PLC");
-			}
-
-			return;
-		}
-
-		if (activeResult.Value)
-		{
-			LastError = "Recipe is being executed on PLC";
-			Status = PlcSyncStatus.Failed;
-			Log.Warning("Sync blocked: recipe is being executed on PLC");
-
-			return;
-		}
-
-		LastError = null;
-		Status = PlcSyncStatus.Syncing;
-
-		var writeResult = await transactionExecutor.WriteRecipeWithRetryAsync(snapshotToSync, ct);
-		if (writeResult.IsFailed)
-		{
-			LastError = writeResult.Errors[0].Message;
-			Status = PlcSyncStatus.Failed;
-			if (!writeResult.Errors.OfType<NotConnectedError>().Any())
-			{
-				Log.Error("Sync failed: {Message}", writeResult.Errors[0].Message);
-			}
-
-			return;
-		}
-
-		LastSyncTime = DateTimeOffset.UtcNow;
-		LastError = null;
-		Status = PlcSyncStatus.Synced;
-
-		lock (_lock)
-		{
-			if (_pendingSnapshot is not null && !_disposed)
-			{
-				Log.Debug("Changes occurred during sync, starting new debounce");
-				StartDebounce();
-			}
-		}
+		_subject.OnNext(Result.Ok(snapshot));
 	}
 }

--- a/SemiStep/S7/Sync/PlcSyncExecutor.cs
+++ b/SemiStep/S7/Sync/PlcSyncExecutor.cs
@@ -28,7 +28,7 @@ internal sealed class PlcSyncExecutor(
 	private CancellationTokenSource? _debounceCts;
 	private Recipe? _pendingSnapshot;
 	private string? _pendingErrorMessage;
-	private bool _disposed;
+	private volatile bool _disposed;
 
 	public string? PendingErrorMessage
 	{
@@ -43,13 +43,13 @@ internal sealed class PlcSyncExecutor(
 
 	public void OnRecipeChanged(Recipe recipe)
 	{
-		if (_disposed)
-		{
-			return;
-		}
-
 		lock (stateLock)
 		{
+			if (_disposed)
+			{
+				return;
+			}
+
 			_pendingSnapshot = recipe;
 
 			if (_syncTask is not null && !_syncTask.IsCompleted)
@@ -110,11 +110,36 @@ internal sealed class PlcSyncExecutor(
 
 	public void Dispose()
 	{
-		_disposed = true;
+		Task? taskToWait;
 		lock (stateLock)
 		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
 			_debounceCts?.Cancel();
 			_debounceCts?.Dispose();
+			_debounceCts = null;
+			taskToWait = _syncTask;
+			_syncTask = null;
+		}
+
+		if (taskToWait is not null)
+		{
+			try
+			{
+				taskToWait.Wait(TimeSpan.FromSeconds(5));
+			}
+			catch (AggregateException ex) when (ex.Flatten().InnerExceptions.All(e => e is OperationCanceledException))
+			{
+				// Expected on cancellation — ignore.
+			}
+			catch (AggregateException ex)
+			{
+				Log.Warning(ex, "Sync task did not complete cleanly during disposal");
+			}
 		}
 	}
 

--- a/SemiStep/S7/Sync/PlcSyncExecutor.cs
+++ b/SemiStep/S7/Sync/PlcSyncExecutor.cs
@@ -1,0 +1,269 @@
+﻿using System.Linq;
+
+using FluentResults;
+
+using S7.Protocol;
+
+using Serilog;
+
+using TypesShared.Core;
+using TypesShared.Domain;
+using TypesShared.Plc;
+
+namespace S7.Sync;
+
+/// <summary>
+/// Owns debounce scheduling and PLC write execution. Called by <see cref="PlcSyncCoordinator"/>.
+/// </summary>
+internal sealed class PlcSyncExecutor(
+	PlcTransactionExecutor transactionExecutor,
+	IS7Service connectionService,
+	Lock stateLock,
+	Action<PlcSyncStatus> setStatus,
+	Action<DateTimeOffset> setLastSyncTime)
+{
+	internal const int DebounceDelayMilliseconds = 1000;
+
+	private Task? _syncTask;
+	private CancellationTokenSource? _debounceCts;
+	private Recipe? _pendingSnapshot;
+	private string? _pendingErrorMessage;
+	private bool _disposed;
+
+	public string? PendingErrorMessage
+	{
+		get
+		{
+			lock (stateLock)
+			{
+				return _pendingErrorMessage;
+			}
+		}
+	}
+
+	public void OnRecipeChanged(Recipe recipe)
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		lock (stateLock)
+		{
+			_pendingSnapshot = recipe;
+
+			if (_syncTask is not null && !_syncTask.IsCompleted)
+			{
+				Log.Debug("Sync in progress, queueing new snapshot");
+
+				return;
+			}
+
+			StartDebounce();
+		}
+	}
+
+	public void ClearPendingSnapshot()
+	{
+		lock (stateLock)
+		{
+			_pendingSnapshot = null;
+		}
+	}
+
+	public void Reset()
+	{
+		lock (stateLock)
+		{
+			_debounceCts?.Cancel();
+			_debounceCts?.Dispose();
+			_debounceCts = null;
+			_pendingSnapshot = null;
+			_pendingErrorMessage = null;
+		}
+	}
+
+	public async Task WaitForPendingSyncAsync(CancellationToken ct)
+	{
+		Task? taskToWait;
+		lock (stateLock)
+		{
+			taskToWait = _syncTask;
+		}
+
+		if (taskToWait is not null)
+		{
+			try
+			{
+				await taskToWait.WaitAsync(ct);
+			}
+			catch (OperationCanceledException) when (ct.IsCancellationRequested)
+			{
+				throw;
+			}
+			catch (OperationCanceledException)
+			{
+				// Internal debounce cancellation — not a caller cancellation.
+			}
+		}
+	}
+
+	public void Dispose()
+	{
+		_disposed = true;
+		lock (stateLock)
+		{
+			_debounceCts?.Cancel();
+			_debounceCts?.Dispose();
+		}
+	}
+
+	private void StartDebounce()
+	{
+		_debounceCts?.Cancel();
+		_debounceCts?.Dispose();
+		_debounceCts = new CancellationTokenSource();
+
+		var ct = _debounceCts.Token;
+		_syncTask = Task.Run(async () =>
+		{
+			try
+			{
+				await Task.Delay(DebounceDelayMilliseconds, ct);
+				await ExecuteSyncAsync(ct);
+			}
+			catch (OperationCanceledException)
+			{
+			}
+			catch (Exception ex)
+			{
+				Log.Error(ex, "Unhandled exception in sync task");
+				lock (stateLock)
+				{
+					_pendingErrorMessage = ex.Message;
+				}
+				setStatus(PlcSyncStatus.Failed);
+			}
+		}, ct);
+	}
+
+	private async Task ExecuteSyncAsync(CancellationToken ct)
+	{
+		var snapshotToSync = ConsumePendingSnapshot();
+
+		if (snapshotToSync is null)
+		{
+			return;
+		}
+
+		var canSyncResult = await CheckCanSyncAsync(ct);
+		if (canSyncResult.IsFailed)
+		{
+			return;
+		}
+
+		await WriteSyncAsync(snapshotToSync, ct);
+	}
+
+	private Recipe? ConsumePendingSnapshot()
+	{
+		lock (stateLock)
+		{
+			var snapshot = _pendingSnapshot;
+			_pendingSnapshot = null;
+			return snapshot;
+		}
+	}
+
+	private async Task<Result> CheckCanSyncAsync(CancellationToken ct)
+	{
+		if (!connectionService.IsConnected)
+		{
+			Log.Debug("Skipping sync: not connected to PLC");
+			setStatus(PlcSyncStatus.Disconnected);
+
+			return Result.Fail("Not connected");
+		}
+
+		var activeResult = await transactionExecutor.IsRecipeActiveAsync(ct);
+		if (activeResult.IsFailed)
+		{
+			var isDisconnected = activeResult.Errors.OfType<NotConnectedError>().Any();
+			lock (stateLock)
+			{
+				_pendingErrorMessage = isDisconnected
+					? "Not connected to PLC"
+					: activeResult.Errors[0].Message;
+			}
+			setStatus(PlcSyncStatus.Failed);
+
+			if (isDisconnected)
+			{
+				Log.Warning("Sync blocked: not connected to PLC");
+			}
+
+			return Result.Fail(activeResult.Errors[0].Message);
+		}
+
+		if (activeResult.Value)
+		{
+			lock (stateLock)
+			{
+				_pendingErrorMessage = "Recipe is being executed on PLC";
+			}
+			setStatus(PlcSyncStatus.Failed);
+			Log.Warning("Sync blocked: recipe is being executed on PLC");
+
+			return Result.Fail("Recipe active");
+		}
+
+		return Result.Ok();
+	}
+
+	private async Task WriteSyncAsync(Recipe recipe, CancellationToken ct)
+	{
+		lock (stateLock)
+		{
+			_pendingErrorMessage = null;
+		}
+		setStatus(PlcSyncStatus.Syncing);
+
+		var writeResult = await transactionExecutor.WriteRecipeWithRetryAsync(recipe, ct);
+		if (writeResult.IsFailed)
+		{
+			lock (stateLock)
+			{
+				_pendingErrorMessage = writeResult.Errors[0].Message;
+			}
+			setStatus(PlcSyncStatus.Failed);
+			if (!writeResult.Errors.OfType<NotConnectedError>().Any())
+			{
+				Log.Error("Sync failed: {Message}", writeResult.Errors[0].Message);
+			}
+
+			return;
+		}
+
+		setLastSyncTime(DateTimeOffset.UtcNow);
+		lock (stateLock)
+		{
+			_pendingErrorMessage = null;
+		}
+		setStatus(PlcSyncStatus.Synced);
+
+		bool hasPending;
+		lock (stateLock)
+		{
+			hasPending = _pendingSnapshot is not null && !_disposed;
+		}
+
+		if (hasPending)
+		{
+			Log.Debug("Changes occurred during sync, starting new debounce");
+			lock (stateLock)
+			{
+				StartDebounce();
+			}
+		}
+	}
+}

--- a/SemiStep/S7/Sync/PlcTransactionExecutor.cs
+++ b/SemiStep/S7/Sync/PlcTransactionExecutor.cs
@@ -34,94 +34,108 @@ internal sealed class PlcTransactionExecutor
 		_managingCodec = new ManagingAreaCodec(_layout.ManagingDb);
 	}
 
-	public async Task<bool> IsRecipeActiveAsync(CancellationToken ct = default)
+	public async Task<Result<bool>> IsRecipeActiveAsync(CancellationToken ct = default)
 	{
-		EnsureConnected();
+		var result = await ReadExecutionStateAsync(ct);
+		return result.Map(info => info.RecipeActive);
+	}
 
-		var bytes = await _transport.ReadBytesAsync(
+	public Task<Result<PlcExecutionInfo>> ReadExecutionStateAsync(CancellationToken ct = default)
+	{
+		return ReadAndDecodeAsync(
 			_layout.ExecutionDb.DbNumber,
-			0,
 			_layout.ExecutionDb.TotalSize,
+			_executionCodec.Decode,
 			ct);
-
-		var state = _executionCodec.Decode(bytes);
-
-		return state.RecipeActive;
 	}
 
-	public async Task<PlcExecutionState> ReadExecutionStateAsync(CancellationToken ct = default)
+	public async Task<Result<PlcRecipeData>> ReadRecipeDataAsync(CancellationToken ct = default)
 	{
-		EnsureConnected();
+		if (!_transport.IsConnected)
+		{
+			return Result.Fail(new NotConnectedError("Not connected to PLC"));
+		}
 
-		var bytes = await _transport.ReadBytesAsync(
-			_layout.ExecutionDb.DbNumber,
-			0,
-			_layout.ExecutionDb.TotalSize,
-			ct);
+		try
+		{
+			var intHeaderBytes = await _transport.ReadBytesAsync(
+				_layout.IntDb.DbNumber,
+				0,
+				_layout.IntDb.DataStartOffset,
+				ct);
+			var intCount = ArrayCodec.ReadArrayCurrentSize(intHeaderBytes, _layout.IntDb);
 
-		return _executionCodec.Decode(bytes);
+			var floatHeaderBytes = await _transport.ReadBytesAsync(
+				_layout.FloatDb.DbNumber,
+				0,
+				_layout.FloatDb.DataStartOffset,
+				ct);
+			var floatCount = ArrayCodec.ReadArrayCurrentSize(floatHeaderBytes, _layout.FloatDb);
+
+			var stringHeaderBytes = await _transport.ReadBytesAsync(
+				_layout.StringDb.DbNumber,
+				0,
+				_layout.StringDb.DataStartOffset,
+				ct);
+			var stringCount = ArrayCodec.ReadArrayCurrentSize(stringHeaderBytes, _layout.StringDb);
+
+			var intDataSize = _layout.IntDb.DataStartOffset + intCount * ProtocolConstants.IntElementSize;
+			var floatDataSize = _layout.FloatDb.DataStartOffset + floatCount * ProtocolConstants.FloatElementSize;
+			var stringDataSize = _layout.StringDb.DataStartOffset + stringCount * ProtocolConstants.WStringElementSize;
+
+			var intData = await _transport.ReadBytesAsync(_layout.IntDb.DbNumber, 0, intDataSize, ct);
+			var floatData = await _transport.ReadBytesAsync(_layout.FloatDb.DbNumber, 0, floatDataSize, ct);
+			var stringData = await _transport.ReadBytesAsync(_layout.StringDb.DbNumber, 0, stringDataSize, ct);
+
+			var intValues = _arrayCodec.DecodeIntArray(intData, intCount);
+			var floatValues = _arrayCodec.DecodeFloatArray(floatData, floatCount);
+			var stringValues = _arrayCodec.DecodeStringArray(stringData, stringCount);
+
+			return Result.Ok(new PlcRecipeData(intValues, floatValues, stringValues, StepCount: intCount));
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return Result.Fail(ex.Message);
+		}
 	}
 
-	public async Task<PlcRecipeData> ReadRecipeDataAsync(CancellationToken ct = default)
+	public async Task<Result> WriteRecipeWithRetryAsync(Recipe recipe, CancellationToken ct = default)
 	{
-		EnsureConnected();
+		if (!_transport.IsConnected)
+		{
+			return Result.Fail(new NotConnectedError("Not connected to PLC"));
+		}
 
-		var intHeaderBytes = await _transport.ReadBytesAsync(
-			_layout.IntDb.DbNumber,
-			0,
-			_layout.IntDb.DataStartOffset,
-			ct);
-		var intCount = ArrayCodec.ReadArrayCurrentSize(intHeaderBytes, _layout.IntDb);
+		var dataResult = _converter.FromRecipe(recipe);
+		if (dataResult.IsFailed)
+		{
+			return dataResult.ToResult();
+		}
 
-		var floatHeaderBytes = await _transport.ReadBytesAsync(
-			_layout.FloatDb.DbNumber,
-			0,
-			_layout.FloatDb.DataStartOffset,
-			ct);
-		var floatCount = ArrayCodec.ReadArrayCurrentSize(floatHeaderBytes, _layout.FloatDb);
-
-		var stringHeaderBytes = await _transport.ReadBytesAsync(
-			_layout.StringDb.DbNumber,
-			0,
-			_layout.StringDb.DataStartOffset,
-			ct);
-		var stringCount = ArrayCodec.ReadArrayCurrentSize(stringHeaderBytes, _layout.StringDb);
-
-		var intDataSize = _layout.IntDb.DataStartOffset + intCount * ProtocolConstants.IntElementSize;
-		var floatDataSize = _layout.FloatDb.DataStartOffset + floatCount * ProtocolConstants.FloatElementSize;
-		var stringDataSize = _layout.StringDb.DataStartOffset + stringCount * ProtocolConstants.WStringElementSize;
-
-		var intData = await _transport.ReadBytesAsync(_layout.IntDb.DbNumber, 0, intDataSize, ct);
-		var floatData = await _transport.ReadBytesAsync(_layout.FloatDb.DbNumber, 0, floatDataSize, ct);
-		var stringData = await _transport.ReadBytesAsync(_layout.StringDb.DbNumber, 0, stringDataSize, ct);
-
-		var intValues = _arrayCodec.DecodeIntArray(intData, intCount);
-		var floatValues = _arrayCodec.DecodeFloatArray(floatData, floatCount);
-		var stringValues = _arrayCodec.DecodeStringArray(stringData, stringCount);
-
-		var stepCount = intCount;
-
-		return new PlcRecipeData(intValues, floatValues, stringValues, stepCount);
-	}
-
-	public async Task WriteRecipeWithRetryAsync(Recipe recipe, CancellationToken ct = default)
-	{
-		var recipeData = _converter.FromRecipe(recipe);
+		var recipeData = dataResult.Value;
 
 		for (var attempt = 1; attempt <= _protocolSettings.MaxRetryAttempts; attempt++)
 		{
-			await WriteRecipeDataAsync(recipeData, ct);
+			var writeResult = await WriteRecipeDataAsync(recipeData, ct);
+			if (writeResult.IsFailed)
+			{
+				return writeResult;
+			}
 
-			var verified = await VerifyWriteAsync(recipeData, ct);
+			var verifyResult = await VerifyWriteAsync(recipeData, ct);
+			if (verifyResult.IsFailed)
+			{
+				return verifyResult.ToResult();
+			}
 
-			if (verified)
+			if (verifyResult.Value)
 			{
 				Log.Information(
 					"Recipe synced to PLC successfully ({StepCount} steps, attempt {Attempt})",
 					recipe.StepCount,
 					attempt);
 
-				return;
+				return Result.Ok();
 			}
 
 			Log.Warning(
@@ -130,132 +144,117 @@ internal sealed class PlcTransactionExecutor
 				_protocolSettings.MaxRetryAttempts);
 		}
 
-		throw new PlcWriteVerificationException(
+		return Result.Fail(
 			$"Recipe write verification failed after {_protocolSettings.MaxRetryAttempts} attempts");
 	}
 
-	public async Task<ManagingAreaState> ReadManagingAreaAsync(CancellationToken ct = default)
+	public Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync(CancellationToken ct = default)
 	{
-		EnsureConnected();
-
-		var bytes = await _transport.ReadBytesAsync(
+		return ReadAndDecodeAsync(
 			_layout.ManagingDb.DbNumber,
-			0,
 			_layout.ManagingDb.TotalSize,
+			_managingCodec.Decode,
 			ct);
-
-		return _managingCodec.Decode(bytes);
 	}
 
 	public async Task<Result<Recipe>> ReadRecipeFromPlcAsync(CancellationToken ct = default)
 	{
-		var managingAreaState = await ReadManagingAreaAsync(ct);
+		var managingAreaResult = await ReadManagingAreaAsync(ct);
+		if (managingAreaResult.IsFailed)
+		{
+			return managingAreaResult.ToResult<Recipe>();
+		}
 
-		if (!managingAreaState.Committed)
+		if (!managingAreaResult.Value.Committed)
 		{
 			return Result.Fail("Recipe not committed on PLC");
 		}
 
-		var recipeData = await ReadRecipeDataAsync(ct);
+		var recipeDataResult = await ReadRecipeDataAsync(ct);
+		if (recipeDataResult.IsFailed)
+		{
+			return recipeDataResult.ToResult<Recipe>();
+		}
 
-		try
-		{
-			var recipe = _converter.ToRecipe(recipeData);
-			return Result.Ok(recipe);
-		}
-		catch (Exception ex)
-		{
-			Log.Warning(ex, "Failed to convert PLC recipe data to Recipe");
-			return Result.Fail($"Failed to convert PLC data to recipe: {ex.Message}");
-		}
+		return _converter.ToRecipe(recipeDataResult.Value);
 	}
 
-	private async Task WriteRecipeDataAsync(PlcRecipeData data, CancellationToken ct)
-	{
-		EnsureConnected();
-
-		await WriteManagingAreaAsync(new ManagingAreaPcData(Committed: false, RecipeLines: 0), ct);
-
-		var intBytes = _arrayCodec.EncodeIntArray(data.IntValues);
-		var floatBytes = _arrayCodec.EncodeFloatArray(data.FloatValues);
-		var stringBytes = _arrayCodec.EncodeStringArray(data.StringValues);
-
-		await _transport.WriteBytesAsync(_layout.IntDb.DbNumber, 0, intBytes, ct);
-		await _transport.WriteBytesAsync(_layout.FloatDb.DbNumber, 0, floatBytes, ct);
-		await _transport.WriteBytesAsync(_layout.StringDb.DbNumber, 0, stringBytes, ct);
-
-		await WriteManagingAreaAsync(new ManagingAreaPcData(Committed: false, RecipeLines: data.StepCount), ct);
-
-		await WriteManagingAreaAsync(new ManagingAreaPcData(Committed: true, RecipeLines: data.StepCount), ct);
-	}
-
-	private async Task<bool> VerifyWriteAsync(PlcRecipeData expected, CancellationToken ct)
-	{
-		var actual = await ReadRecipeDataAsync(ct);
-
-		if (actual.IntValues.Length != expected.IntValues.Length)
-		{
-			return false;
-		}
-
-		if (actual.FloatValues.Length != expected.FloatValues.Length)
-		{
-			return false;
-		}
-
-		if (actual.StringValues.Length != expected.StringValues.Length)
-		{
-			return false;
-		}
-
-		for (var i = 0; i < expected.IntValues.Length; i++)
-		{
-			if (actual.IntValues[i] != expected.IntValues[i])
-			{
-				return false;
-			}
-		}
-
-		for (var i = 0; i < expected.FloatValues.Length; i++)
-		{
-			if (!CompareFloats_ExpectedBytesEqual(actual.FloatValues[i], expected.FloatValues[i]))
-			{
-				return false;
-			}
-		}
-
-		for (var i = 0; i < expected.StringValues.Length; i++)
-		{
-			if (actual.StringValues[i] != expected.StringValues[i])
-			{
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	// Floats are serialised to raw IEEE 754 bytes, written to the PLC, and read back without
-	// any arithmetic transformation. The round-trip is byte-exact, so bit-exact equality is
-	// the correct comparison here — not an epsilon-based approximation.
-	// BitConverter.SingleToInt32Bits is used rather than == to correctly handle NaN payloads
-	// and distinguish +0 from -0 (different IEEE-754 bit patterns).
-	private static bool CompareFloats_ExpectedBytesEqual(float actual, float expected)
-	{
-		return BitConverter.SingleToInt32Bits(actual) == BitConverter.SingleToInt32Bits(expected);
-	}
-
-	private async Task WriteManagingAreaAsync(ManagingAreaPcData data, CancellationToken ct)
-	{
-		var bytes = _managingCodec.EncodePcData(data);
-		await _transport.WriteBytesAsync(_layout.ManagingDb.DbNumber, 0, bytes, ct);
-	}
-
-	private void EnsureConnected()
+	private async Task<Result<T>> ReadAndDecodeAsync<T>(
+		int dbNumber, int size, Func<byte[], Result<T>> decode, CancellationToken ct)
 	{
 		if (!_transport.IsConnected)
 		{
-			throw new PlcNotConnectedException("Not connected to PLC");
+			return Result.Fail(new NotConnectedError("Not connected to PLC"));
+		}
+
+		try
+		{
+			var bytes = await _transport.ReadBytesAsync(dbNumber, 0, size, ct);
+			return decode(bytes);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return Result.Fail(ex.Message);
+		}
+	}
+
+	private async Task<Result> WriteRecipeDataAsync(PlcRecipeData data, CancellationToken ct)
+	{
+		try
+		{
+			var writeManagingResult = await WriteManagingAreaAsync(
+				new ManagingAreaPcData(Committed: false, RecipeLines: 0), ct);
+			if (writeManagingResult.IsFailed)
+			{
+				return writeManagingResult;
+			}
+
+			var intBytes = _arrayCodec.EncodeIntArray(data.IntValues);
+			var floatBytes = _arrayCodec.EncodeFloatArray(data.FloatValues);
+			var stringBytes = _arrayCodec.EncodeStringArray(data.StringValues);
+
+			await _transport.WriteBytesAsync(_layout.IntDb.DbNumber, 0, intBytes, ct);
+			await _transport.WriteBytesAsync(_layout.FloatDb.DbNumber, 0, floatBytes, ct);
+			await _transport.WriteBytesAsync(_layout.StringDb.DbNumber, 0, stringBytes, ct);
+
+			var writeLinesResult = await WriteManagingAreaAsync(
+				new ManagingAreaPcData(Committed: false, RecipeLines: data.StepCount), ct);
+			if (writeLinesResult.IsFailed)
+			{
+				return writeLinesResult;
+			}
+
+			return await WriteManagingAreaAsync(
+				new ManagingAreaPcData(Committed: true, RecipeLines: data.StepCount), ct);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return Result.Fail(ex.Message);
+		}
+	}
+
+	private async Task<Result<bool>> VerifyWriteAsync(PlcRecipeData expected, CancellationToken ct)
+	{
+		var actualResult = await ReadRecipeDataAsync(ct);
+		if (actualResult.IsFailed)
+		{
+			return actualResult.ToResult<bool>();
+		}
+
+		return Result.Ok(PlcRecipeDataComparer.DataMatchesExpected(actualResult.Value, expected));
+	}
+
+	private async Task<Result> WriteManagingAreaAsync(ManagingAreaPcData data, CancellationToken ct)
+	{
+		try
+		{
+			var bytes = _managingCodec.EncodePcData(data);
+			await _transport.WriteBytesAsync(_layout.ManagingDb.DbNumber, 0, bytes, ct);
+			return Result.Ok();
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return Result.Fail(ex.Message);
 		}
 	}
 }

--- a/SemiStep/S7/Sync/PlcWriteVerificationException.cs
+++ b/SemiStep/S7/Sync/PlcWriteVerificationException.cs
@@ -1,3 +1,0 @@
-﻿namespace S7.Sync;
-
-internal sealed class PlcWriteVerificationException(string message) : Exception(message);

--- a/SemiStep/Tests/Helpers/StubPlcSyncService.cs
+++ b/SemiStep/Tests/Helpers/StubPlcSyncService.cs
@@ -1,4 +1,8 @@
-﻿using TypesShared.Core;
+﻿using System.Reactive.Subjects;
+
+using FluentResults;
+
+using TypesShared.Core;
 using TypesShared.Domain;
 using TypesShared.Plc;
 
@@ -6,21 +10,26 @@ namespace Tests.Helpers;
 
 public sealed class StubPlcSyncService : IPlcSyncService
 {
-	public PlcSyncStatus Status => PlcSyncStatus.Idle;
+	private readonly BehaviorSubject<Result<PlcSessionSnapshot>> _plcStateSubject = new(
+		PlcSessionSnapshot.InitialState);
 
-	public string? LastError => null;
+	public PlcSyncStatus Status => PlcSyncStatus.Idle;
 
 	public DateTimeOffset? LastSyncTime => null;
 
-	public event Action<PlcSyncStatus>? StatusChanged;
-
-	public event Action<string?>? ErrorChanged;
+	public IObservable<Result<PlcSessionSnapshot>> PlcState => _plcStateSubject;
 
 	/// <summary>True if <see cref="Reset"/> was called at least once.</summary>
 	public bool WasResetCalled { get; private set; }
 
 	/// <summary>Number of times <see cref="NotifyRecipeChanged"/> was called.</summary>
 	public int NotifyRecipeChangedCallCount { get; private set; }
+
+	/// <summary>Pushes a new PLC state snapshot to subscribers of <see cref="PlcState"/>.</summary>
+	public void PushPlcState(Result<PlcSessionSnapshot> state)
+	{
+		_plcStateSubject.OnNext(state);
+	}
 
 	public void NotifyRecipeChanged(Recipe recipe, bool isValid)
 	{
@@ -30,5 +39,13 @@ public sealed class StubPlcSyncService : IPlcSyncService
 	public void Reset()
 	{
 		WasResetCalled = true;
+	}
+
+	public void SetSyncEnabled(bool value)
+	{
+	}
+
+	public void UpdateConnectionState(PlcConnectionState state)
+	{
 	}
 }

--- a/SemiStep/Tests/S7/ExecutionStateCodecTests.cs
+++ b/SemiStep/Tests/S7/ExecutionStateCodecTests.cs
@@ -1,0 +1,145 @@
+﻿using System.Buffers.Binary;
+
+using FluentAssertions;
+
+using S7.Serialization;
+
+using TypesShared.Plc.Memory;
+
+using Xunit;
+
+namespace Tests.S7;
+
+[Trait("Component", "S7")]
+[Trait("Area", "Serialization")]
+[Trait("Category", "Unit")]
+public sealed class ExecutionStateCodecTests
+{
+	private static ExecutionDbLayout DefaultLayout => ExecutionDbLayout.Default;
+
+	private static ExecutionStateCodec BuildCodec()
+	{
+		return new ExecutionStateCodec(DefaultLayout);
+	}
+
+	[Fact]
+	public void Decode_TooShortData_ReturnsFailedResult()
+	{
+		var codec = BuildCodec();
+		var shortBytes = new byte[DefaultLayout.TotalSize - 1];
+
+		var result = codec.Decode(shortBytes);
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors[0].Message.Should().Contain("length");
+	}
+
+	[Fact]
+	public void Decode_RecipeActive_TrueWhenFirstByteNonZero()
+	{
+		var codec = BuildCodec();
+		var bytes = new byte[DefaultLayout.TotalSize];
+		bytes[DefaultLayout.RecipeActiveOffset] = 0x01;
+		bytes[DefaultLayout.RecipeActiveOffset + 1] = 0x00;
+
+		var result = codec.Decode(bytes);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.RecipeActive.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Decode_RecipeActive_TrueWhenSecondByteNonZero()
+	{
+		var codec = BuildCodec();
+		var bytes = new byte[DefaultLayout.TotalSize];
+		bytes[DefaultLayout.RecipeActiveOffset] = 0x00;
+		bytes[DefaultLayout.RecipeActiveOffset + 1] = 0x01;
+
+		var result = codec.Decode(bytes);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.RecipeActive.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Decode_RecipeActive_FalseWhenBothBytesZero()
+	{
+		var codec = BuildCodec();
+		var bytes = new byte[DefaultLayout.TotalSize];
+		bytes[DefaultLayout.RecipeActiveOffset] = 0x00;
+		bytes[DefaultLayout.RecipeActiveOffset + 1] = 0x00;
+
+		var result = codec.Decode(bytes);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.RecipeActive.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Decode_ActualLine_ParsedBigEndianFromOffset()
+	{
+		var codec = BuildCodec();
+		var bytes = new byte[DefaultLayout.TotalSize];
+		const int ExpectedLine = 42;
+		BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(DefaultLayout.ActualLineOffset), ExpectedLine);
+
+		var result = codec.Decode(bytes);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.ActualLine.Should().Be(ExpectedLine);
+	}
+
+	[Fact]
+	public void Decode_StepCurrentTime_ParsedAsIeee754BigEndian()
+	{
+		var codec = BuildCodec();
+		var bytes = new byte[DefaultLayout.TotalSize];
+		const float ExpectedTime = 3.14f;
+		BinaryPrimitives.WriteInt32BigEndian(
+			bytes.AsSpan(DefaultLayout.StepCurrentTimeOffset),
+			BitConverter.SingleToInt32Bits(ExpectedTime));
+
+		var result = codec.Decode(bytes);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.StepCurrentTime.Should().Be(ExpectedTime);
+	}
+
+	[Fact]
+	public void Decode_ForLoopCounts_ParsedBigEndianFromOffsets()
+	{
+		var codec = BuildCodec();
+		var bytes = new byte[DefaultLayout.TotalSize];
+		const int Count1 = 10;
+		const int Count2 = 20;
+		const int Count3 = 30;
+		BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(DefaultLayout.ForLoopCount1Offset), Count1);
+		BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(DefaultLayout.ForLoopCount2Offset), Count2);
+		BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(DefaultLayout.ForLoopCount3Offset), Count3);
+
+		var result = codec.Decode(bytes);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.ForLoopCount1.Should().Be(Count1);
+		result.Value.ForLoopCount2.Should().Be(Count2);
+		result.Value.ForLoopCount3.Should().Be(Count3);
+	}
+
+	[Fact]
+	public void Decode_AllZeroBytes_ReturnsInactiveRecipeAndZeroFields()
+	{
+		var codec = BuildCodec();
+		var bytes = new byte[DefaultLayout.TotalSize];
+
+		var result = codec.Decode(bytes);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.RecipeActive.Should().BeFalse();
+		result.Value.ActualLine.Should().Be(0);
+		result.Value.StepCurrentTime.Should().Be(0f);
+		result.Value.ForLoopCount1.Should().Be(0);
+		result.Value.ForLoopCount2.Should().Be(0);
+		result.Value.ForLoopCount3.Should().Be(0);
+	}
+}

--- a/SemiStep/Tests/S7/Helpers/FailFirstExecutionTransport.cs
+++ b/SemiStep/Tests/S7/Helpers/FailFirstExecutionTransport.cs
@@ -1,0 +1,33 @@
+﻿using S7;
+
+namespace Tests.S7.Helpers;
+
+/// <summary>
+/// A transport that throws an <see cref="InvalidOperationException"/> on the first read of the
+/// execution DB, then delegates all subsequent reads to an inner <see cref="IS7Transport"/>.
+/// Used to verify that the execution monitor poll loop recovers from transient errors.
+/// </summary>
+internal sealed class FailFirstExecutionTransport(IS7Transport inner, int executionDbNumber) : IS7Transport
+{
+	private int _executionReadCount;
+
+	public bool IsConnected => true;
+
+	public async Task<byte[]> ReadBytesAsync(int dbNumber, int startByte, int count, CancellationToken ct = default)
+	{
+		if (dbNumber == executionDbNumber)
+		{
+			if (Interlocked.Increment(ref _executionReadCount) == 1)
+			{
+				throw new InvalidOperationException("Simulated transient read failure");
+			}
+		}
+
+		return await inner.ReadBytesAsync(dbNumber, startByte, count, ct);
+	}
+
+	public Task WriteBytesAsync(int dbNumber, int startByte, byte[] data, CancellationToken ct = default)
+	{
+		return inner.WriteBytesAsync(dbNumber, startByte, data, ct);
+	}
+}

--- a/SemiStep/Tests/S7/Helpers/FakeExecutionTransport.cs
+++ b/SemiStep/Tests/S7/Helpers/FakeExecutionTransport.cs
@@ -1,5 +1,4 @@
 ﻿using S7;
-using S7.Protocol;
 
 using TypesShared.Plc;
 using TypesShared.Plc.Memory;
@@ -7,16 +6,16 @@ using TypesShared.Plc.Memory;
 namespace Tests.S7.Helpers;
 
 /// <summary>
-/// A transport that returns a configurable <see cref="PlcExecutionState"/> encoded as bytes
+/// A transport that returns a configurable <see cref="PlcExecutionInfo"/> encoded as bytes
 /// for execution DB reads, and returns empty arrays for all other DBs.
 /// </summary>
 internal sealed class FakeExecutionTransport : IS7Transport
 {
 	private readonly PlcProtocolLayout _layout;
-	private readonly PlcExecutionState _executionState;
+	private readonly PlcExecutionInfo _executionState;
 	private int _executionReadCount;
 
-	public FakeExecutionTransport(PlcProtocolLayout layout, PlcExecutionState executionState)
+	public FakeExecutionTransport(PlcProtocolLayout layout, PlcExecutionInfo executionState)
 	{
 		_layout = layout;
 		_executionState = executionState;

--- a/SemiStep/Tests/S7/ManagingAreaCodecTests.cs
+++ b/SemiStep/Tests/S7/ManagingAreaCodecTests.cs
@@ -77,10 +77,10 @@ public sealed class ManagingAreaCodecTests
 
 		var bytes = codec.EncodePcData(data);
 
-		bytes[2].Should().Be(0);
-		bytes[3].Should().Be(0);
-		bytes[4].Should().Be(0);
-		bytes[5].Should().Be(0);
+		bytes[DefaultLayout.RecipeLinesOffset].Should().Be(0);
+		bytes[DefaultLayout.RecipeLinesOffset + 1].Should().Be(0);
+		bytes[DefaultLayout.RecipeLinesOffset + 2].Should().Be(0);
+		bytes[DefaultLayout.RecipeLinesOffset + 3].Should().Be(0);
 	}
 
 	[Fact]
@@ -90,9 +90,10 @@ public sealed class ManagingAreaCodecTests
 		var bytes = new byte[DefaultLayout.TotalSize];
 		bytes[DefaultLayout.CommittedOffset] = 0x01;
 
-		var state = codec.Decode(bytes);
+		var result = codec.Decode(bytes);
 
-		state.Committed.Should().BeTrue();
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Committed.Should().BeTrue();
 	}
 
 	[Fact]
@@ -102,9 +103,10 @@ public sealed class ManagingAreaCodecTests
 		var bytes = new byte[DefaultLayout.TotalSize];
 		bytes[DefaultLayout.CommittedOffset] = 0x00;
 
-		var state = codec.Decode(bytes);
+		var result = codec.Decode(bytes);
 
-		state.Committed.Should().BeFalse();
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Committed.Should().BeFalse();
 	}
 
 	[Fact]
@@ -115,9 +117,10 @@ public sealed class ManagingAreaCodecTests
 		const int ExpectedLines = 99;
 		BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(DefaultLayout.RecipeLinesOffset), ExpectedLines);
 
-		var state = codec.Decode(bytes);
+		var result = codec.Decode(bytes);
 
-		state.RecipeLines.Should().Be(ExpectedLines);
+		result.IsSuccess.Should().BeTrue();
+		result.Value.RecipeLines.Should().Be(ExpectedLines);
 	}
 
 	[Fact]
@@ -126,22 +129,23 @@ public sealed class ManagingAreaCodecTests
 		var codec = BuildCodec();
 		var bytes = new byte[DefaultLayout.TotalSize];
 
-		var state = codec.Decode(bytes);
+		var result = codec.Decode(bytes);
 
-		state.Committed.Should().BeFalse();
-		state.RecipeLines.Should().Be(0);
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Committed.Should().BeFalse();
+		result.Value.RecipeLines.Should().Be(0);
 	}
 
 	[Fact]
-	public void Decode_TooShortData_ThrowsArgumentException()
+	public void Decode_TooShortData_ReturnsFailedResult()
 	{
 		var codec = BuildCodec();
 		var shortBytes = new byte[3];
 
-		var act = () => codec.Decode(shortBytes);
+		var result = codec.Decode(shortBytes);
 
-		act.Should().Throw<ArgumentException>()
-			.WithMessage("*length*");
+		result.IsFailed.Should().BeTrue();
+		result.Errors[0].Message.Should().Contain("length");
 	}
 
 	[Fact]
@@ -152,10 +156,11 @@ public sealed class ManagingAreaCodecTests
 		var pcData = new ManagingAreaPcData(Committed: true, RecipeLines: Lines);
 
 		var bytes = codec.EncodePcData(pcData);
-		var state = codec.Decode(bytes);
+		var result = codec.Decode(bytes);
 
-		state.Committed.Should().BeTrue();
-		state.RecipeLines.Should().Be(Lines);
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Committed.Should().BeTrue();
+		result.Value.RecipeLines.Should().Be(Lines);
 	}
 
 	[Fact]
@@ -166,9 +171,10 @@ public sealed class ManagingAreaCodecTests
 		var pcData = new ManagingAreaPcData(Committed: false, RecipeLines: Lines);
 
 		var bytes = codec.EncodePcData(pcData);
-		var state = codec.Decode(bytes);
+		var result = codec.Decode(bytes);
 
-		state.Committed.Should().BeFalse();
-		state.RecipeLines.Should().Be(Lines);
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Committed.Should().BeFalse();
+		result.Value.RecipeLines.Should().Be(Lines);
 	}
 }

--- a/SemiStep/Tests/S7/PlcExecutionMonitorTests.cs
+++ b/SemiStep/Tests/S7/PlcExecutionMonitorTests.cs
@@ -3,7 +3,6 @@
 using FluentAssertions;
 
 using S7;
-using S7.Protocol;
 using S7.Serialization;
 using S7.Sync;
 
@@ -57,12 +56,12 @@ public sealed class PlcExecutionMonitorTests
 	/// that returns a controllable execution state on every poll tick.
 	/// </summary>
 	private static (PlcExecutionMonitor Monitor, FakeExecutionTransport Transport) BuildMonitor(
-		PlcExecutionState? executionStateToReturn = null)
+		PlcExecutionInfo? executionStateToReturn = null)
 	{
 		var configuration = BuildTestConfiguration();
 		var transport = new FakeExecutionTransport(
 			configuration.Layout,
-			executionStateToReturn ?? new PlcExecutionState(
+			executionStateToReturn ?? new PlcExecutionInfo(
 				RecipeActive: false,
 				ActualLine: 0,
 				StepCurrentTime: 0f,
@@ -107,7 +106,7 @@ public sealed class PlcExecutionMonitorTests
 	[Fact]
 	public async Task Start_PublishesExecutionStateFromPoll()
 	{
-		var expectedState = new PlcExecutionState(
+		var expectedState = new PlcExecutionInfo(
 			RecipeActive: true,
 			ActualLine: 3,
 			StepCurrentTime: 1.5f,
@@ -136,7 +135,7 @@ public sealed class PlcExecutionMonitorTests
 	public async Task Start_ThenStop_LastPublishedValueIsEmpty()
 	{
 		var (monitor, _) = BuildMonitor(
-			new PlcExecutionState(
+			new PlcExecutionInfo(
 				RecipeActive: true,
 				ActualLine: 1,
 				StepCurrentTime: 0f,
@@ -184,7 +183,7 @@ public sealed class PlcExecutionMonitorTests
 	[Fact]
 	public async Task LastKnown_UpdatesAfterPoll()
 	{
-		var executionState = new PlcExecutionState(
+		var executionState = new PlcExecutionInfo(
 			RecipeActive: true,
 			ActualLine: 5,
 			StepCurrentTime: 2.0f,

--- a/SemiStep/Tests/S7/PlcExecutionMonitorTests.cs
+++ b/SemiStep/Tests/S7/PlcExecutionMonitorTests.cs
@@ -203,6 +203,35 @@ public sealed class PlcExecutionMonitorTests
 	}
 
 	[Fact]
+	public async Task PollLoop_TransientError_ContinuesPolling()
+	{
+		var configuration = BuildTestConfiguration();
+		var successState = new PlcExecutionInfo(
+			RecipeActive: true,
+			ActualLine: 7,
+			StepCurrentTime: 0f,
+			ForLoopCount1: 0,
+			ForLoopCount2: 0,
+			ForLoopCount3: 0);
+
+		var innerTransport = new FakeExecutionTransport(configuration.Layout, successState);
+		var transport = new FailFirstExecutionTransport(innerTransport, configuration.Layout.ExecutionDb.DbNumber);
+		var converter = new RecipeConverter(BuildEmptyConfigRegistry());
+		var executor = new PlcTransactionExecutor(transport, converter, configuration);
+		var monitor = new PlcExecutionMonitor(executor, configuration.ProtocolSettings, onConnectionLost: () => { });
+
+		var received = new List<PlcExecutionInfo>();
+		monitor.State.Subscribe(info => received.Add(info));
+
+		monitor.Start();
+		await Task.Delay(500);
+		monitor.Stop();
+
+		received.Should().Contain(info => info.RecipeActive,
+			"the poll loop must continue after a transient (non-NotConnectedError) failure and eventually deliver a valid result");
+	}
+
+	[Fact]
 	public void Dispose_CompletesObservable()
 	{
 		var (monitor, _) = BuildMonitor();

--- a/SemiStep/Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/Tests/S7/PlcSyncCoordinatorTests.cs
@@ -2,6 +2,8 @@
 
 using FluentAssertions;
 
+using FluentResults;
+
 using S7.Serialization;
 using S7.Sync;
 
@@ -88,29 +90,32 @@ public sealed class PlcSyncCoordinatorTests
 	}
 
 	[Fact]
-	public void NotifyRecipeChanged_IsValidFalse_FiresStatusChangedEvent()
+	public void NotifyRecipeChanged_IsValidFalse_EmitsOutOfSyncSnapshot()
 	{
 		var (coordinator, _, _) = Build();
-		PlcSyncStatus? receivedStatus = null;
-		coordinator.StatusChanged += status => receivedStatus = status;
+		Result<PlcSessionSnapshot>? received = null;
+		using var sub = coordinator.PlcState.Skip(1).Take(1).Subscribe(s => received = s);
 
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: false);
 
-		receivedStatus.Should().Be(PlcSyncStatus.OutOfSync);
+		received.Should().NotBeNull();
+		received!.Value.SyncStatus.Should().Be(PlcSyncStatus.OutOfSync);
 	}
 
 	[Fact]
-	public void NotifyRecipeChanged_IsValidFalse_StatusChangedMultipleTimes_OnlyFiresWhenValueChanges()
+	public void NotifyRecipeChanged_IsValidFalse_StatusChangedMultipleTimes_OnlyEmitsWhenValueChanges()
 	{
 		var (coordinator, _, _) = Build();
-		var receivedStatuses = new List<PlcSyncStatus>();
-		coordinator.StatusChanged += status => receivedStatuses.Add(status);
+		var snapshots = new List<Result<PlcSessionSnapshot>>();
+
+		// Skip the initial state emitted on subscription.
+		using var sub = coordinator.PlcState.Skip(1).Subscribe(snapshots.Add);
 
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: false);
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: false);
 
-		receivedStatuses.Should().HaveCount(1,
-			"StatusChanged must not fire when the status value has not changed");
+		snapshots.Should().HaveCount(1,
+			"PlcState must not emit a new snapshot when the status value has not changed");
 	}
 
 	[Fact]

--- a/SemiStep/Tests/S7/PlcTransactionExecutorTests.cs
+++ b/SemiStep/Tests/S7/PlcTransactionExecutorTests.cs
@@ -2,6 +2,9 @@
 
 using FluentAssertions;
 
+using FluentResults;
+
+using S7.Protocol;
 using S7.Serialization;
 using S7.Sync;
 
@@ -24,28 +27,18 @@ public sealed class PlcTransactionExecutorTests
 {
 	// Layout where CapacityOffset=0 (4 bytes) and CurrentSizeOffset=4 (4 bytes), so the
 	// 8-byte header leaves enough room for ReadUInt32BigEndian at both offsets.
-	private static DataDbLayout BuildTestIntLayout()
+	private static DataDbLayout BuildTestDataDbLayout(int dbNumber)
 	{
-		return new(DbNumber: 3, CapacityOffset: 0, CurrentSizeOffset: 4, DataStartOffset: 8);
-	}
-
-	private static DataDbLayout BuildTestFloatLayout()
-	{
-		return new(DbNumber: 4, CapacityOffset: 0, CurrentSizeOffset: 4, DataStartOffset: 8);
-	}
-
-	private static DataDbLayout BuildTestStringLayout()
-	{
-		return new(DbNumber: 5, CapacityOffset: 0, CurrentSizeOffset: 4, DataStartOffset: 8);
+		return new(DbNumber: dbNumber, CapacityOffset: 0, CurrentSizeOffset: 4, DataStartOffset: 8);
 	}
 
 	private static PlcConfiguration BuildTestConfiguration()
 	{
 		var layout = new PlcProtocolLayout(
 			ManagingDb: ManagingDbLayout.Default,
-			IntDb: BuildTestIntLayout(),
-			FloatDb: BuildTestFloatLayout(),
-			StringDb: BuildTestStringLayout(),
+			IntDb: BuildTestDataDbLayout(3),
+			FloatDb: BuildTestDataDbLayout(4),
+			StringDb: BuildTestDataDbLayout(5),
 			ExecutionDb: ExecutionDbLayout.Default);
 
 		return new PlcConfiguration(
@@ -67,7 +60,7 @@ public sealed class PlcTransactionExecutorTests
 		return new ConfigRegistry(config);
 	}
 
-	private static (PlcTransactionExecutor Executor, FakeS7Transport Transport) BuildExecutor()
+	private static (PlcTransactionExecutor executor, FakeS7Transport transport) BuildExecutor()
 	{
 		var transport = new FakeS7Transport();
 		var converter = new RecipeConverter(BuildEmptyConfigRegistry());
@@ -234,10 +227,12 @@ public sealed class PlcTransactionExecutorTests
 		transport.SetReadResponseForDb(layout.FloatDb.DbNumber, (_, count) => new byte[count]);
 		transport.SetReadResponseForDb(layout.StringDb.DbNumber, (_, count) => new byte[count]);
 
-		var act = async () => await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		var result = await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
 
-		await act.Should().ThrowAsync<PlcWriteVerificationException>(
-			"after exhausting all retry attempts a PlcWriteVerificationException must be thrown");
+		result.IsFailed.Should().BeTrue(
+			"after exhausting all retry attempts the result must be failed");
+		result.Errors.Should().ContainSingle(e =>
+			e.Message.Contains("verification failed", StringComparison.OrdinalIgnoreCase));
 	}
 
 	[Fact]
@@ -246,7 +241,7 @@ public sealed class PlcTransactionExecutorTests
 		var (executor, transport) = BuildExecutor();
 		var layout = BuildTestConfiguration().Layout;
 
-		const int MaxRetryAttempts = 3;
+		var maxRetryAttempts = PlcProtocolSettings.Default.MaxRetryAttempts;
 
 		// Mismatch: read-back claims 1 int element, but write was 0.
 		var mismatchHeader = BuildArrayHeaderBytes(1);
@@ -260,30 +255,25 @@ public sealed class PlcTransactionExecutorTests
 		transport.SetReadResponseForDb(layout.FloatDb.DbNumber, (_, count) => new byte[count]);
 		transport.SetReadResponseForDb(layout.StringDb.DbNumber, (_, count) => new byte[count]);
 
-		try
-		{
-			await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
-		}
-		catch (PlcWriteVerificationException)
-		{
-		}
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
 
 		var intHeaderReads = transport.ReadLog
 			.Count(r => r.DbNumber == layout.IntDb.DbNumber && r.Count == 8);
 
-		intHeaderReads.Should().Be(MaxRetryAttempts,
+		intHeaderReads.Should().Be(maxRetryAttempts,
 			"int header should be read once per retry attempt during verification");
 	}
 
 	[Fact]
-	public async Task WriteRecipeWithRetryAsync_NotConnected_ThrowsPlcNotConnectedException()
+	public async Task WriteRecipeWithRetryAsync_NotConnected_ReturnsFailedResultWithNotConnectedError()
 	{
 		var (executor, transport) = BuildExecutor();
 		transport.SetConnected(false);
 
-		var act = async () => await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		var result = await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
 
-		await act.Should().ThrowAsync<Exception>()
-			.Where(ex => ex.GetType().Name == "PlcNotConnectedException");
+		result.IsFailed.Should().BeTrue("writing to a disconnected PLC must return a failed result");
+		result.HasError<NotConnectedError>().Should().BeTrue(
+			"the failure reason must be a NotConnectedError");
 	}
 }

--- a/SemiStep/Tests/S7/S7ServiceTests.cs
+++ b/SemiStep/Tests/S7/S7ServiceTests.cs
@@ -99,7 +99,7 @@ public sealed class S7ServiceTests
 
 		await service.ConnectAsync(PlcConnectionSettings.Default);
 
-		// Transport now reports IsConnected = false, causing PlcNotConnectedException on the next poll.
+		// Transport now reports IsConnected = false, causing NotConnectedError on the next poll.
 		driver.SetConnected(false);
 
 		await Task.Delay(200);

--- a/SemiStep/Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/Tests/UI/Helpers/UIFixture.cs
@@ -32,8 +32,7 @@ public sealed class UIFixture : IAsyncLifetime
 		MessagePanel = new MessagePanelViewModel();
 		QueryService = new RecipeQueryService(Facade, ConfigRegistry);
 		var appConfiguration = services.GetRequiredService<AppConfiguration>();
-		var syncService = new StubPlcSyncService();
-		Coordinator = new RecipeMutationCoordinator(Facade, appConfiguration, QueryService, MessagePanel, syncService);
+		Coordinator = new RecipeMutationCoordinator(Facade, appConfiguration, QueryService, MessagePanel);
 		Coordinator.Initialize();
 		Grid = new RecipeGridViewModel(Coordinator, ConfigRegistry, MessagePanel);
 		Grid.Initialize();

--- a/SemiStep/Tests/UI/MessagePanelViewModelTests.cs
+++ b/SemiStep/Tests/UI/MessagePanelViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using Avalonia.Threading;
+
+using FluentAssertions;
 
 using FluentResults;
 
@@ -21,6 +23,7 @@ public sealed class MessagePanelViewModelTests
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("msg", "src");
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ErrorCount.Should().Be(1);
 	}
@@ -31,6 +34,7 @@ public sealed class MessagePanelViewModelTests
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("test error", "src");
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().ContainSingle(e => e.IsError);
 	}
@@ -41,6 +45,7 @@ public sealed class MessagePanelViewModelTests
 		var panel = new MessagePanelViewModel();
 
 		panel.AddInfo("msg", "src");
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ErrorCount.Should().Be(0);
 		panel.WarningCount.Should().Be(0);
@@ -52,6 +57,7 @@ public sealed class MessagePanelViewModelTests
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("msg", "src");
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.HasErrors.Should().BeTrue();
 	}
@@ -76,7 +82,9 @@ public sealed class MessagePanelViewModelTests
 	public void ErrorCountText_Singular_WhenOneError()
 	{
 		var panel = new MessagePanelViewModel();
+
 		panel.AddError("msg", "src");
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ErrorCountText.Should().Be("1 Error");
 	}
@@ -85,8 +93,11 @@ public sealed class MessagePanelViewModelTests
 	public void ErrorCountText_Plural_WhenTwoErrors()
 	{
 		var panel = new MessagePanelViewModel();
+
 		panel.AddError("msg1", "src");
+		Dispatcher.UIThread.RunJobs(null);
 		panel.AddError("msg2", "src");
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ErrorCountText.Should().Be("2 Errors");
 	}
@@ -95,7 +106,9 @@ public sealed class MessagePanelViewModelTests
 	public void WarningCountText_Singular_WhenOneWarning()
 	{
 		var panel = new MessagePanelViewModel();
-		panel.RefreshReasons(new List<IReason> { new Warning("msg") });
+
+		panel.RefreshReasons([new Warning("msg")]);
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.WarningCountText.Should().Be("1 Warning");
 	}
@@ -104,8 +117,11 @@ public sealed class MessagePanelViewModelTests
 	public void StatusErrorSummary_BothErrorsAndWarnings()
 	{
 		var panel = new MessagePanelViewModel();
+
 		panel.AddError("e", "src");
-		panel.RefreshReasons(new List<IReason> { new Warning("w") });
+		Dispatcher.UIThread.RunJobs(null);
+		panel.RefreshReasons([new Warning("w")]);
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.StatusErrorSummary.Should().Be("1 Error, 1 Warning");
 	}
@@ -114,8 +130,11 @@ public sealed class MessagePanelViewModelTests
 	public void StatusErrorSummary_OnlyErrors()
 	{
 		var panel = new MessagePanelViewModel();
+
 		panel.AddError("e1", "src");
+		Dispatcher.UIThread.RunJobs(null);
 		panel.AddError("e2", "src");
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.StatusErrorSummary.Should().Be("2 Errors");
 	}
@@ -124,7 +143,9 @@ public sealed class MessagePanelViewModelTests
 	public void StatusErrorSummary_OnlyWarnings()
 	{
 		var panel = new MessagePanelViewModel();
-		panel.RefreshReasons(new List<IReason> { new Warning("w") });
+
+		panel.RefreshReasons([new Warning("w")]);
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.StatusErrorSummary.Should().Be("1 Warning");
 	}
@@ -141,10 +162,13 @@ public sealed class MessagePanelViewModelTests
 	public void Clear_ResetsCountsAndEntries()
 	{
 		var panel = new MessagePanelViewModel();
-		panel.AddError("e", "src");
-		panel.RefreshReasons(new List<IReason> { new Warning("w") });
 
+		panel.AddError("e", "src");
+		Dispatcher.UIThread.RunJobs(null);
+		panel.RefreshReasons([new Warning("w")]);
+		Dispatcher.UIThread.RunJobs(null);
 		panel.Clear();
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ErrorCount.Should().Be(0);
 		panel.WarningCount.Should().Be(0);
@@ -155,9 +179,11 @@ public sealed class MessagePanelViewModelTests
 	public void Clear_SetsHasErrorsFalse()
 	{
 		var panel = new MessagePanelViewModel();
-		panel.AddError("e", "src");
 
+		panel.AddError("e", "src");
+		Dispatcher.UIThread.RunJobs(null);
 		panel.Clear();
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.HasErrors.Should().BeFalse();
 	}
@@ -168,6 +194,7 @@ public sealed class MessagePanelViewModelTests
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("e", "src");
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.HasEntries.Should().BeTrue();
 	}
@@ -184,8 +211,12 @@ public sealed class MessagePanelViewModelTests
 	public void ShowPanel_True_WhenHasEntriesAndVisible()
 	{
 		var panel = new MessagePanelViewModel();
+		panel.IsVisible = false;
+
 		panel.AddError("e", "src");
+		Dispatcher.UIThread.RunJobs(null);
 		panel.IsVisible = true;
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ShowPanel.Should().BeTrue();
 	}
@@ -194,8 +225,11 @@ public sealed class MessagePanelViewModelTests
 	public void ShowPanel_False_WhenNotVisible()
 	{
 		var panel = new MessagePanelViewModel();
+
 		panel.AddError("e", "src");
+		Dispatcher.UIThread.RunJobs(null);
 		panel.IsVisible = false;
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ShowPanel.Should().BeFalse();
 	}
@@ -204,9 +238,10 @@ public sealed class MessagePanelViewModelTests
 	public void RefreshReasons_AddsStructuralErrors()
 	{
 		var panel = new MessagePanelViewModel();
-		var reasons = new List<IReason> { new Error("some error") };
+		List<IReason> reasons = [new Error("some error")];
 
 		panel.RefreshReasons(reasons);
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().ContainSingle(e => e.IsStructural && e.IsError);
 	}
@@ -215,9 +250,10 @@ public sealed class MessagePanelViewModelTests
 	public void RefreshReasons_AddsStructuralWarnings()
 	{
 		var panel = new MessagePanelViewModel();
-		var reasons = new List<IReason> { new Warning("some warning") };
+		List<IReason> reasons = [new Warning("some warning")];
 
 		panel.RefreshReasons(reasons);
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().ContainSingle(e => e.IsStructural && e.IsWarning);
 	}
@@ -226,9 +262,11 @@ public sealed class MessagePanelViewModelTests
 	public void RefreshReasons_RemovesOldStructuralEntries_BeforeAddingNew()
 	{
 		var panel = new MessagePanelViewModel();
-		panel.RefreshReasons(new List<IReason> { new Error("old error") });
 
-		panel.RefreshReasons(new List<IReason>());
+		panel.RefreshReasons([new Error("old error")]);
+		Dispatcher.UIThread.RunJobs(null);
+		panel.RefreshReasons([]);
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().BeEmpty();
 	}
@@ -237,9 +275,11 @@ public sealed class MessagePanelViewModelTests
 	public void RefreshReasons_PreservesNonStructuralEntries()
 	{
 		var panel = new MessagePanelViewModel();
-		panel.AddError("non-structural", "custom source");
 
-		panel.RefreshReasons(new List<IReason>());
+		panel.AddError("non-structural", "custom source");
+		Dispatcher.UIThread.RunJobs(null);
+		panel.RefreshReasons([]);
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().ContainSingle(e => !e.IsStructural);
 	}
@@ -248,9 +288,11 @@ public sealed class MessagePanelViewModelTests
 	public void ClearCommand_RemovesNonStructuralEntries()
 	{
 		var panel = new MessagePanelViewModel();
-		panel.AddError("e", "src");
 
+		panel.AddError("e", "src");
+		Dispatcher.UIThread.RunJobs(null);
 		panel.ClearCommand.Execute().Subscribe();
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().BeEmpty();
 	}
@@ -259,9 +301,11 @@ public sealed class MessagePanelViewModelTests
 	public void ClearCommand_PreservesStructuralEntries()
 	{
 		var panel = new MessagePanelViewModel();
-		panel.RefreshReasons(new List<IReason> { new Error("structural error") });
 
+		panel.RefreshReasons([new Error("structural error")]);
+		Dispatcher.UIThread.RunJobs(null);
 		panel.ClearCommand.Execute().Subscribe();
+		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().ContainSingle(e => e.IsStructural);
 	}

--- a/SemiStep/Tests/UI/RecipeGridViewModelTests.cs
+++ b/SemiStep/Tests/UI/RecipeGridViewModelTests.cs
@@ -36,8 +36,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_panel = new MessagePanelViewModel();
 		var queryService = new RecipeQueryService(_facade, _configRegistry);
 		var appConfiguration = services.GetRequiredService<AppConfiguration>();
-		var syncService = new StubPlcSyncService();
-		_coordinator = new RecipeMutationCoordinator(_facade, appConfiguration, queryService, _panel, syncService);
+		_coordinator = new RecipeMutationCoordinator(_facade, appConfiguration, queryService, _panel);
 		_coordinator.Initialize();
 		_grid = new RecipeGridViewModel(_coordinator, _configRegistry, _panel);
 		_grid.Initialize();

--- a/SemiStep/Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
@@ -100,6 +100,33 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		}
 	}
 
+	[Fact]
+	public async Task LoadRecipeAsync_Success_WithWarnings_ShowsWarningsInPanel()
+	{
+		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
+		var tempFilePath = Path.Combine(Path.GetTempPath(), $"{TempFilePrefix}.{Guid.NewGuid():N}.csv");
+
+		try
+		{
+			// Save the default empty recipe so we have a valid CSV file with no steps.
+			await coordinator.SaveRecipeAsync(tempFilePath);
+
+			// Load it back — an empty recipe triggers a "Recipe has no steps" warning from the analyzer.
+			var result = await coordinator.LoadRecipeAsync(tempFilePath);
+			Dispatcher.UIThread.RunJobs(null);
+
+			result.IsSuccess.Should().BeTrue("loading a valid CSV should succeed even when it has warnings");
+			panel.Entries.Should().Contain(e => e.IsWarning,
+				"the message panel must show the 'Recipe has no steps' warning after loading an empty recipe");
+		}
+		finally
+		{
+			coordinator.Dispose();
+			panel.Dispose();
+			File.Delete(tempFilePath);
+		}
+	}
+
 	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel)> BuildCoordinatorWithCsvAsync()
 	{
 		var configDir = TestConfigLocator.GetConfigDirectory("WithGroups");

--- a/SemiStep/Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
@@ -1,4 +1,6 @@
-﻿using Config.Facade;
+﻿using Avalonia.Threading;
+
+using Config.Facade;
 
 using Core;
 
@@ -37,8 +39,10 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		try
 		{
 			panel.AddError("stale error", "Test");
+			Dispatcher.UIThread.RunJobs(null);
 
 			await coordinator.LoadRecipeAsync(tempFilePath);
+			Dispatcher.UIThread.RunJobs(null);
 
 			panel.Entries.Should().BeEmpty();
 		}
@@ -58,8 +62,10 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		try
 		{
 			panel.AddError("pre-existing error", "Test");
+			Dispatcher.UIThread.RunJobs(null);
 
 			await coordinator.LoadRecipeAsync("nonexistent/path/recipe.csv");
+			Dispatcher.UIThread.RunJobs(null);
 
 			panel.Entries.Should().ContainSingle(e => e.Source == "Test");
 			panel.ErrorCount.Should().BeGreaterThan(0);

--- a/SemiStep/Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
@@ -31,6 +31,7 @@ namespace Tests.UI;
 [Trait("Category", "Integration")]
 public sealed class RecipeMutationCoordinatorLoadRecipeTests
 {
+	private const string TempFilePrefix = "SemiStep.CoordinatorTest";
 	[Fact]
 	public async Task LoadRecipeAsync_Success_ClearsMessagePanelBeforeAddingNewReasons()
 	{
@@ -38,7 +39,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 
 		try
 		{
-			panel.AddError("stale error", "Test");
+			await coordinator.LoadRecipeAsync("nonexistent/path/recipe.csv");
 			Dispatcher.UIThread.RunJobs(null);
 
 			await coordinator.LoadRecipeAsync(tempFilePath);
@@ -68,6 +69,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 			Dispatcher.UIThread.RunJobs(null);
 
 			panel.Entries.Should().ContainSingle(e => e.Source == "Test");
+			panel.Entries.Should().Contain(e => e.IsStructural && e.IsError);
 			panel.ErrorCount.Should().BeGreaterThan(0);
 		}
 		finally
@@ -120,19 +122,22 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		var panel = new MessagePanelViewModel();
 		var queryService = new RecipeQueryService(facade, configRegistry);
 		var appConfiguration = services.GetRequiredService<AppConfiguration>();
-		var syncService = services.GetRequiredService<IPlcSyncService>();
-		var coordinator = new RecipeMutationCoordinator(facade, appConfiguration, queryService, panel, syncService);
+		var coordinator = new RecipeMutationCoordinator(facade, appConfiguration, queryService, panel);
+		coordinator.Initialize();
 
 		return (coordinator, panel);
 	}
 
-	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel, string TempFilePath)> BuildCoordinatorWithCsvAndSavedRecipeAsync()
+	private static async Task<(
+		RecipeMutationCoordinator Coordinator,
+		MessagePanelViewModel Panel,
+		string TempFilePath)> BuildCoordinatorWithCsvAndSavedRecipeAsync()
 	{
 		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
 
 		coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var tempFilePath = Path.Combine(Path.GetTempPath(), $"SemiStep.CoordinatorTest.{Guid.NewGuid():N}.csv");
+		var tempFilePath = Path.Combine(Path.GetTempPath(), $"{TempFilePrefix}.{Guid.NewGuid():N}.csv");
 		await coordinator.SaveRecipeAsync(tempFilePath);
 
 		return (coordinator, panel, tempFilePath);

--- a/SemiStep/Tests/UI/RecipeMutationCoordinatorTests.cs
+++ b/SemiStep/Tests/UI/RecipeMutationCoordinatorTests.cs
@@ -1,4 +1,6 @@
-﻿using Config;
+﻿using Avalonia.Threading;
+
+using Config;
 
 using Domain;
 using Domain.Facade;
@@ -232,8 +234,10 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	{
 		_facade.SetNewRecipe();
 		_panel.AddError("some error", "test");
+		Dispatcher.UIThread.RunJobs(null);
 
 		_coordinator.NewRecipe();
+		Dispatcher.UIThread.RunJobs(null);
 
 		_panel.Entries.Should().BeEmpty();
 	}
@@ -269,6 +273,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		_facade.SetNewRecipe();
 
 		_coordinator.AppendStep(9999);
+		Dispatcher.UIThread.RunJobs(null);
 
 		_panel.ErrorCount.Should().BeGreaterThan(0);
 	}

--- a/SemiStep/Tests/UI/RecipeMutationCoordinatorTests.cs
+++ b/SemiStep/Tests/UI/RecipeMutationCoordinatorTests.cs
@@ -38,8 +38,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		_panel = new MessagePanelViewModel();
 		var queryService = new RecipeQueryService(_facade, configRegistry);
 		var appConfiguration = services.GetRequiredService<AppConfiguration>();
-		var syncService = new StubPlcSyncService();
-		_coordinator = new RecipeMutationCoordinator(_facade, appConfiguration, queryService, _panel, syncService);
+		_coordinator = new RecipeMutationCoordinator(_facade, appConfiguration, queryService, _panel);
 		_coordinator.Initialize();
 	}
 
@@ -233,7 +232,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	public void NewRecipe_ClearsMessagePanel()
 	{
 		_facade.SetNewRecipe();
-		_panel.AddError("some error", "test");
+		_coordinator.AppendStep(9999);
 		Dispatcher.UIThread.RunJobs(null);
 
 		_coordinator.NewRecipe();

--- a/SemiStep/Tests/YamlConfigs/Standalone/UnknownYamlFields/connection/connection.yaml
+++ b/SemiStep/Tests/YamlConfigs/Standalone/UnknownYamlFields/connection/connection.yaml
@@ -10,17 +10,7 @@ max_retries_attempts: 3
 polling_interval_ms: 100
 writing_timeout_ms: 5000
 commit_timeout_ms: 5000
-
-header_db_number: 1
-magic_number_offset: 0
-word_order_offset: 2
-protocol_version_offset: 4
-managing_db_number_offset: 6
-int_db_number_offset: 8
-float_db_number_offset: 10
-string_db_number_offset: 12
-execution_db_number_offset: 14
-header_db_total_size: 16
+keep_alive_interval_ms: 5000
 
 managing_db_number: 2
 committed_offset: 0
@@ -29,18 +19,18 @@ managing_db_total_size: 6
 
 int_db_number: 3
 int_db_total_capacity_offset: 0
-int_db_current_size_offset: 2
-int_db_data_offset: 4
+int_db_current_size_offset: 4
+int_db_data_offset: 8
 
 float_db_number: 4
 float_db_total_capacity_offset: 0
-float_db_current_size_offset: 2
-float_db_data_offset: 4
+float_db_current_size_offset: 4
+float_db_data_offset: 8
 
 string_db_number: 5
 string_db_total_capacity_offset: 0
-string_db_current_size_offset: 2
-string_db_data_offset: 4
+string_db_current_size_offset: 4
+string_db_data_offset: 8
 
 execution_db_number: 6
 recipe_active_offset: 0

--- a/SemiStep/Tests/YamlConfigs/Standard/connection/connection.yaml
+++ b/SemiStep/Tests/YamlConfigs/Standard/connection/connection.yaml
@@ -13,21 +13,6 @@ writing_timeout_ms: 5000
 commit_timeout_ms: 5000
 keep_alive_interval_ms: 5000
 
-# -- Header DB --
-header_db_number: 1
-magic_number_offset: 0
-word_order_offset: 2
-protocol_version_offset: 4
-
-managing_db_number_offset: 6
-
-int_db_number_offset: 8
-float_db_number_offset: 10
-string_db_number_offset: 12
-execution_db_number_offset: 14
-
-header_db_total_size: 16
-
 # -- Managing DB --
 managing_db_number: 2
 committed_offset: 0
@@ -37,29 +22,27 @@ managing_db_total_size: 6
 # -- Int DB --
 int_db_number: 3
 int_db_total_capacity_offset: 0
-int_db_current_size_offset: 2
-int_db_data_offset: 4
+int_db_current_size_offset: 4
+int_db_data_offset: 8
 
 # -- Float DB --
 float_db_number: 4
 float_db_total_capacity_offset: 0
-float_db_current_size_offset: 2
-float_db_data_offset: 4
+float_db_current_size_offset: 4
+float_db_data_offset: 8
 
 # -- String DB --
 string_db_number: 5
 string_db_total_capacity_offset: 0
-string_db_current_size_offset: 2
-string_db_data_offset: 4
+string_db_current_size_offset: 4
+string_db_data_offset: 8
 
 # -- Execution DB --
 execution_db_number: 6
 recipe_active_offset: 0
 actual_line_offset: 2
 step_current_time_offset: 6
-
 for_loop_count1_offset: 10
 for_loop_count2_offset: 14
 for_loop_count3_offset: 18
-
 execution_db_total_size: 22

--- a/SemiStep/Tests/YamlConfigs/WithGroups/connection/connection.yaml
+++ b/SemiStep/Tests/YamlConfigs/WithGroups/connection/connection.yaml
@@ -11,21 +11,7 @@ max_retries_attempts: 3
 polling_interval_ms: 100
 writing_timeout_ms: 5000
 commit_timeout_ms: 5000
-
-# -- Header DB --
-header_db_number: 1
-magic_number_offset: 0
-word_order_offset: 2
-protocol_version_offset: 4
-
-managing_db_number_offset: 6
-
-int_db_number_offset: 8
-float_db_number_offset: 10
-string_db_number_offset: 12
-execution_db_number_offset: 14
-
-header_db_total_size: 16
+keep_alive_interval_ms: 5000
 
 # -- Managing DB --
 managing_db_number: 2
@@ -36,29 +22,27 @@ managing_db_total_size: 6
 # -- Int DB --
 int_db_number: 3
 int_db_total_capacity_offset: 0
-int_db_current_size_offset: 2
-int_db_data_offset: 4
+int_db_current_size_offset: 4
+int_db_data_offset: 8
 
 # -- Float DB --
 float_db_number: 4
 float_db_total_capacity_offset: 0
-float_db_current_size_offset: 2
-float_db_data_offset: 4
+float_db_current_size_offset: 4
+float_db_data_offset: 8
 
 # -- String DB --
 string_db_number: 5
 string_db_total_capacity_offset: 0
-string_db_current_size_offset: 2
-string_db_data_offset: 4
+string_db_current_size_offset: 4
+string_db_data_offset: 8
 
 # -- Execution DB --
 execution_db_number: 6
 recipe_active_offset: 0
 actual_line_offset: 2
 step_current_time_offset: 6
-
 for_loop_count1_offset: 10
 for_loop_count2_offset: 14
 for_loop_count3_offset: 18
-
 execution_db_total_size: 22

--- a/SemiStep/TypesShared/Domain/IPlcSyncService.cs
+++ b/SemiStep/TypesShared/Domain/IPlcSyncService.cs
@@ -1,4 +1,6 @@
-﻿using TypesShared.Core;
+﻿using FluentResults;
+
+using TypesShared.Core;
 using TypesShared.Plc;
 
 namespace TypesShared.Domain;
@@ -9,13 +11,13 @@ public interface IPlcSyncService
 
 	void Reset();
 
-	PlcSyncStatus Status { get; }
+	void SetSyncEnabled(bool value);
 
-	string? LastError { get; }
+	void UpdateConnectionState(PlcConnectionState state);
+
+	PlcSyncStatus Status { get; }
 
 	DateTimeOffset? LastSyncTime { get; }
 
-	event Action<PlcSyncStatus>? StatusChanged;
-
-	event Action<string?>? ErrorChanged;
+	IObservable<Result<PlcSessionSnapshot>> PlcState { get; }
 }

--- a/SemiStep/TypesShared/Plc/Memory/DataDbLayout.cs
+++ b/SemiStep/TypesShared/Plc/Memory/DataDbLayout.cs
@@ -9,18 +9,18 @@ public sealed record DataDbLayout(
 	public static DataDbLayout DefaultInt => new(
 		DbNumber: 3,
 		CapacityOffset: 0,
-		CurrentSizeOffset: 2,
-		DataStartOffset: 4);
+		CurrentSizeOffset: 4,
+		DataStartOffset: 8);
 
 	public static DataDbLayout DefaultFloat => new(
 		DbNumber: 4,
 		CapacityOffset: 0,
-		CurrentSizeOffset: 2,
-		DataStartOffset: 4);
+		CurrentSizeOffset: 4,
+		DataStartOffset: 8);
 
 	public static DataDbLayout DefaultString => new(
 		DbNumber: 5,
 		CapacityOffset: 0,
-		CurrentSizeOffset: 2,
-		DataStartOffset: 4);
+		CurrentSizeOffset: 4,
+		DataStartOffset: 8);
 }

--- a/SemiStep/TypesShared/Plc/PlcSessionSnapshot.cs
+++ b/SemiStep/TypesShared/Plc/PlcSessionSnapshot.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace TypesShared.Plc;
+
+public sealed record PlcSessionSnapshot(PlcConnectionState ConnectionState, PlcSyncStatus SyncStatus, bool IsSyncEnabled)
+{
+	public static readonly Result<PlcSessionSnapshot> InitialState = Result.Ok(
+		new PlcSessionSnapshot(PlcConnectionState.Disconnected, PlcSyncStatus.Disconnected, false));
+}

--- a/SemiStep/UI/App.axaml.cs
+++ b/SemiStep/UI/App.axaml.cs
@@ -3,8 +3,11 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
+using Domain.Facade;
+
 using Microsoft.Extensions.DependencyInjection;
 
+using UI.Coordinator;
 using UI.Dialogs;
 using UI.MainWindow;
 
@@ -59,12 +62,27 @@ public class App : Application
 	{
 		ArgumentNullException.ThrowIfNull(serviceProvider);
 		BuildAvaloniaApp()
+			.AfterSetup(_ =>
+				// UseReactiveUI() above has already registered AvaloniaScheduler as
+				// RxApp.MainThreadScheduler. Initialize services here — after the
+				// scheduler is set — so that ReactiveCommand singletons capture the
+				// correct scheduler at construction time.
+				InitializeServices(serviceProvider))
 			.AfterSetup(builder =>
 			{
 				var app = (App)builder.Instance!;
 				app._serviceProvider = serviceProvider;
 			})
 			.StartWithClassicDesktopLifetime([]);
+	}
+
+	private static void InitializeServices(IServiceProvider provider)
+	{
+		var domainFacade = provider.GetRequiredService<DomainFacade>();
+		domainFacade.Initialize();
+
+		var coordinator = provider.GetRequiredService<RecipeMutationCoordinator>();
+		coordinator.Initialize();
 	}
 
 	public static void RunErrorWindow(IReadOnlyList<string> errors)

--- a/SemiStep/UI/App.axaml.cs
+++ b/SemiStep/UI/App.axaml.cs
@@ -5,8 +5,6 @@ using Avalonia.ReactiveUI;
 
 using Microsoft.Extensions.DependencyInjection;
 
-using ReactiveUI;
-
 using UI.Dialogs;
 using UI.MainWindow;
 
@@ -60,7 +58,6 @@ public class App : Application
 	public static void Run(IServiceProvider serviceProvider)
 	{
 		ArgumentNullException.ThrowIfNull(serviceProvider);
-		RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
 		BuildAvaloniaApp()
 			.AfterSetup(builder =>
 			{

--- a/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
+++ b/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
@@ -1,5 +1,8 @@
-﻿using System.Reactive;
+﻿using System.Linq;
+using System.Reactive;
 using System.Reactive.Subjects;
+
+using Avalonia.Threading;
 
 using Domain.Facade;
 
@@ -24,9 +27,9 @@ public sealed class RecipeMutationCoordinator(
 	private readonly Subject<MutationSignal> _stateChanged = new();
 	private readonly Subject<(Recipe Local, Recipe Plc)> _plcRecipeConflictDetected = new();
 	private readonly Subject<Unit> _connectionStateChanged = new();
-	private Action? _connectionStateChangedRelay;
-	private Action<PlcSyncStatus>? _statusChangedRelay;
-	private Action<string?>? _errorChangedRelay;
+	private readonly Lock _subjectLock = new();
+	private Action<string?>? _syncErrorChangedRelay;
+	private bool _initialized;
 
 	public IObservable<MutationSignal> StateChanged => _stateChanged;
 	public IObservable<(Recipe Local, Recipe Plc)> PlcRecipeConflictDetected => _plcRecipeConflictDetected;
@@ -51,16 +54,19 @@ public sealed class RecipeMutationCoordinator(
 
 	public RecipeMutationCoordinator Initialize()
 	{
+		if (_initialized)
+		{
+			throw new InvalidOperationException("RecipeMutationCoordinator has already been initialized.");
+		}
+
+		_initialized = true;
+
 		domainFacade.PlcRecipeConflictDetected += OnPlcRecipeConflictDetected;
+		domainFacade.ConnectionStateChanged += OnConnectionStateChanged;
+		syncService.StatusChanged += OnSyncStatusChanged;
 
-		_connectionStateChangedRelay = () => _connectionStateChanged.OnNext(Unit.Default);
-		domainFacade.ConnectionStateChanged += _connectionStateChangedRelay;
-
-		_statusChangedRelay = _ => _connectionStateChanged.OnNext(Unit.Default);
-		syncService.StatusChanged += _statusChangedRelay;
-
-		_errorChangedRelay = _ => _connectionStateChanged.OnNext(Unit.Default);
-		syncService.ErrorChanged += _errorChangedRelay;
+		_syncErrorChangedRelay = _ => NotifyConnectionStateChanged();
+		syncService.ErrorChanged += _syncErrorChangedRelay;
 
 		return this;
 	}
@@ -68,25 +74,20 @@ public sealed class RecipeMutationCoordinator(
 	public void Dispose()
 	{
 		domainFacade.PlcRecipeConflictDetected -= OnPlcRecipeConflictDetected;
+		domainFacade.ConnectionStateChanged -= OnConnectionStateChanged;
+		syncService.StatusChanged -= OnSyncStatusChanged;
 
-		if (_connectionStateChangedRelay is not null)
+		if (_syncErrorChangedRelay is not null)
 		{
-			domainFacade.ConnectionStateChanged -= _connectionStateChangedRelay;
-		}
-
-		if (_statusChangedRelay is not null)
-		{
-			syncService.StatusChanged -= _statusChangedRelay;
-		}
-
-		if (_errorChangedRelay is not null)
-		{
-			syncService.ErrorChanged -= _errorChangedRelay;
+			syncService.ErrorChanged -= _syncErrorChangedRelay;
 		}
 
 		_stateChanged.Dispose();
 		_plcRecipeConflictDetected.Dispose();
-		_connectionStateChanged.Dispose();
+		lock (_subjectLock)
+		{
+			_connectionStateChanged.Dispose();
+		}
 	}
 
 	public int? ConsumeSuggestedSelection()
@@ -99,7 +100,15 @@ public sealed class RecipeMutationCoordinator(
 
 	public async Task<Result> EnableSync()
 	{
-		return await domainFacade.EnableSync(appConfiguration.PlcConfiguration);
+		var result = await domainFacade.EnableSync(appConfiguration.PlcConfiguration);
+
+		if (result.IsFailed)
+		{
+			var errorMessage = string.Join("; ", result.Errors.Select(e => e.Message));
+			Dispatcher.UIThread.Post(() => messagePanel.AddError($"Failed to enable sync: {errorMessage}", "PLC"));
+		}
+
+		return result;
 	}
 
 	public async Task DisableSync()
@@ -300,13 +309,62 @@ public sealed class RecipeMutationCoordinator(
 		_stateChanged.OnNext(new MutationSignal.MetadataChanged());
 	}
 
+	private void OnConnectionStateChanged(PlcConnectionState state)
+	{
+		NotifyConnectionStateChanged();
+
+		// Disconnection events are suppressed when sync is not user-enabled, as they are
+		// expected during normal startup and do not represent a loss of user-initiated sync.
+		Dispatcher.UIThread.Post(() =>
+		{
+			var ipAddress = appConfiguration.PlcConfiguration.Connection.IpAddress;
+
+			switch (state)
+			{
+				case PlcConnectionState.Connected:
+					messagePanel.AddInfo($"Connected to PLC ({ipAddress})", "PLC");
+					break;
+				case PlcConnectionState.Disconnected when queryService.IsSyncEnabled:
+					messagePanel.AddError("PLC connection lost", "PLC");
+					break;
+			}
+		});
+	}
+
+	private void OnSyncStatusChanged(PlcSyncStatus status)
+	{
+		NotifyConnectionStateChanged();
+
+		var lastError = syncService.LastError;
+		Dispatcher.UIThread.Post(() =>
+		{
+			switch (status)
+			{
+				case PlcSyncStatus.Synced:
+					messagePanel.AddInfo("Recipe synced to PLC", "PLC");
+					break;
+				case PlcSyncStatus.Failed:
+					messagePanel.AddError(lastError ?? "Sync failed", "PLC");
+					break;
+			}
+		});
+	}
+
 	private void OnPlcRecipeConflictDetected(Recipe local, Recipe plc)
 	{
-		_plcRecipeConflictDetected.OnNext((local, plc));
+		Dispatcher.UIThread.Post(() => _plcRecipeConflictDetected.OnNext((local, plc)));
 	}
 
 	private void RefreshMessagePanel(Result mutationResult)
 	{
 		messagePanel.RefreshReasons(mutationResult.Reasons);
+	}
+
+	private void NotifyConnectionStateChanged()
+	{
+		lock (_subjectLock)
+		{
+			_connectionStateChanged.OnNext(Unit.Default);
+		}
 	}
 }

--- a/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
+++ b/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
@@ -1,12 +1,12 @@
 ﻿using System.Linq;
-using System.Reactive;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
-
-using Avalonia.Threading;
 
 using Domain.Facade;
 
 using FluentResults;
+
+using ReactiveUI;
 
 using TypesShared.Config;
 using TypesShared.Core;
@@ -21,18 +21,20 @@ public sealed class RecipeMutationCoordinator(
 	DomainFacade domainFacade,
 	AppConfiguration appConfiguration,
 	RecipeQueryService queryService,
-	MessagePanelViewModel messagePanel,
-	IPlcSyncService syncService) : IDisposable
+	MessagePanelViewModel messagePanel) : IDisposable
 {
 	private readonly Subject<MutationSignal> _stateChanged = new();
 	private readonly Subject<(Recipe Local, Recipe Plc)> _plcRecipeConflictDetected = new();
-	private readonly Subject<Unit> _connectionStateChanged = new();
-	private Action<string?>? _syncErrorChangedRelay;
+	private readonly Subject<Result<PlcSessionSnapshot>> _plcStateChanged = new();
+	private Result _lastRecipeResult = Result.Ok();
+	private Result<PlcSessionSnapshot> _lastPlcState = PlcSessionSnapshot.InitialState;
+	private IDisposable? _plcStateSubscription;
 	private bool _initialized;
+	private bool _disposed;
 
 	public IObservable<MutationSignal> StateChanged => _stateChanged;
 	public IObservable<(Recipe Local, Recipe Plc)> PlcRecipeConflictDetected => _plcRecipeConflictDetected;
-	public IObservable<Unit> ConnectionStateChanged => _connectionStateChanged;
+	public IObservable<Result<PlcSessionSnapshot>> PlcStateChanged => _plcStateChanged;
 
 	public int? SuggestedSelection { get; private set; }
 
@@ -61,29 +63,30 @@ public sealed class RecipeMutationCoordinator(
 		_initialized = true;
 
 		domainFacade.PlcRecipeConflictDetected += OnPlcRecipeConflictDetected;
-		domainFacade.ConnectionStateChanged += OnConnectionStateChanged;
-		syncService.StatusChanged += OnSyncStatusChanged;
 
-		_syncErrorChangedRelay = _ => Dispatcher.UIThread.Post(NotifyConnectionStateChanged);
-		syncService.ErrorChanged += _syncErrorChangedRelay;
+		_plcStateSubscription = domainFacade.PlcState
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Subscribe(OnPlcStateChanged);
 
 		return this;
 	}
 
 	public void Dispose()
 	{
-		domainFacade.PlcRecipeConflictDetected -= OnPlcRecipeConflictDetected;
-		domainFacade.ConnectionStateChanged -= OnConnectionStateChanged;
-		syncService.StatusChanged -= OnSyncStatusChanged;
-
-		if (_syncErrorChangedRelay is not null)
+		if (_disposed)
 		{
-			syncService.ErrorChanged -= _syncErrorChangedRelay;
+			return;
 		}
+
+		_disposed = true;
+
+		domainFacade.PlcRecipeConflictDetected -= OnPlcRecipeConflictDetected;
+
+		_plcStateSubscription?.Dispose();
 
 		_stateChanged.Dispose();
 		_plcRecipeConflictDetected.Dispose();
-		_connectionStateChanged.Dispose();
+		_plcStateChanged.Dispose();
 	}
 
 	public int? ConsumeSuggestedSelection()
@@ -94,17 +97,9 @@ public sealed class RecipeMutationCoordinator(
 		return value;
 	}
 
-	public async Task<Result> EnableSync()
+	public Task<Result> EnableSync()
 	{
-		var result = await domainFacade.EnableSync(appConfiguration.PlcConfiguration);
-
-		if (result.IsFailed)
-		{
-			var errorMessage = string.Join("; ", result.Errors.Select(e => e.Message));
-			messagePanel.AddError($"Failed to enable sync: {errorMessage}", "PLC");
-		}
-
-		return result;
+		return domainFacade.EnableSync(appConfiguration.PlcConfiguration);
 	}
 
 	public async Task DisableSync()
@@ -116,12 +111,14 @@ public sealed class RecipeMutationCoordinator(
 	{
 		var result = await domainFacade.LoadRecipeFromPlcAsync();
 
-		if (!result.IsFailed)
+		_lastRecipeResult = Result.Ok();
+
+		if (result.IsFailed)
 		{
-			messagePanel.Clear();
+			_lastRecipeResult = result;
 		}
 
-		RefreshMessagePanel(result);
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -142,7 +139,8 @@ public sealed class RecipeMutationCoordinator(
 	public void AppendStep(int actionId)
 	{
 		var result = domainFacade.AppendStep(actionId);
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -156,7 +154,8 @@ public sealed class RecipeMutationCoordinator(
 	public void InsertStep(int index, int actionId)
 	{
 		var result = domainFacade.InsertStep(index, actionId);
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -170,7 +169,8 @@ public sealed class RecipeMutationCoordinator(
 	public void RemoveStep(int index)
 	{
 		var result = domainFacade.RemoveStep(index);
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -186,7 +186,8 @@ public sealed class RecipeMutationCoordinator(
 	public void RemoveSteps(IReadOnlyList<int> indices)
 	{
 		var result = domainFacade.RemoveSteps(indices);
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -202,7 +203,8 @@ public sealed class RecipeMutationCoordinator(
 	public void InsertSteps(int startIndex, IReadOnlyList<Step> steps)
 	{
 		var result = domainFacade.InsertSteps(startIndex, steps);
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -216,7 +218,8 @@ public sealed class RecipeMutationCoordinator(
 	public void ChangeStepAction(int stepIndex, int newActionId)
 	{
 		var result = domainFacade.ChangeStepAction(stepIndex, newActionId);
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -230,7 +233,8 @@ public sealed class RecipeMutationCoordinator(
 	public void UpdateStepProperty(int stepIndex, string columnKey, string value)
 	{
 		var result = domainFacade.UpdateStepProperty(stepIndex, columnKey, value);
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -243,7 +247,8 @@ public sealed class RecipeMutationCoordinator(
 	public void Undo()
 	{
 		var result = domainFacade.Undo();
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -257,7 +262,8 @@ public sealed class RecipeMutationCoordinator(
 	public void Redo()
 	{
 		var result = domainFacade.Redo();
-		RefreshMessagePanel(result);
+		_lastRecipeResult = result;
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -271,7 +277,8 @@ public sealed class RecipeMutationCoordinator(
 	public void NewRecipe()
 	{
 		domainFacade.SetNewRecipe();
-		messagePanel.Clear();
+		_lastRecipeResult = Result.Ok();
+		RebuildMessagePanel();
 		SuggestedSelection = null;
 		_stateChanged.OnNext(new MutationSignal.RecipeReplaced());
 	}
@@ -280,12 +287,14 @@ public sealed class RecipeMutationCoordinator(
 	{
 		var result = await domainFacade.LoadRecipeAsync(filePath);
 
-		if (!result.IsFailed)
+		_lastRecipeResult = Result.Ok();
+
+		if (result.IsFailed)
 		{
-			messagePanel.Clear();
+			_lastRecipeResult = result;
 		}
 
-		RefreshMessagePanel(result);
+		RebuildMessagePanel();
 
 		if (result.IsFailed)
 		{
@@ -305,62 +314,21 @@ public sealed class RecipeMutationCoordinator(
 		_stateChanged.OnNext(new MutationSignal.MetadataChanged());
 	}
 
-	private void OnConnectionStateChanged(PlcConnectionState state)
+	private void OnPlcStateChanged(Result<PlcSessionSnapshot> result)
 	{
-		var ipAddress = appConfiguration.PlcConfiguration.Connection.IpAddress;
-		var isSyncEnabled = queryService.IsSyncEnabled;
-
-		Dispatcher.UIThread.Post(() =>
-		{
-			NotifyConnectionStateChanged();
-
-			// Disconnection events are suppressed when sync is not user-enabled, as they
-			// are expected during normal startup and do not represent a loss of
-			// user-initiated sync.
-			switch (state)
-			{
-				case PlcConnectionState.Connected:
-					messagePanel.AddInfo($"Connected to PLC ({ipAddress})", "PLC");
-					break;
-				case PlcConnectionState.Disconnected when isSyncEnabled:
-					messagePanel.AddError("PLC connection lost", "PLC");
-					break;
-			}
-		});
-	}
-
-	private void OnSyncStatusChanged(PlcSyncStatus status)
-	{
-		var lastError = syncService.LastError;
-
-		Dispatcher.UIThread.Post(() =>
-		{
-			NotifyConnectionStateChanged();
-
-			switch (status)
-			{
-				case PlcSyncStatus.Synced:
-					messagePanel.AddInfo("Recipe synced to PLC", "PLC");
-					break;
-				case PlcSyncStatus.Failed:
-					messagePanel.AddError(lastError ?? "Sync failed", "PLC");
-					break;
-			}
-		});
+		_lastPlcState = result;
+		_plcStateChanged.OnNext(result);
+		RebuildMessagePanel();
 	}
 
 	private void OnPlcRecipeConflictDetected(Recipe local, Recipe plc)
 	{
-		Dispatcher.UIThread.Post(() => _plcRecipeConflictDetected.OnNext((local, plc)));
+		Avalonia.Threading.Dispatcher.UIThread.Post(() => _plcRecipeConflictDetected.OnNext((local, plc)));
 	}
 
-	private void RefreshMessagePanel(Result mutationResult)
+	private void RebuildMessagePanel()
 	{
-		messagePanel.RefreshReasons(mutationResult.Reasons);
-	}
-
-	private void NotifyConnectionStateChanged()
-	{
-		_connectionStateChanged.OnNext(Unit.Default);
+		var combinedReasons = _lastRecipeResult.Reasons.Concat(_lastPlcState.Reasons);
+		messagePanel.RefreshReasons(combinedReasons);
 	}
 }

--- a/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
+++ b/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Reactive.Linq;
+﻿using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
 using Domain.Facade;
@@ -17,12 +16,13 @@ using UI.MessageService;
 
 namespace UI.Coordinator;
 
-public sealed class RecipeMutationCoordinator(
-	DomainFacade domainFacade,
-	AppConfiguration appConfiguration,
-	RecipeQueryService queryService,
-	MessagePanelViewModel messagePanel) : IDisposable
+public sealed class RecipeMutationCoordinator : IDisposable
 {
+	private readonly DomainFacade _domainFacade;
+	private readonly AppConfiguration _appConfiguration;
+	private readonly RecipeQueryService _queryService;
+	private readonly MessagePanelViewModel _messagePanel;
+	private readonly RecipeStepCoordinator _stepCoordinator;
 	private readonly Subject<MutationSignal> _stateChanged = new();
 	private readonly Subject<(Recipe Local, Recipe Plc)> _plcRecipeConflictDetected = new();
 	private readonly Subject<Result<PlcSessionSnapshot>> _plcStateChanged = new();
@@ -32,26 +32,45 @@ public sealed class RecipeMutationCoordinator(
 	private bool _initialized;
 	private bool _disposed;
 
+	public RecipeMutationCoordinator(
+		DomainFacade domainFacade,
+		AppConfiguration appConfiguration,
+		RecipeQueryService queryService,
+		MessagePanelViewModel messagePanel)
+	{
+		_domainFacade = domainFacade;
+		_appConfiguration = appConfiguration;
+		_queryService = queryService;
+		_messagePanel = messagePanel;
+		_stepCoordinator = new RecipeStepCoordinator(
+			domainFacade,
+			() => _queryService.CurrentRecipe,
+			result => _lastRecipeResult = result,
+			index => SuggestedSelection = index,
+			signal => _stateChanged.OnNext(signal),
+			RebuildMessagePanel);
+	}
+
 	public IObservable<MutationSignal> StateChanged => _stateChanged;
 	public IObservable<(Recipe Local, Recipe Plc)> PlcRecipeConflictDetected => _plcRecipeConflictDetected;
 	public IObservable<Result<PlcSessionSnapshot>> PlcStateChanged => _plcStateChanged;
 
 	public int? SuggestedSelection { get; private set; }
 
-	public Recipe CurrentRecipe => queryService.CurrentRecipe;
+	public Recipe CurrentRecipe => _queryService.CurrentRecipe;
 
-	public RecipeSnapshot Snapshot => queryService.Snapshot;
+	public RecipeSnapshot Snapshot => _queryService.Snapshot;
 
-	public bool IsDirty => queryService.IsDirty;
-	public bool CanUndo => queryService.CanUndo;
-	public bool CanRedo => queryService.CanRedo;
-	public bool IsConnected => queryService.IsConnected;
+	public bool IsDirty => _queryService.IsDirty;
+	public bool CanUndo => _queryService.CanUndo;
+	public bool CanRedo => _queryService.CanRedo;
+	public bool IsConnected => _queryService.IsConnected;
 
-	public IObservable<PlcExecutionInfo> ExecutionState => queryService.ExecutionState;
-	public bool IsRecipeActive => queryService.IsRecipeActive;
-	public bool IsSyncEnabled => queryService.IsSyncEnabled;
+	public IObservable<PlcExecutionInfo> ExecutionState => _queryService.ExecutionState;
+	public bool IsRecipeActive => _queryService.IsRecipeActive;
+	public bool IsSyncEnabled => _queryService.IsSyncEnabled;
 
-	public RecipeQueryService QueryService => queryService;
+	public RecipeQueryService QueryService => _queryService;
 
 	public RecipeMutationCoordinator Initialize()
 	{
@@ -62,9 +81,9 @@ public sealed class RecipeMutationCoordinator(
 
 		_initialized = true;
 
-		domainFacade.PlcRecipeConflictDetected += OnPlcRecipeConflictDetected;
+		_domainFacade.PlcRecipeConflictDetected += OnPlcRecipeConflictDetected;
 
-		_plcStateSubscription = domainFacade.PlcState
+		_plcStateSubscription = _domainFacade.PlcState
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(OnPlcStateChanged);
 
@@ -80,7 +99,7 @@ public sealed class RecipeMutationCoordinator(
 
 		_disposed = true;
 
-		domainFacade.PlcRecipeConflictDetected -= OnPlcRecipeConflictDetected;
+		_domainFacade.PlcRecipeConflictDetected -= OnPlcRecipeConflictDetected;
 
 		_plcStateSubscription?.Dispose();
 
@@ -99,24 +118,19 @@ public sealed class RecipeMutationCoordinator(
 
 	public Task<Result> EnableSync()
 	{
-		return domainFacade.EnableSync(appConfiguration.PlcConfiguration);
+		return _domainFacade.EnableSync(_appConfiguration.PlcConfiguration);
 	}
 
-	public async Task DisableSync()
+	public Task DisableSync()
 	{
-		await domainFacade.DisableSync();
+		return _domainFacade.DisableSync();
 	}
 
 	public async Task<Result> LoadRecipeFromPlcAsync()
 	{
-		var result = await domainFacade.LoadRecipeFromPlcAsync();
+		var result = await _domainFacade.LoadRecipeFromPlcAsync();
 
-		_lastRecipeResult = Result.Ok();
-
-		if (result.IsFailed)
-		{
-			_lastRecipeResult = result;
-		}
+		_lastRecipeResult = result;
 
 		RebuildMessagePanel();
 
@@ -133,166 +147,64 @@ public sealed class RecipeMutationCoordinator(
 
 	public void ResolveConflict(bool keepLocal)
 	{
-		domainFacade.ResolveConflict(keepLocal);
+		_domainFacade.ResolveConflict(keepLocal);
 	}
 
 	public void AppendStep(int actionId)
 	{
-		var result = domainFacade.AppendStep(actionId);
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		SuggestedSelection = CurrentRecipe.StepCount - 1;
-		_stateChanged.OnNext(new MutationSignal.StepAppended(CurrentRecipe.StepCount - 1));
+		_stepCoordinator.AppendStep(actionId);
 	}
 
 	public void InsertStep(int index, int actionId)
 	{
-		var result = domainFacade.InsertStep(index, actionId);
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		SuggestedSelection = index;
-		_stateChanged.OnNext(new MutationSignal.StepsInserted(index, 1));
+		_stepCoordinator.InsertStep(index, actionId);
 	}
 
 	public void RemoveStep(int index)
 	{
-		var result = domainFacade.RemoveStep(index);
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		SuggestedSelection = CurrentRecipe.StepCount > 0
-			? Math.Min(index, CurrentRecipe.StepCount - 1)
-			: null;
-		_stateChanged.OnNext(new MutationSignal.StepRemoved(index));
+		_stepCoordinator.RemoveStep(index);
 	}
 
 	public void RemoveSteps(IReadOnlyList<int> indices)
 	{
-		var result = domainFacade.RemoveSteps(indices);
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		SuggestedSelection = CurrentRecipe.StepCount > 0
-			? Math.Min(indices.Min(), CurrentRecipe.StepCount - 1)
-			: null;
-		_stateChanged.OnNext(new MutationSignal.StepsRemoved([.. indices]));
+		_stepCoordinator.RemoveSteps(indices);
 	}
 
 	public void InsertSteps(int startIndex, IReadOnlyList<Step> steps)
 	{
-		var result = domainFacade.InsertSteps(startIndex, steps);
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		SuggestedSelection = startIndex;
-		_stateChanged.OnNext(new MutationSignal.StepsInserted(startIndex, steps.Count));
+		_stepCoordinator.InsertSteps(startIndex, steps);
 	}
 
 	public void ChangeStepAction(int stepIndex, int newActionId)
 	{
-		var result = domainFacade.ChangeStepAction(stepIndex, newActionId);
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		SuggestedSelection = stepIndex;
-		_stateChanged.OnNext(new MutationSignal.StepActionChanged(stepIndex));
+		_stepCoordinator.ChangeStepAction(stepIndex, newActionId);
 	}
 
 	public void UpdateStepProperty(int stepIndex, string columnKey, string value)
 	{
-		var result = domainFacade.UpdateStepProperty(stepIndex, columnKey, value);
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		_stateChanged.OnNext(new MutationSignal.PropertyUpdated(stepIndex));
+		_stepCoordinator.UpdateStepProperty(stepIndex, columnKey, value);
 	}
 
 	public void Undo()
 	{
-		var result = domainFacade.Undo();
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		SuggestedSelection = null;
-		_stateChanged.OnNext(new MutationSignal.RecipeReplaced());
+		_stepCoordinator.Undo();
 	}
 
 	public void Redo()
 	{
-		var result = domainFacade.Redo();
-		_lastRecipeResult = result;
-		RebuildMessagePanel();
-
-		if (result.IsFailed)
-		{
-			return;
-		}
-
-		SuggestedSelection = null;
-		_stateChanged.OnNext(new MutationSignal.RecipeReplaced());
+		_stepCoordinator.Redo();
 	}
 
 	public void NewRecipe()
 	{
-		domainFacade.SetNewRecipe();
-		_lastRecipeResult = Result.Ok();
-		RebuildMessagePanel();
-		SuggestedSelection = null;
-		_stateChanged.OnNext(new MutationSignal.RecipeReplaced());
+		_stepCoordinator.NewRecipe();
 	}
 
 	public async Task<Result> LoadRecipeAsync(string filePath)
 	{
-		var result = await domainFacade.LoadRecipeAsync(filePath);
+		var result = await _domainFacade.LoadRecipeAsync(filePath);
 
-		_lastRecipeResult = Result.Ok();
-
-		if (result.IsFailed)
-		{
-			_lastRecipeResult = result;
-		}
+		_lastRecipeResult = result;
 
 		RebuildMessagePanel();
 
@@ -309,13 +221,18 @@ public sealed class RecipeMutationCoordinator(
 
 	public async Task SaveRecipeAsync(string filePath)
 	{
-		await domainFacade.SaveRecipeAsync(filePath);
+		await _domainFacade.SaveRecipeAsync(filePath);
 		SuggestedSelection = null;
 		_stateChanged.OnNext(new MutationSignal.MetadataChanged());
 	}
 
 	private void OnPlcStateChanged(Result<PlcSessionSnapshot> result)
 	{
+		if (_disposed)
+		{
+			return;
+		}
+
 		_lastPlcState = result;
 		_plcStateChanged.OnNext(result);
 		RebuildMessagePanel();
@@ -323,12 +240,19 @@ public sealed class RecipeMutationCoordinator(
 
 	private void OnPlcRecipeConflictDetected(Recipe local, Recipe plc)
 	{
-		Avalonia.Threading.Dispatcher.UIThread.Post(() => _plcRecipeConflictDetected.OnNext((local, plc)));
+		Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+		{
+			if (_disposed)
+			{
+				return;
+			}
+			_plcRecipeConflictDetected.OnNext((local, plc));
+		});
 	}
 
 	private void RebuildMessagePanel()
 	{
 		var combinedReasons = _lastRecipeResult.Reasons.Concat(_lastPlcState.Reasons);
-		messagePanel.RefreshReasons(combinedReasons);
+		_messagePanel.RefreshReasons(combinedReasons);
 	}
 }

--- a/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
+++ b/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
@@ -27,7 +27,6 @@ public sealed class RecipeMutationCoordinator(
 	private readonly Subject<MutationSignal> _stateChanged = new();
 	private readonly Subject<(Recipe Local, Recipe Plc)> _plcRecipeConflictDetected = new();
 	private readonly Subject<Unit> _connectionStateChanged = new();
-	private readonly Lock _subjectLock = new();
 	private Action<string?>? _syncErrorChangedRelay;
 	private bool _initialized;
 
@@ -65,7 +64,7 @@ public sealed class RecipeMutationCoordinator(
 		domainFacade.ConnectionStateChanged += OnConnectionStateChanged;
 		syncService.StatusChanged += OnSyncStatusChanged;
 
-		_syncErrorChangedRelay = _ => NotifyConnectionStateChanged();
+		_syncErrorChangedRelay = _ => Dispatcher.UIThread.Post(NotifyConnectionStateChanged);
 		syncService.ErrorChanged += _syncErrorChangedRelay;
 
 		return this;
@@ -84,10 +83,7 @@ public sealed class RecipeMutationCoordinator(
 
 		_stateChanged.Dispose();
 		_plcRecipeConflictDetected.Dispose();
-		lock (_subjectLock)
-		{
-			_connectionStateChanged.Dispose();
-		}
+		_connectionStateChanged.Dispose();
 	}
 
 	public int? ConsumeSuggestedSelection()
@@ -105,7 +101,7 @@ public sealed class RecipeMutationCoordinator(
 		if (result.IsFailed)
 		{
 			var errorMessage = string.Join("; ", result.Errors.Select(e => e.Message));
-			Dispatcher.UIThread.Post(() => messagePanel.AddError($"Failed to enable sync: {errorMessage}", "PLC"));
+			messagePanel.AddError($"Failed to enable sync: {errorMessage}", "PLC");
 		}
 
 		return result;
@@ -311,20 +307,22 @@ public sealed class RecipeMutationCoordinator(
 
 	private void OnConnectionStateChanged(PlcConnectionState state)
 	{
-		NotifyConnectionStateChanged();
+		var ipAddress = appConfiguration.PlcConfiguration.Connection.IpAddress;
+		var isSyncEnabled = queryService.IsSyncEnabled;
 
-		// Disconnection events are suppressed when sync is not user-enabled, as they are
-		// expected during normal startup and do not represent a loss of user-initiated sync.
 		Dispatcher.UIThread.Post(() =>
 		{
-			var ipAddress = appConfiguration.PlcConfiguration.Connection.IpAddress;
+			NotifyConnectionStateChanged();
 
+			// Disconnection events are suppressed when sync is not user-enabled, as they
+			// are expected during normal startup and do not represent a loss of
+			// user-initiated sync.
 			switch (state)
 			{
 				case PlcConnectionState.Connected:
 					messagePanel.AddInfo($"Connected to PLC ({ipAddress})", "PLC");
 					break;
-				case PlcConnectionState.Disconnected when queryService.IsSyncEnabled:
+				case PlcConnectionState.Disconnected when isSyncEnabled:
 					messagePanel.AddError("PLC connection lost", "PLC");
 					break;
 			}
@@ -333,11 +331,12 @@ public sealed class RecipeMutationCoordinator(
 
 	private void OnSyncStatusChanged(PlcSyncStatus status)
 	{
-		NotifyConnectionStateChanged();
-
 		var lastError = syncService.LastError;
+
 		Dispatcher.UIThread.Post(() =>
 		{
+			NotifyConnectionStateChanged();
+
 			switch (status)
 			{
 				case PlcSyncStatus.Synced:
@@ -362,9 +361,6 @@ public sealed class RecipeMutationCoordinator(
 
 	private void NotifyConnectionStateChanged()
 	{
-		lock (_subjectLock)
-		{
-			_connectionStateChanged.OnNext(Unit.Default);
-		}
+		_connectionStateChanged.OnNext(Unit.Default);
 	}
 }

--- a/SemiStep/UI/Coordinator/RecipeQueryService.cs
+++ b/SemiStep/UI/Coordinator/RecipeQueryService.cs
@@ -26,7 +26,6 @@ public sealed class RecipeQueryService(
 	public IObservable<PlcExecutionInfo> ExecutionState => domainFacade.ExecutionState;
 	public bool IsRecipeActive => domainFacade.IsRecipeActive;
 	public PlcSyncStatus SyncStatus => domainFacade.SyncStatus;
-	public string? SyncLastError => domainFacade.SyncLastError;
 	public DateTimeOffset? LastSyncTime => domainFacade.LastSyncTime;
 	public bool IsSyncEnabled => domainFacade.IsSyncEnabled;
 
@@ -37,7 +36,8 @@ public sealed class RecipeQueryService(
 
 	public int GetDefaultActionId()
 	{
-		return configRegistry.GetAllActions().First().Id;
+		return configRegistry.GetAllActions().FirstOrDefault()?.Id
+			?? throw new InvalidOperationException("No actions are defined in the configuration.");
 	}
 
 	public string SerializeStepsForClipboard(IReadOnlyList<Step> steps)

--- a/SemiStep/UI/Coordinator/RecipeStepCoordinator.cs
+++ b/SemiStep/UI/Coordinator/RecipeStepCoordinator.cs
@@ -1,0 +1,168 @@
+﻿using System.Linq;
+
+using Domain.Facade;
+
+using FluentResults;
+
+using TypesShared.Core;
+using TypesShared.Domain;
+
+namespace UI.Coordinator;
+
+internal sealed class RecipeStepCoordinator(
+	DomainFacade domainFacade,
+	Func<Recipe> getCurrentRecipe,
+	Action<Result> setLastRecipeResult,
+	Action<int?> setSuggestedSelection,
+	Action<MutationSignal> publishSignal,
+	Action rebuildMessagePanel)
+{
+	public void AppendStep(int actionId)
+	{
+		var result = domainFacade.AppendStep(actionId);
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		setSuggestedSelection(getCurrentRecipe().StepCount - 1);
+		publishSignal(new MutationSignal.StepAppended(getCurrentRecipe().StepCount - 1));
+	}
+
+	public void InsertStep(int index, int actionId)
+	{
+		var result = domainFacade.InsertStep(index, actionId);
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		setSuggestedSelection(index);
+		publishSignal(new MutationSignal.StepsInserted(index, 1));
+	}
+
+	public void RemoveStep(int index)
+	{
+		var result = domainFacade.RemoveStep(index);
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		var currentRecipe = getCurrentRecipe();
+		setSuggestedSelection(currentRecipe.StepCount > 0
+			? Math.Min(index, currentRecipe.StepCount - 1)
+			: null);
+		publishSignal(new MutationSignal.StepRemoved(index));
+	}
+
+	public void RemoveSteps(IReadOnlyList<int> indices)
+	{
+		var result = domainFacade.RemoveSteps(indices);
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		var currentRecipe = getCurrentRecipe();
+		setSuggestedSelection(currentRecipe.StepCount > 0
+			? Math.Min(indices.Min(), currentRecipe.StepCount - 1)
+			: null);
+		publishSignal(new MutationSignal.StepsRemoved([.. indices]));
+	}
+
+	public void InsertSteps(int startIndex, IReadOnlyList<Step> steps)
+	{
+		var result = domainFacade.InsertSteps(startIndex, steps);
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		setSuggestedSelection(startIndex);
+		publishSignal(new MutationSignal.StepsInserted(startIndex, steps.Count));
+	}
+
+	public void ChangeStepAction(int stepIndex, int newActionId)
+	{
+		var result = domainFacade.ChangeStepAction(stepIndex, newActionId);
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		setSuggestedSelection(stepIndex);
+		publishSignal(new MutationSignal.StepActionChanged(stepIndex));
+	}
+
+	public void UpdateStepProperty(int stepIndex, string columnKey, string value)
+	{
+		var result = domainFacade.UpdateStepProperty(stepIndex, columnKey, value);
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		publishSignal(new MutationSignal.PropertyUpdated(stepIndex));
+	}
+
+	public void Undo()
+	{
+		var result = domainFacade.Undo();
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		setSuggestedSelection(null);
+		publishSignal(new MutationSignal.RecipeReplaced());
+	}
+
+	public void Redo()
+	{
+		var result = domainFacade.Redo();
+		setLastRecipeResult(result);
+		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return;
+		}
+
+		setSuggestedSelection(null);
+		publishSignal(new MutationSignal.RecipeReplaced());
+	}
+
+	public void NewRecipe()
+	{
+		domainFacade.SetNewRecipe();
+		setLastRecipeResult(Result.Ok());
+		rebuildMessagePanel();
+		setSuggestedSelection(null);
+		publishSignal(new MutationSignal.RecipeReplaced());
+	}
+}

--- a/SemiStep/UI/MainWindow/AppStatusBar.axaml
+++ b/SemiStep/UI/MainWindow/AppStatusBar.axaml
@@ -119,14 +119,6 @@
                            VerticalAlignment="Center"
                            Foreground="{DynamicResource SecondaryForegroundBrush}" />
 
-                <!-- Sync error text (red, visible only when error present) -->
-                <TextBlock Text="{Binding PlcSyncErrorText}"
-                           FontSize="12"
-                           VerticalAlignment="Center"
-                           Foreground="{DynamicResource ErrorBrush}"
-                           IsVisible="{Binding PlcSyncErrorText,
-                                       Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-
                 <!-- Last sync time -->
                 <TextBlock FontSize="12"
                            VerticalAlignment="Center"

--- a/SemiStep/UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/UI/MainWindow/MainWindowViewModel.cs
@@ -58,7 +58,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 			.Subscribe(_ => RaiseAllStateProperties())
 			.DisposeWith(_disposables);
 
-		_coordinator.ConnectionStateChanged
+		_coordinator.PlcStateChanged
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(_ => RaiseConnectionStateProperties())
 			.DisposeWith(_disposables);
@@ -66,6 +66,11 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		_coordinator.PlcRecipeConflictDetected
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(conflict => _ = HandleConflictAsync(conflict.Local, conflict.Plc))
+			.DisposeWith(_disposables);
+
+		Observable.Interval(TimeSpan.FromSeconds(1))
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Subscribe(_ => this.RaisePropertyChanged(nameof(LastSyncTimeText)))
 			.DisposeWith(_disposables);
 	}
 
@@ -105,8 +110,6 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 
 	public string PlcSyncStatusText => MapSyncStatus(_coordinator.QueryService.SyncStatus);
 
-	public string? PlcSyncErrorText => _coordinator.QueryService.SyncLastError;
-
 	public string LastSyncTimeText => FormatLastSyncTime(_coordinator.QueryService.LastSyncTime);
 
 	public void Dispose()
@@ -135,7 +138,12 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		}
 		else
 		{
-			await _coordinator.EnableSync();
+			var result = await _coordinator.EnableSync();
+
+			if (result.IsFailed)
+			{
+				MessagePanel.AddError(result.Errors[0].Message, "PLC");
+			}
 		}
 
 		RaiseConnectionStateProperties();
@@ -177,7 +185,6 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		this.RaisePropertyChanged(nameof(ConnectionStatus));
 		this.RaisePropertyChanged(nameof(IsSyncEnabled));
 		this.RaisePropertyChanged(nameof(PlcSyncStatusText));
-		this.RaisePropertyChanged(nameof(PlcSyncErrorText));
 		this.RaisePropertyChanged(nameof(LastSyncTimeText));
 	}
 

--- a/SemiStep/UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/UI/MainWindow/MainWindowViewModel.cs
@@ -48,6 +48,11 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		ExitCommand = ReactiveCommand.Create(ExecuteExit);
 		ToggleSyncCommand = ReactiveCommand.CreateFromTask(ExecuteToggleSyncAsync);
 
+		ToggleSyncCommand.ThrownExceptions
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Subscribe(ex => messagePanel.AddError($"Sync toggle failed: {ex.Message}", "PLC"))
+			.DisposeWith(_disposables);
+
 		_coordinator.StateChanged
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(_ => RaiseAllStateProperties())
@@ -151,7 +156,8 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		}
 		catch (Exception ex)
 		{
-			Log.Warning(ex, "Unexpected error while handling PLC recipe conflict");
+			Log.Warning("Unexpected error while handling PLC recipe conflict: {Message}", ex.Message);
+			MessagePanel.AddError("Failed to resolve PLC recipe conflict — sync disabled", "PLC");
 		}
 	}
 

--- a/SemiStep/UI/MessageService/MessagePanelViewModel.cs
+++ b/SemiStep/UI/MessageService/MessagePanelViewModel.cs
@@ -3,6 +3,8 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
+using Avalonia.Threading;
+
 using FluentResults;
 
 using ReactiveUI;
@@ -133,53 +135,86 @@ public class MessagePanelViewModel : ReactiveObject, IDisposable
 
 	public void AddError(string message, string source)
 	{
-		Entries.Add(new MessageEntry(MessageSeverity.Error, message, source, DateTime.Now));
-		RecountAndNotify();
+		PostOnUiThread(() =>
+		{
+			Entries.Add(new MessageEntry(MessageSeverity.Error, message, source, DateTime.Now));
+			RecountAndNotify();
+		});
 	}
 
 	public void AddWarning(string message, string source)
 	{
-		Entries.Add(new MessageEntry(MessageSeverity.Warning, message, source, DateTime.Now));
-		RecountAndNotify();
+		PostOnUiThread(() =>
+		{
+			Entries.Add(new MessageEntry(MessageSeverity.Warning, message, source, DateTime.Now));
+			RecountAndNotify();
+		});
 	}
 
 	public void AddInfo(string message, string source)
 	{
-		Entries.Add(new MessageEntry(MessageSeverity.Info, message, source, DateTime.Now));
-		RecountAndNotify();
+		PostOnUiThread(() =>
+		{
+			Entries.Add(new MessageEntry(MessageSeverity.Info, message, source, DateTime.Now));
+			RecountAndNotify();
+		});
 	}
 
+	// Only IError and Warning subtypes are rendered; other IReason subtypes (plain Success) are intentionally ignored.
 	public void RefreshReasons(IEnumerable<IReason> reasons)
 	{
-		RemoveByPredicate(entry => entry.IsStructural);
-
-		foreach (var error in reasons.OfType<IError>())
+		ArgumentNullException.ThrowIfNull(reasons);
+		var reasonList = reasons.ToList();
+		PostOnUiThread(() =>
 		{
-			Entries.Add(new MessageEntry(MessageSeverity.Error, error.Message, MessageEntry.StructuralSource,
-				DateTime.Now));
-		}
+			RemoveByPredicate(entry => entry.IsStructural);
 
-		foreach (var warning in reasons.OfType<Warning>())
-		{
-			Entries.Add(new MessageEntry(MessageSeverity.Warning, warning.Message, MessageEntry.StructuralSource,
-				DateTime.Now));
-		}
+			foreach (var error in reasonList.OfType<IError>())
+			{
+				Entries.Add(new MessageEntry(MessageSeverity.Error, error.Message, MessageEntry.StructuralSource,
+					DateTime.Now));
+			}
 
-		RecountAndNotify();
+			foreach (var warning in reasonList.OfType<Warning>())
+			{
+				Entries.Add(new MessageEntry(MessageSeverity.Warning, warning.Message, MessageEntry.StructuralSource,
+					DateTime.Now));
+			}
+
+			RecountAndNotify();
+		});
 	}
 
 	public void Clear()
 	{
-		Entries.Clear();
-		ErrorCount = 0;
-		WarningCount = 0;
-		HasEntries = false;
+		PostOnUiThread(() =>
+		{
+			Entries.Clear();
+			ErrorCount = 0;
+			WarningCount = 0;
+			HasEntries = false;
+		});
 	}
 
 	private void ClearNonStructural()
 	{
-		RemoveByPredicate(entry => !entry.IsStructural);
-		RecountAndNotify();
+		PostOnUiThread(() =>
+		{
+			RemoveByPredicate(entry => !entry.IsStructural);
+			RecountAndNotify();
+		});
+	}
+
+	private void PostOnUiThread(Action action)
+	{
+		if (Dispatcher.UIThread.CheckAccess())
+		{
+			action();
+		}
+		else
+		{
+			Dispatcher.UIThread.Post(action);
+		}
 	}
 
 	private void RemoveByPredicate(Func<MessageEntry, bool> predicate)

--- a/SemiStep/UI/MessageService/MessagePanelViewModel.cs
+++ b/SemiStep/UI/MessageService/MessagePanelViewModel.cs
@@ -137,6 +137,12 @@ public class MessagePanelViewModel : ReactiveObject, IDisposable
 		RecountAndNotify();
 	}
 
+	public void AddWarning(string message, string source)
+	{
+		Entries.Add(new MessageEntry(MessageSeverity.Warning, message, source, DateTime.Now));
+		RecountAndNotify();
+	}
+
 	public void AddInfo(string message, string source)
 	{
 		Entries.Add(new MessageEntry(MessageSeverity.Info, message, source, DateTime.Now));

--- a/SemiStep/UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/UI/RecipeGrid/RecipeGridViewModel.cs
@@ -56,7 +56,10 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 			.Subscribe(OnExecutionStateChanged)
 			.DisposeWith(_disposables);
 
-		coordinator.StateChanged.Subscribe(OnStateChange).DisposeWith(_disposables);
+		coordinator.StateChanged
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Subscribe(OnStateChange)
+			.DisposeWith(_disposables);
 	}
 
 	internal ConfigRegistry ConfigRegistry { get; }


### PR DESCRIPTION
## Summary
This branch delivers the complete S7/PLC integration overhaul across five commits:
- **Fix S7 protocol** — corrected `DataDbLayout` offsets and `S7Driver` connection endpoint so the protocol wire format is bit-exact
- **Refactor S7 module** — replaced exception-based control flow with `Result<T>` propagation throughout the S7 layer; introduced `PlcSyncCoordinator`, `PlcSyncExecutor`, sync loop with execution monitoring, reconnect reconciliation, recipe debounce write, and write verification
- **Surface PLC operational events in the message panel** — PLC connect/disconnect, sync errors, and conflict events are displayed in the UI message panel
- **Fix threading architecture** — STA entry point, unified dispatch model, self-marshalling `MessagePanelViewModel` (internal `Post`/`CheckAccess` pattern); removed premature `AvaloniaScheduler.Instance` assignment
- **Unify PLC state into `Result<PlcSessionSnapshot>`** — `IPlcSyncService.PlcState` observable replaces `LastError`/`ErrorChanged`/`StatusChanged`; `RecipeMutationCoordinator` rebuilds the message panel from both recipe analysis reasons and PLC state reasons on every change; `PlcSyncErrorText` status-bar label removed
## Key design decisions
- `MessagePanelViewModel` is self-marshalling: all mutating methods dispatch to the UI thread internally; call sites do not wrap in `Dispatcher.UIThread.Post`
- PLC state flows as `Result<PlcSessionSnapshot>` from `PlcSyncCoordinator` → `DomainFacade` → `RecipeMutationCoordinator` → `MessagePanelViewModel`
- `DomainFacade` was split: `PlcLifecycleManager` handles enable/disable/reconnect; `RecipeEditService` handles recipe mutations
- `PlcSyncCoordinator` was split: `PlcSyncExecutor` owns the sync execution loop