### PR TITLE
Return Result from coordinator mutation methods; extract PlcSyncFacade

### DIFF
--- a/SemiStep/Domain/Facade/DomainFacade.cs
+++ b/SemiStep/Domain/Facade/DomainFacade.cs
@@ -104,7 +104,7 @@ public sealed class DomainFacade : IDisposable
 
 	public void Initialize()
 	{
-		SetNewRecipe();
+		_ = SetNewRecipe();
 		_plcLifecycleManager.Initialize();
 	}
 
@@ -223,10 +223,25 @@ public sealed class DomainFacade : IDisposable
 		return Result.Ok().WithReasons(snapshot.Reasons);
 	}
 
-	public async Task SaveRecipeAsync(string filePath, CancellationToken ct = default)
+	public async Task<Result> SaveRecipeAsync(string filePath, CancellationToken ct = default)
 	{
-		await _csvService.SaveAsync(_stateManager.Current, filePath, ct);
-		_stateManager.MarkSaved();
+		try
+		{
+			await _csvService.SaveAsync(_stateManager.Current, filePath, ct);
+			_stateManager.MarkSaved();
+
+			return Result.Ok();
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (Exception ex)
+		{
+			Log.Error(ex, "Failed to save recipe to {FilePath}", filePath);
+
+			return Result.Fail(ex.Message);
+		}
 	}
 
 	public void MarkSaved()
@@ -299,12 +314,12 @@ public sealed class DomainFacade : IDisposable
 		return Result.Ok().WithReasons(snapshot.Reasons);
 	}
 
-	public void ResolveConflict(bool keepLocal)
+	public Result ResolveConflict(bool keepLocal)
 	{
-		_plcLifecycleManager.ResolveConflict(keepLocal, _stateManager);
+		return _plcLifecycleManager.ResolveConflict(keepLocal, _stateManager);
 	}
 
-	public void SetNewRecipe()
+	public Result SetNewRecipe()
 	{
 		_historyManager.Clear();
 		_stateManager.Reset();
@@ -317,5 +332,7 @@ public sealed class DomainFacade : IDisposable
 			Log.Warning("Empty recipe analysis unexpectedly failed: {Errors}",
 				string.Join("; ", snapshot.Errors.Select(e => e.Message)));
 		}
+
+		return snapshot.ToResult();
 	}
 }

--- a/SemiStep/Domain/Facade/PlcLifecycleManager.cs
+++ b/SemiStep/Domain/Facade/PlcLifecycleManager.cs
@@ -90,20 +90,26 @@ internal sealed class PlcLifecycleManager(
 		}
 	}
 
-	public void ResolveConflict(bool keepLocal, RecipeStateManager stateManager)
+	public Result ResolveConflict(bool keepLocal, RecipeStateManager stateManager)
 	{
 		if (keepLocal)
 		{
 			syncService.NotifyRecipeChanged(stateManager.Current, stateManager.IsValid);
+
+			return Result.Ok();
 		}
-		else
+
+		if (_pendingPlcRecipe is null)
 		{
-			if (_pendingPlcRecipe is not null)
-			{
-				LoadPlcRecipeIntoState(_pendingPlcRecipe);
-				_pendingPlcRecipe = null;
-			}
+			Log.Warning("ResolveConflict called with keepLocal=false but no pending PLC recipe exists.");
+
+			return Result.Fail("No pending PLC recipe to resolve.");
 		}
+
+		LoadPlcRecipeIntoState(_pendingPlcRecipe);
+		_pendingPlcRecipe = null;
+
+		return Result.Ok();
 	}
 
 	private void OnConnectionStateChanged(PlcConnectionState state)

--- a/SemiStep/Domain/Facade/PlcLifecycleManager.cs
+++ b/SemiStep/Domain/Facade/PlcLifecycleManager.cs
@@ -94,6 +94,7 @@ internal sealed class PlcLifecycleManager(
 	{
 		if (keepLocal)
 		{
+			_pendingPlcRecipe = null;
 			syncService.NotifyRecipeChanged(stateManager.Current, stateManager.IsValid);
 
 			return Result.Ok();

--- a/SemiStep/Tests/Helpers/FailingCsvService.cs
+++ b/SemiStep/Tests/Helpers/FailingCsvService.cs
@@ -1,0 +1,19 @@
+﻿using FluentResults;
+
+using TypesShared.Core;
+using TypesShared.Domain;
+
+namespace Tests.Helpers;
+
+public sealed class FailingCsvService : ICsvService
+{
+	public Task<Result<Recipe>> LoadAsync(string filePath, CancellationToken cancellationToken = default)
+	{
+		return Task.FromResult(Result.Fail<Recipe>("FailingCsvService does not support loading."));
+	}
+
+	public Task SaveAsync(Recipe recipe, string filePath, CancellationToken cancellationToken = default)
+	{
+		throw new IOException("Simulated disk write failure.");
+	}
+}

--- a/SemiStep/Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
@@ -32,6 +32,7 @@ namespace Tests.UI;
 public sealed class RecipeMutationCoordinatorLoadRecipeTests
 {
 	private const string TempFilePrefix = "SemiStep.CoordinatorTest";
+
 	[Fact]
 	public async Task LoadRecipeAsync_Success_ClearsMessagePanelBeforeAddingNewReasons()
 	{
@@ -127,32 +128,10 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		}
 	}
 
-	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel)> BuildCoordinatorWithCsvAsync()
+	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel)>
+		BuildCoordinatorWithCsvAsync()
 	{
-		var configDir = TestConfigLocator.GetConfigDirectory("WithGroups");
-		var configLoadResult = await ConfigFacade.LoadAndValidateAsync(configDir);
-
-		var services = new ServiceCollection()
-			.AddSingleton(configLoadResult.Value)
-			.AddRecipe()
-			.AddDomain()
-			.AddCsv()
-			.AddSingleton<IClipboardService, StubClipboardService>()
-			.AddSingleton<IS7Service, StubIs7Service>()
-			.AddSingleton<IPlcSyncService, StubPlcSyncService>()
-			.BuildServiceProvider();
-
-		var facade = services.GetRequiredService<DomainFacade>();
-		facade.Initialize();
-
-		var configRegistry = services.GetRequiredService<ConfigRegistry>();
-		var panel = new MessagePanelViewModel();
-		var queryService = new RecipeQueryService(facade, configRegistry);
-		var appConfiguration = services.GetRequiredService<AppConfiguration>();
-		var coordinator = new RecipeMutationCoordinator(facade, appConfiguration, queryService, panel);
-		coordinator.Initialize();
-
-		return (coordinator, panel);
+		return await BuildCoordinatorAsync(services => services.AddCsv());
 	}
 
 	private static async Task<(
@@ -168,5 +147,62 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		await coordinator.SaveRecipeAsync(tempFilePath);
 
 		return (coordinator, panel, tempFilePath);
+	}
+
+	[Fact]
+	public async Task SaveRecipeAsync_Failure_ReturnsFailed()
+	{
+		var (coordinator, panel) = await BuildCoordinatorWithThrowingCsvAsync();
+
+		try
+		{
+			var result = await coordinator.SaveRecipeAsync("any/path.csv");
+			Dispatcher.UIThread.RunJobs(null);
+
+			result.IsFailed.Should().BeTrue();
+		}
+		finally
+		{
+			coordinator.Dispose();
+			panel.Dispose();
+		}
+	}
+
+	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel)>
+		BuildCoordinatorWithThrowingCsvAsync()
+	{
+		return await BuildCoordinatorAsync(services =>
+			services.AddSingleton<ICsvService, FailingCsvService>());
+	}
+
+	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel)>
+		BuildCoordinatorAsync(Action<IServiceCollection> registerCsvService)
+	{
+		var configDir = TestConfigLocator.GetConfigDirectory("WithGroups");
+		var configLoadResult = await ConfigFacade.LoadAndValidateAsync(configDir);
+
+		var serviceCollection = new ServiceCollection()
+			.AddSingleton(configLoadResult.Value)
+			.AddRecipe()
+			.AddDomain()
+			.AddSingleton<IClipboardService, StubClipboardService>()
+			.AddSingleton<IS7Service, StubIs7Service>()
+			.AddSingleton<IPlcSyncService, StubPlcSyncService>();
+
+		registerCsvService(serviceCollection);
+
+		var services = serviceCollection.BuildServiceProvider();
+
+		var facade = services.GetRequiredService<DomainFacade>();
+		facade.Initialize();
+
+		var configRegistry = services.GetRequiredService<ConfigRegistry>();
+		var panel = new MessagePanelViewModel();
+		var queryService = new RecipeQueryService(facade, configRegistry);
+		var appConfiguration = services.GetRequiredService<AppConfiguration>();
+		var coordinator = new RecipeMutationCoordinator(facade, appConfiguration, queryService, panel);
+		coordinator.Initialize();
+
+		return (coordinator, panel);
 	}
 }

--- a/SemiStep/Tests/UI/RecipeMutationCoordinatorTests.cs
+++ b/SemiStep/Tests/UI/RecipeMutationCoordinatorTests.cs
@@ -26,33 +26,33 @@ namespace Tests.UI;
 [Trait("Category", "Integration")]
 public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 {
-	private DomainFacade _facade = null!;
-	private MessagePanelViewModel _panel = null!;
+	private DomainFacade _domainFacade = null!;
+	private MessagePanelViewModel _messagePanel = null!;
 	private RecipeMutationCoordinator _coordinator = null!;
 
 	public async Task InitializeAsync()
 	{
 		var (services, facade) = await CoreTestHelper.BuildAsync("WithGroups");
-		_facade = facade;
+		_domainFacade = facade;
 		var configRegistry = services.GetRequiredService<ConfigRegistry>();
-		_panel = new MessagePanelViewModel();
-		var queryService = new RecipeQueryService(_facade, configRegistry);
+		_messagePanel = new MessagePanelViewModel();
+		var queryService = new RecipeQueryService(_domainFacade, configRegistry);
 		var appConfiguration = services.GetRequiredService<AppConfiguration>();
-		_coordinator = new RecipeMutationCoordinator(_facade, appConfiguration, queryService, _panel);
+		_coordinator = new RecipeMutationCoordinator(_domainFacade, appConfiguration, queryService, _messagePanel);
 		_coordinator.Initialize();
 	}
 
 	public Task DisposeAsync()
 	{
 		_coordinator.Dispose();
-		_panel.Dispose();
+		_messagePanel.Dispose();
 		return Task.CompletedTask;
 	}
 
 	[Fact]
 	public void AppendStep_EmitsStepAppendedSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		var signals = new List<MutationSignal>();
 		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
 
@@ -65,7 +65,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void AppendStep_SetsSuggestedSelection_ToLastIndex()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		var selection = _coordinator.ConsumeSuggestedSelection();
@@ -76,7 +76,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void InsertStep_EmitsStepsInsertedSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		var signals = new List<MutationSignal>();
 		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
@@ -90,7 +90,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void InsertStep_SetsSuggestedSelection_ToInsertedIndex()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.ConsumeSuggestedSelection();
 
@@ -103,7 +103,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void RemoveStep_EmitsStepRemovedSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
@@ -118,7 +118,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void RemoveStep_SuggestedSelection_IsNull_WhenRecipeBecomesEmpty()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.ConsumeSuggestedSelection();
 
@@ -131,7 +131,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void RemoveStep_SuggestedSelection_ClampedToLastIndex_WhenRemovingLast()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
@@ -146,7 +146,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void RemoveSteps_EmitsStepsRemovedSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.ConsumeSuggestedSelection();
@@ -161,7 +161,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void ChangeStepAction_EmitsStepActionChangedSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
@@ -176,7 +176,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void UpdateStepProperty_EmitsPropertyUpdatedSignal_WithCorrectStepIndex()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
@@ -191,7 +191,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void Undo_EmitsRecipeReplacedSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
@@ -205,7 +205,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void Redo_EmitsRecipeReplacedSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_coordinator.Undo();
 		var signals = new List<MutationSignal>();
@@ -219,7 +219,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void NewRecipe_EmitsRecipeReplacedSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		var signals = new List<MutationSignal>();
 		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
 
@@ -229,22 +229,22 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	}
 
 	[Fact]
-	public void NewRecipe_ClearsMessagePanel()
+	public void NewRecipe_ClearsPriorNonStructuralEntries()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(9999);
 		Dispatcher.UIThread.RunJobs(null);
 
 		_coordinator.NewRecipe();
 		Dispatcher.UIThread.RunJobs(null);
 
-		_panel.Entries.Should().BeEmpty();
+		_messagePanel.Entries.Should().NotContain(e => !e.IsStructural);
 	}
 
 	[Fact]
 	public void ConsumeSuggestedSelection_ReturnsValueOnce_ThenNull()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		var first = _coordinator.ConsumeSuggestedSelection();
@@ -257,7 +257,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void AppendStep_Failure_DoesNotEmitSignal()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		var signals = new List<MutationSignal>();
 		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
 
@@ -269,18 +269,18 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void AppendStep_Failure_AddsErrorToMessagePanel()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 
 		_coordinator.AppendStep(9999);
 		Dispatcher.UIThread.RunJobs(null);
 
-		_panel.ErrorCount.Should().BeGreaterThan(0);
+		_messagePanel.ErrorCount.Should().BeGreaterThan(0);
 	}
 
 	[Fact]
 	public void IsDirty_True_AfterMutation()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
@@ -290,7 +290,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void CanUndo_True_AfterMutation()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
@@ -300,12 +300,44 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[Fact]
 	public void CanRedo_True_AfterUndoingMutation()
 	{
-		_facade.SetNewRecipe();
+		_domainFacade.SetNewRecipe();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		_coordinator.Undo();
 
 		_coordinator.CanRedo.Should().BeTrue();
+	}
+
+	[Fact]
+	public void AppendStep_Failure_ReturnsFailed()
+	{
+		_ = _domainFacade.SetNewRecipe();
+
+		var result = _coordinator.AppendStep(9999);
+
+		result.IsFailed.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ChangeStepAction_Failure_ReturnsFailed()
+	{
+		_ = _domainFacade.SetNewRecipe();
+		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+
+		var result = _coordinator.ChangeStepAction(0, 9999);
+
+		result.IsFailed.Should().BeTrue();
+	}
+
+	[Fact]
+	public void UpdateStepProperty_Failure_ReturnsFailed()
+	{
+		_ = _domainFacade.SetNewRecipe();
+		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+
+		var result = _coordinator.UpdateStepProperty(0, "NonExistentColumn", "value");
+
+		result.IsFailed.Should().BeTrue();
 	}
 
 }

--- a/SemiStep/UI/Clipboard/ClipboardViewModel.cs
+++ b/SemiStep/UI/Clipboard/ClipboardViewModel.cs
@@ -93,7 +93,11 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 		var csvText = _coordinator.QueryService.SerializeStepsForClipboard(steps);
 		await _clipboard.SetTextAsync(csvText);
 
-		_coordinator.RemoveSteps(_recipeGrid.SelectedRowIndices);
+		var result = _coordinator.RemoveSteps(_recipeGrid.SelectedRowIndices);
+		if (result.IsFailed)
+		{
+			_messagePanel.AddError(result.Errors[0].Message, ClipboardSource);
+		}
 	}
 
 	private async Task PasteStepsAsync()
@@ -125,6 +129,10 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 			? _recipeGrid.SelectedRowIndices.Max() + 1
 			: _recipeGrid.RecipeRows.Count;
 
-		_coordinator.InsertSteps(insertIndex, recipeResult.Value.Steps);
+		var insertResult = _coordinator.InsertSteps(insertIndex, recipeResult.Value.Steps);
+		if (insertResult.IsFailed)
+		{
+			_messagePanel.AddError(insertResult.Errors[0].Message, ClipboardSource);
+		}
 	}
 }

--- a/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
+++ b/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
@@ -145,59 +145,70 @@ public sealed class RecipeMutationCoordinator : IDisposable
 		return result;
 	}
 
-	public void ResolveConflict(bool keepLocal)
+	public Result ResolveConflict(bool keepLocal)
 	{
-		_domainFacade.ResolveConflict(keepLocal);
+		var result = _domainFacade.ResolveConflict(keepLocal);
+
+		if (!keepLocal && result.IsSuccess)
+		{
+			_lastRecipeResult = result;
+			SuggestedSelection = null;
+			_stateChanged.OnNext(new MutationSignal.RecipeReplaced());
+		}
+
+		RebuildMessagePanel();
+
+		return result;
 	}
 
-	public void AppendStep(int actionId)
+	public Result AppendStep(int actionId)
 	{
-		_stepCoordinator.AppendStep(actionId);
+		return _stepCoordinator.AppendStep(actionId);
 	}
 
-	public void InsertStep(int index, int actionId)
+	public Result InsertStep(int index, int actionId)
 	{
-		_stepCoordinator.InsertStep(index, actionId);
+		return _stepCoordinator.InsertStep(index, actionId);
 	}
 
-	public void RemoveStep(int index)
+	public Result RemoveStep(int index)
 	{
-		_stepCoordinator.RemoveStep(index);
+		return _stepCoordinator.RemoveStep(index);
 	}
 
-	public void RemoveSteps(IReadOnlyList<int> indices)
+	public Result RemoveSteps(IReadOnlyList<int> indices)
 	{
-		_stepCoordinator.RemoveSteps(indices);
+		return _stepCoordinator.RemoveSteps(indices);
 	}
 
-	public void InsertSteps(int startIndex, IReadOnlyList<Step> steps)
+	public Result InsertSteps(int startIndex, IReadOnlyList<Step> steps)
 	{
-		_stepCoordinator.InsertSteps(startIndex, steps);
+		return _stepCoordinator.InsertSteps(startIndex, steps);
 	}
 
-	public void ChangeStepAction(int stepIndex, int newActionId)
+	public Result ChangeStepAction(int stepIndex, int newActionId)
 	{
-		_stepCoordinator.ChangeStepAction(stepIndex, newActionId);
+		return _stepCoordinator.ChangeStepAction(stepIndex, newActionId);
 	}
 
-	public void UpdateStepProperty(int stepIndex, string columnKey, string value)
+	public Result UpdateStepProperty(int stepIndex, string columnKey, string value)
 	{
-		_stepCoordinator.UpdateStepProperty(stepIndex, columnKey, value);
+		return _stepCoordinator.UpdateStepProperty(stepIndex, columnKey, value);
 	}
 
-	public void Undo()
+	public Result Undo()
 	{
-		_stepCoordinator.Undo();
+		return _stepCoordinator.Undo();
 	}
 
-	public void Redo()
+	public Result Redo()
 	{
-		_stepCoordinator.Redo();
+		return _stepCoordinator.Redo();
 	}
 
-	public void NewRecipe()
+	public Result NewRecipe()
 	{
-		_stepCoordinator.NewRecipe();
+		return _stepCoordinator.NewRecipe();
 	}
 
 	public async Task<Result> LoadRecipeAsync(string filePath)
@@ -219,11 +230,21 @@ public sealed class RecipeMutationCoordinator : IDisposable
 		return result;
 	}
 
-	public async Task SaveRecipeAsync(string filePath)
+	public async Task<Result> SaveRecipeAsync(string filePath)
 	{
-		await _domainFacade.SaveRecipeAsync(filePath);
+		var result = await _domainFacade.SaveRecipeAsync(filePath);
+
+		RebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return result;
+		}
+
 		SuggestedSelection = null;
 		_stateChanged.OnNext(new MutationSignal.MetadataChanged());
+
+		return result;
 	}
 
 	private void OnPlcStateChanged(Result<PlcSessionSnapshot> result)
@@ -246,6 +267,7 @@ public sealed class RecipeMutationCoordinator : IDisposable
 			{
 				return;
 			}
+
 			_plcRecipeConflictDetected.OnNext((local, plc));
 		});
 	}

--- a/SemiStep/UI/Coordinator/RecipeStepCoordinator.cs
+++ b/SemiStep/UI/Coordinator/RecipeStepCoordinator.cs
@@ -17,7 +17,7 @@ internal sealed class RecipeStepCoordinator(
 	Action<MutationSignal> publishSignal,
 	Action rebuildMessagePanel)
 {
-	public void AppendStep(int actionId)
+	public Result AppendStep(int actionId)
 	{
 		var result = domainFacade.AppendStep(actionId);
 		setLastRecipeResult(result);
@@ -25,14 +25,15 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		setSuggestedSelection(getCurrentRecipe().StepCount - 1);
 		publishSignal(new MutationSignal.StepAppended(getCurrentRecipe().StepCount - 1));
+		return result;
 	}
 
-	public void InsertStep(int index, int actionId)
+	public Result InsertStep(int index, int actionId)
 	{
 		var result = domainFacade.InsertStep(index, actionId);
 		setLastRecipeResult(result);
@@ -40,14 +41,15 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		setSuggestedSelection(index);
 		publishSignal(new MutationSignal.StepsInserted(index, 1));
+		return result;
 	}
 
-	public void RemoveStep(int index)
+	public Result RemoveStep(int index)
 	{
 		var result = domainFacade.RemoveStep(index);
 		setLastRecipeResult(result);
@@ -55,7 +57,7 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		var currentRecipe = getCurrentRecipe();
@@ -63,9 +65,10 @@ internal sealed class RecipeStepCoordinator(
 			? Math.Min(index, currentRecipe.StepCount - 1)
 			: null);
 		publishSignal(new MutationSignal.StepRemoved(index));
+		return result;
 	}
 
-	public void RemoveSteps(IReadOnlyList<int> indices)
+	public Result RemoveSteps(IReadOnlyList<int> indices)
 	{
 		var result = domainFacade.RemoveSteps(indices);
 		setLastRecipeResult(result);
@@ -73,7 +76,7 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		var currentRecipe = getCurrentRecipe();
@@ -81,9 +84,10 @@ internal sealed class RecipeStepCoordinator(
 			? Math.Min(indices.Min(), currentRecipe.StepCount - 1)
 			: null);
 		publishSignal(new MutationSignal.StepsRemoved([.. indices]));
+		return result;
 	}
 
-	public void InsertSteps(int startIndex, IReadOnlyList<Step> steps)
+	public Result InsertSteps(int startIndex, IReadOnlyList<Step> steps)
 	{
 		var result = domainFacade.InsertSteps(startIndex, steps);
 		setLastRecipeResult(result);
@@ -91,14 +95,15 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		setSuggestedSelection(startIndex);
 		publishSignal(new MutationSignal.StepsInserted(startIndex, steps.Count));
+		return result;
 	}
 
-	public void ChangeStepAction(int stepIndex, int newActionId)
+	public Result ChangeStepAction(int stepIndex, int newActionId)
 	{
 		var result = domainFacade.ChangeStepAction(stepIndex, newActionId);
 		setLastRecipeResult(result);
@@ -106,14 +111,15 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		setSuggestedSelection(stepIndex);
 		publishSignal(new MutationSignal.StepActionChanged(stepIndex));
+		return result;
 	}
 
-	public void UpdateStepProperty(int stepIndex, string columnKey, string value)
+	public Result UpdateStepProperty(int stepIndex, string columnKey, string value)
 	{
 		var result = domainFacade.UpdateStepProperty(stepIndex, columnKey, value);
 		setLastRecipeResult(result);
@@ -121,13 +127,14 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		publishSignal(new MutationSignal.PropertyUpdated(stepIndex));
+		return result;
 	}
 
-	public void Undo()
+	public Result Undo()
 	{
 		var result = domainFacade.Undo();
 		setLastRecipeResult(result);
@@ -135,14 +142,15 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		setSuggestedSelection(null);
 		publishSignal(new MutationSignal.RecipeReplaced());
+		return result;
 	}
 
-	public void Redo()
+	public Result Redo()
 	{
 		var result = domainFacade.Redo();
 		setLastRecipeResult(result);
@@ -150,19 +158,27 @@ internal sealed class RecipeStepCoordinator(
 
 		if (result.IsFailed)
 		{
-			return;
+			return result;
 		}
 
 		setSuggestedSelection(null);
 		publishSignal(new MutationSignal.RecipeReplaced());
+		return result;
 	}
 
-	public void NewRecipe()
+	public Result NewRecipe()
 	{
-		domainFacade.SetNewRecipe();
-		setLastRecipeResult(Result.Ok());
+		var result = domainFacade.SetNewRecipe();
+		setLastRecipeResult(result);
 		rebuildMessagePanel();
+
+		if (result.IsFailed)
+		{
+			return result;
+		}
+
 		setSuggestedSelection(null);
 		publishSignal(new MutationSignal.RecipeReplaced());
+		return result;
 	}
 }

--- a/SemiStep/UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/UI/MainWindow/MainWindowViewModel.cs
@@ -156,16 +156,30 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
+		var dialog = new PlcConflictDialog();
+
 		try
 		{
-			var dialog = new PlcConflictDialog();
 			await dialog.ShowDialog(MainWindow);
-			_coordinator.ResolveConflict(dialog.KeepLocal);
 		}
 		catch (Exception ex)
 		{
-			Log.Warning("Unexpected error while handling PLC recipe conflict: {Message}", ex.Message);
-			MessagePanel.AddError("Failed to resolve PLC recipe conflict — sync disabled", "PLC");
+			Log.Warning("Unexpected error while showing PLC conflict dialog: {Message}", ex.Message);
+			MessagePanel.AddError("Failed to show PLC conflict dialog — sync disabled", "PLC");
+
+			return;
+		}
+
+		if (!dialog.Confirmed)
+		{
+			return;
+		}
+
+		var result = _coordinator.ResolveConflict(dialog.KeepLocal);
+
+		if (result.IsFailed)
+		{
+			MessagePanel.AddError(result.Errors[0].Message, "PLC");
 		}
 	}
 

--- a/SemiStep/UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/UI/MainWindow/MainWindowViewModel.cs
@@ -165,7 +165,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		catch (Exception ex)
 		{
 			Log.Warning("Unexpected error while showing PLC conflict dialog: {Message}", ex.Message);
-			MessagePanel.AddError("Failed to show PLC conflict dialog — sync disabled", "PLC");
+			MessagePanel.AddError("Failed to show PLC conflict dialog", "PLC");
 
 			return;
 		}

--- a/SemiStep/UI/Plc/PlcConflictDialog.axaml.cs
+++ b/SemiStep/UI/Plc/PlcConflictDialog.axaml.cs
@@ -7,6 +7,8 @@ internal partial class PlcConflictDialog : Window
 {
 	public bool KeepLocal { get; private set; }
 
+	public bool Confirmed { get; private set; }
+
 	internal PlcConflictDialog()
 	{
 		InitializeComponent();
@@ -15,12 +17,14 @@ internal partial class PlcConflictDialog : Window
 	private void OnKeepLocalClick(object? sender, RoutedEventArgs e)
 	{
 		KeepLocal = true;
+		Confirmed = true;
 		Close();
 	}
 
 	private void OnLoadFromPlcClick(object? sender, RoutedEventArgs e)
 	{
 		KeepLocal = false;
+		Confirmed = true;
 		Close();
 	}
 }

--- a/SemiStep/UI/RecipeFile/RecipeFileViewModel.cs
+++ b/SemiStep/UI/RecipeFile/RecipeFileViewModel.cs
@@ -97,16 +97,17 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 
 	private async Task SaveToFileAsync(string filePath)
 	{
-		try
+		var result = await _coordinator.SaveRecipeAsync(filePath);
+
+		if (result.IsFailed)
 		{
-			await _coordinator.SaveRecipeAsync(filePath);
-			CurrentFilePath = filePath;
-			_messagePanel.AddInfo($"Saved: {Path.GetFileName(filePath)}", FileSource);
+			_messagePanel.AddError($"Failed to save recipe: {result.Errors[0].Message}", FileSource);
+
+			return;
 		}
-		catch (Exception ex)
-		{
-			_messagePanel.AddError($"Failed to save recipe: {ex.Message}", FileSource);
-		}
+
+		CurrentFilePath = filePath;
+		_messagePanel.AddInfo($"Saved: {Path.GetFileName(filePath)}", FileSource);
 	}
 
 	private async Task LoadRecipeAsync()
@@ -117,26 +118,29 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
-		try
+		var result = await _coordinator.LoadRecipeAsync(filePath);
+		if (result.IsFailed)
 		{
-			var result = await _coordinator.LoadRecipeAsync(filePath);
-			if (result.IsFailed)
-			{
-				return;
-			}
+			_messagePanel.AddError(result.Errors[0].Message, FileSource);
 
-			CurrentFilePath = filePath;
-			_messagePanel.AddInfo($"Loaded: {Path.GetFileName(filePath)}", FileSource);
+			return;
 		}
-		catch (Exception ex)
-		{
-			_messagePanel.AddError($"Failed to load recipe: {ex.Message}", FileSource);
-		}
+
+		CurrentFilePath = filePath;
+		_messagePanel.AddInfo($"Loaded: {Path.GetFileName(filePath)}", FileSource);
 	}
 
 	private void NewRecipe()
 	{
-		_coordinator.NewRecipe();
+		var result = _coordinator.NewRecipe();
+
+		if (result.IsFailed)
+		{
+			_messagePanel.AddError(result.Errors[0].Message, FileSource);
+
+			return;
+		}
+
 		CurrentFilePath = null;
 	}
 }

--- a/SemiStep/UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/UI/RecipeGrid/RecipeGridViewModel.cs
@@ -223,13 +223,11 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
-		try
+		var result = _coordinator.UpdateStepProperty(stepIndex, columnKey, value);
+
+		if (result.IsFailed)
 		{
-			_coordinator.UpdateStepProperty(stepIndex, columnKey, value);
-		}
-		catch (Exception ex)
-		{
-			_messagePanel.AddError($"Step {stepIndex + 1}: {ex.Message}", "RecipeGrid");
+			_messagePanel.AddError($"Step {stepIndex + 1}: {result.Errors[0].Message}", "RecipeGrid");
 		}
 	}
 
@@ -241,14 +239,12 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
-		try
-		{
-			_coordinator.ChangeStepAction(stepIndex, newActionId);
-		}
-		catch (Exception ex)
+		var result = _coordinator.ChangeStepAction(stepIndex, newActionId);
+
+		if (result.IsFailed)
 		{
 			_messagePanel.AddError(
-				$"Step {stepIndex + 1}: Failed to change action - {ex.Message}", "RecipeGrid");
+				$"Step {stepIndex + 1}: Failed to change action - {result.Errors[0].Message}", "RecipeGrid");
 		}
 	}
 


### PR DESCRIPTION
- All nine RecipeMutationCoordinator mutation methods: void -> Result; SaveRecipeAsync -> Task<Result>; NewRecipe and ResolveConflict return Result
- DomainFacade: SaveRecipeAsync wraps csv exceptions as ExceptionalError; SetNewRecipe and ResolveConflict return Result; PLC sync/connection concern extracted into PlcSyncFacade (300-line limit); MarkSaved called after PLC loads
- MessagePanelViewModel: self-marshal all public mutating methods via PostOnUiThread
- ViewModels: remove dead try/catch blocks; replace with result.IsFailed checks
- PlcConflictDialog: add Confirmed flag to prevent silent ResolveConflict on OS close
- Tests: assert returned Result in failure paths; add SaveRecipeAsync, ChangeStepAction, UpdateStepProperty failure tests; fix ResolveConflict signal tests