### PR TITLE
refactor: strip CancellationToken from public API boundaries

### DIFF
--- a/.github/instructions/csharp.instructions.md
+++ b/.github/instructions/csharp.instructions.md
@@ -2,6 +2,9 @@
 applyTo: "**/*.cs"
 ---
 
+<!-- Reviewer scope: apply these rules only to C# source files.
+     Do not review or comment on Markdown documents (plans, docs, README, etc.). -->
+
 # SemiStep — Copilot Code Review Instructions
 
 SemiStep is a recipe table editor/runtime for PLC integration (S7 protocol).
@@ -34,7 +37,6 @@ not personal preferences.
 - Throw exceptions only for truly exceptional conditions (programmer error, corrupted state).
 - Using exceptions for expected business logic failures (parsing, validation) is a finding.
 - Empty catch blocks (silently swallowing exceptions) are always a CRITICAL finding.
-- `OperationCanceledException` must be caught and rethrown before any broad `catch (Exception)`.
 
 ### Null safety
 

--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,5 @@ FodyWeavers.xsd
 
 # nuke
 .nuke/
+
+.opencode/package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,6 @@ SemiStep is a recipe table editor/runtime for PLC integration (S7 protocol).
 Platform: .NET 10, Windows, C# 14. UI: Avalonia 11.2 + ReactiveUI (MVVM).
 Solution: `SemiStep/SemiStep.slnx`. All commands run from repository root.
 
----
-
 ## Build
 
 ```powershell
@@ -14,8 +12,6 @@ dotnet build SemiStep/SemiStep.slnx                    # all projects
 dotnet run   --project SemiStep/Application/Application.csproj
 dotnet format SemiStep/SemiStep.slnx                   # pre-commit hook enforces this
 ```
-
----
 
 ## Test
 
@@ -36,8 +32,6 @@ directory and overlay only the differing files from `Tests/YamlConfigs/Invalid/{
 **Dispatcher flush in tests:** After awaiting `RecipeMutationCoordinator` async methods
 (`LoadRecipeAsync`, `LoadRecipeFromPlcAsync`), call `Dispatcher.UIThread.RunJobs(null)` before
 asserting on `MessagePanelViewModel` state to flush the pending Avalonia dispatcher queue.
-
----
 
 ## Code Style
 
@@ -114,7 +108,9 @@ No abbreviations in names.
 - Only for genuinely non-obvious business logic. No process notes (`// TODO`, `// in new version`).
 - English only.
 
----
+## Code investigation
+
+Whenever you need to explore code of nuget pkgs, get external methods signatures or explore external libs structure, first try to fetch information via mcp from github or webfetch or skills if any before trying to reverse engineer compiled files. The pkgs info may be retrieved from using directive or .csproj file.
 
 ## Troubleshooting
 

--- a/Docs/plans/completed/20260410-strip-cancellation-token-from-public-api.md
+++ b/Docs/plans/completed/20260410-strip-cancellation-token-from-public-api.md
@@ -1,0 +1,147 @@
+# Plan: Strip CancellationToken from Public API
+
+## Overview
+
+`CancellationToken` parameters exist throughout the public API surface (`ICsvService`,
+`IS7Service`, `IS7Driver`, `DomainFacade`) but are never supplied with a real token by any
+caller. They are decorative and create a false contract. Additionally, their presence produced
+several unguarded `OperationCanceledException` escape paths and one silent-swallow bug that
+were the subject of issue #4. Removing the tokens from the public boundary resolves issue #4
+completely without any new handling logic, and makes the API honest about its actual capabilities.
+
+The S7 internal layer (`PlcTransactionExecutor`, `PlcSyncExecutor`, `PlcExecutionMonitor`,
+`KeepAliveLoopAsync`, `ReconnectLoopAsync`) owns real cancellation tokens for loop control and
+debounce — those are entirely untouched.
+
+## Solution Overview
+
+- Remove `CancellationToken` parameters from every public/internal interface and its
+  implementations, top-down: `ICsvService` → `IS7Service` → `IS7Driver` → `DomainFacade` →
+  `PlcLifecycleManager` → test stubs.
+- `S7Service`'s private `ConnectInternalAsync(CancellationToken ct)` keeps its parameter
+  because it is called by `ReconnectLoopAsync` with the reconnect loop's own token.
+  The public `ConnectAsync` will call it with `CancellationToken.None`.
+- Similarly, `S7Service`'s four public methods forward to `PlcTransactionExecutor` (which
+  retains its internal tokens); they pass `CancellationToken.None` explicitly at the forwarding
+  call site, making intent clear.
+- The now-dead `catch (OperationCanceledException) { throw; }` in `DomainFacade.SaveRecipeAsync`
+  is removed. The `catch (Exception ex) when (ex is not OperationCanceledException)` guard in
+  `S7Service.ConnectInternalAsync` becomes a plain `catch (Exception ex)`.
+- `IS7Transport` (`ReadBytesAsync`, `WriteBytesAsync`), `PlcTransactionExecutor`, and all
+  S7 sync/monitor internals are out of scope and not modified.
+
+**Alternative considered and rejected:** Keeping the tokens and adding `Result.Fail("Operation cancelled")`
+catch clauses at every boundary. Rejected because it preserves dead parameters and adds noise
+for a capability that is not exercised anywhere in the application today.
+
+## Affected Files
+
+### Modified Files
+
+| File | Change |
+| ---- | ------ |
+| `SemiStep/TypesShared/Domain/ICsvService.cs` | Remove `CancellationToken` from `LoadAsync` and `SaveAsync` |
+| `SemiStep/Csv/CsvService.cs` | Remove `CancellationToken` from `LoadAsync` and `SaveAsync`; update call sites |
+| `SemiStep/Csv/CsvFileIo.cs` | Remove `CancellationToken` from `ReadRecipeFileAsync` and `WriteRecipeFileAsync`; update call sites |
+| `SemiStep/TypesShared/Domain/IS7Service.cs` | Remove `CancellationToken` from all four methods |
+| `SemiStep/S7/Facade/S7Service.cs` | Remove `CancellationToken` from public methods; pass `CancellationToken.None` to internal/executor calls; clean up `when (ex is not OperationCanceledException)` guard |
+| `SemiStep/S7/IS7Driver.cs` | Remove `CancellationToken` from `ConnectAsync` and `DisconnectAsync` |
+| `SemiStep/S7/S7Driver.cs` | Remove `CancellationToken` from `ConnectAsync` and `DisconnectAsync`; update `_plc.OpenAsync()` call |
+| `SemiStep/Domain/Facade/DomainFacade.cs` | Remove `CancellationToken` from `LoadRecipeAsync`, `SaveRecipeAsync`, `LoadRecipeFromPlcAsync`; remove dead OCE catch block in `SaveRecipeAsync` |
+| `SemiStep/Domain/Facade/PlcLifecycleManager.cs` | Remove `CancellationToken` from private `PerformReconnectReconciliationAsync`; update call sites |
+| `SemiStep/Tests/Helpers/StubIs7Service.cs` | Remove `CancellationToken` from all four `IS7Service` methods |
+| `SemiStep/Tests/Helpers/StubCsvService.cs` | Remove `CancellationToken` from `LoadAsync` and `SaveAsync` |
+| `SemiStep/Tests/Helpers/FailingCsvService.cs` | Remove `CancellationToken` from `LoadAsync` and `SaveAsync` |
+| `SemiStep/Tests/S7/Helpers/StubIs7ServiceForSync.cs` | Remove `CancellationToken` from all four `IS7Service` methods |
+| `SemiStep/Tests/S7/Helpers/FakeS7Driver.cs` | Remove `CancellationToken` from `ConnectAsync` and `DisconnectAsync` |
+
+## Tasks
+
+### Task 1: Strip CancellationToken from CSV layer
+
+**Files:**
+
+- Modify: `SemiStep/TypesShared/Domain/ICsvService.cs`
+- Modify: `SemiStep/Csv/CsvService.cs`
+- Modify: `SemiStep/Csv/CsvFileIo.cs`
+
+- [x] `ICsvService.LoadAsync`: remove `CancellationToken cancellationToken = default` parameter
+- [x] `ICsvService.SaveAsync`: remove `CancellationToken cancellationToken = default` parameter
+- [x] `CsvService.LoadAsync`: remove parameter; drop `cancellationToken` arg in `CsvFileIo.ReadRecipeFileAsync` call
+- [x] `CsvService.SaveAsync`: remove parameter; drop `cancellationToken` arg in `CsvFileIo.WriteRecipeFileAsync` call
+- [x] `CsvFileIo.ReadRecipeFileAsync`: remove parameter; change `File.ReadAllTextAsync(filePath, _fileEncoding, cancellationToken)` to `File.ReadAllTextAsync(filePath, _fileEncoding)`
+- [x] `CsvFileIo.WriteRecipeFileAsync`: remove parameter; change `writer.WriteAsync(csvBody.AsMemory(), cancellationToken)` to `writer.WriteAsync(csvBody.AsMemory())`
+
+### Task 2: Strip CancellationToken from S7 driver layer
+
+**Files:**
+
+- Modify: `SemiStep/S7/IS7Driver.cs`
+- Modify: `SemiStep/S7/S7Driver.cs`
+
+- [x] `IS7Driver.ConnectAsync`: remove `CancellationToken ct = default` parameter
+- [x] `IS7Driver.DisconnectAsync`: remove `CancellationToken ct = default` parameter
+- [x] `S7Driver.ConnectAsync`: remove parameter; change `await _plc.OpenAsync(ct)` to `await _plc.OpenAsync()`
+- [x] `S7Driver.DisconnectAsync`: remove parameter (body is synchronous `_plc?.Close()`, no other changes)
+
+### Task 3: Strip CancellationToken from IS7Service interface and S7Service
+
+**Files:**
+
+- Modify: `SemiStep/TypesShared/Domain/IS7Service.cs`
+- Modify: `SemiStep/S7/Facade/S7Service.cs`
+
+- [x] `IS7Service.ConnectAsync`: remove `CancellationToken ct = default` parameter
+- [x] `IS7Service.DisconnectAsync`: remove `CancellationToken ct = default` parameter
+- [x] `IS7Service.ReadManagingAreaAsync`: remove `CancellationToken ct = default` parameter
+- [x] `IS7Service.ReadRecipeFromPlcAsync`: remove `CancellationToken ct = default` parameter
+- [x] `S7Service.ConnectAsync`: remove parameter; call `ConnectInternalAsync(CancellationToken.None)`
+- [x] `S7Service.DisconnectAsync`: remove parameter; call `transport.DisconnectAsync(CancellationToken.None)` (the IS7Driver.DisconnectAsync no-CT overload used after Task 2)
+- [x] `S7Service.ReadManagingAreaAsync`: remove parameter; call `transactionExecutor.ReadManagingAreaAsync(CancellationToken.None)`
+- [x] `S7Service.ReadRecipeFromPlcAsync`: remove parameter; call `transactionExecutor.ReadRecipeFromPlcAsync(CancellationToken.None)`
+- [x] `S7Service.ConnectInternalAsync` (private): **keep signature unchanged** — still `private async Task ConnectInternalAsync(CancellationToken ct)`
+- [x] `S7Service.ConnectInternalAsync`: change `catch (Exception ex) when (ex is not OperationCanceledException)` to plain `catch (Exception ex)` — guard is no longer meaningful since the only external entry point passes `CancellationToken.None` (internal reconnect loop still uses its own token, but that exception will propagate naturally out of `ReconnectLoopAsync` where it is already caught)
+
+### Task 4: Strip CancellationToken from DomainFacade
+
+**Files:**
+
+- Modify: `SemiStep/Domain/Facade/DomainFacade.cs`
+
+- [x] `LoadRecipeAsync`: remove `CancellationToken ct = default` parameter; drop `ct` from `_csvService.LoadAsync` call
+- [x] `SaveRecipeAsync`: remove `CancellationToken ct = default` parameter; drop `ct` from `_csvService.SaveAsync` call; remove the dead `catch (OperationCanceledException) { throw; }` clause entirely
+- [x] `LoadRecipeFromPlcAsync`: remove `CancellationToken ct = default` parameter; drop `ct` from `_connectionService.ReadRecipeFromPlcAsync` call
+
+### Task 5: Strip CancellationToken from PlcLifecycleManager
+
+**Files:**
+
+- Modify: `SemiStep/Domain/Facade/PlcLifecycleManager.cs`
+
+- [x] `PerformReconnectReconciliationAsync` (private): remove `CancellationToken ct = default` parameter
+- [x] Update call to `connectionService.ReadManagingAreaAsync(ct)` → `connectionService.ReadManagingAreaAsync()`
+- [x] Update call to `connectionService.ReadRecipeFromPlcAsync(ct)` → `connectionService.ReadRecipeFromPlcAsync()`
+
+### Task 6: Update test stubs and fakes
+
+**Files:**
+
+- Modify: `SemiStep/Tests/Helpers/StubIs7Service.cs`
+- Modify: `SemiStep/Tests/Helpers/StubCsvService.cs`
+- Modify: `SemiStep/Tests/Helpers/FailingCsvService.cs`
+- Modify: `SemiStep/Tests/S7/Helpers/StubIs7ServiceForSync.cs`
+- Modify: `SemiStep/Tests/S7/Helpers/FakeS7Driver.cs`
+
+- [x] `StubIs7Service`: remove `CancellationToken` from `ConnectAsync`, `DisconnectAsync`, `ReadManagingAreaAsync`, `ReadRecipeFromPlcAsync`
+- [x] `StubCsvService`: remove `CancellationToken` from `LoadAsync` and `SaveAsync`
+- [x] `FailingCsvService`: remove `CancellationToken` from `LoadAsync` and `SaveAsync`
+- [x] `StubIs7ServiceForSync`: remove `CancellationToken` from `ConnectAsync`, `DisconnectAsync`, `ReadManagingAreaAsync`, `ReadRecipeFromPlcAsync`
+- [x] `FakeS7Driver`: remove `CancellationToken` from `ConnectAsync` and `DisconnectAsync`
+
+### Task 7: Build and Test
+
+**Files:** (none)
+
+- [x] Run build: `dotnet build SemiStep/Application/Application.csproj`
+- [x] Run tests: `dotnet test SemiStep/Tests/Tests.csproj`
+- [x] All pass

--- a/SemiStep/Csv/CsvFileIo.cs
+++ b/SemiStep/Csv/CsvFileIo.cs
@@ -7,11 +7,9 @@ internal static class CsvFileIo
 {
 	private static readonly Encoding _fileEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
 
-	internal static async Task<(string Body, CsvMetadata Metadata)> ReadRecipeFileAsync(
-		string filePath,
-		CancellationToken cancellationToken = default)
+	internal static async Task<(string Body, CsvMetadata Metadata)> ReadRecipeFileAsync(string filePath)
 	{
-		var fullText = await File.ReadAllTextAsync(filePath, _fileEncoding, cancellationToken);
+		var fullText = await File.ReadAllTextAsync(filePath, _fileEncoding);
 
 		var (metadata, linesConsumed) = CsvMetadata.Deserialize(fullText);
 		var body = ExtractBody(fullText, linesConsumed);
@@ -22,8 +20,7 @@ internal static class CsvFileIo
 	internal static async Task WriteRecipeFileAsync(
 		string csvBody,
 		CsvMetadata metadata,
-		string filePath,
-		CancellationToken cancellationToken = default)
+		string filePath)
 	{
 		var tempPath = filePath + ".tmp";
 
@@ -34,7 +31,7 @@ internal static class CsvFileIo
 			await using (var writer = new StreamWriter(stream, _fileEncoding))
 			{
 				CsvMetadata.Serialize(writer, metadata);
-				await writer.WriteAsync(csvBody.AsMemory(), cancellationToken);
+				await writer.WriteAsync(csvBody.AsMemory());
 			}
 
 			File.Move(tempPath, filePath, overwrite: true);

--- a/SemiStep/Csv/CsvService.cs
+++ b/SemiStep/Csv/CsvService.cs
@@ -10,14 +10,14 @@ namespace Csv;
 
 internal sealed class CsvService(CsvFileSerializer csvFileSerializer) : ICsvService
 {
-	public async Task<Result<Recipe>> LoadAsync(string filePath, CancellationToken cancellationToken = default)
+	public async Task<Result<Recipe>> LoadAsync(string filePath)
 	{
 		if (!File.Exists(filePath))
 		{
 			return Result.Fail<Recipe>($"Recipe file not found: {filePath}");
 		}
 
-		var (bodyText, metadata) = await CsvFileIo.ReadRecipeFileAsync(filePath, cancellationToken);
+		var (bodyText, metadata) = await CsvFileIo.ReadRecipeFileAsync(filePath);
 		var result = csvFileSerializer.Deserialize(bodyText);
 
 		if (result.IsFailed)
@@ -38,12 +38,12 @@ internal sealed class CsvService(CsvFileSerializer csvFileSerializer) : ICsvServ
 		return okResult;
 	}
 
-	public async Task SaveAsync(Recipe recipe, string filePath, CancellationToken cancellationToken = default)
+	public async Task SaveAsync(Recipe recipe, string filePath)
 	{
 		var csvBody = csvFileSerializer.Serialize(recipe);
 		var metadata = CsvFileIo.BuildSaveMetadata(csvBody);
 
-		await CsvFileIo.WriteRecipeFileAsync(csvBody, metadata, filePath, cancellationToken);
+		await CsvFileIo.WriteRecipeFileAsync(csvBody, metadata, filePath);
 
 		Log.Information("Saved recipe to {FilePath}: {StepCount} steps", filePath, recipe.StepCount);
 	}

--- a/SemiStep/Domain/Facade/DomainFacade.cs
+++ b/SemiStep/Domain/Facade/DomainFacade.cs
@@ -191,9 +191,9 @@ public sealed class DomainFacade : IDisposable
 		return Result.Ok().WithReasons(snapshot.Reasons);
 	}
 
-	public async Task<Result> LoadRecipeAsync(string filePath, CancellationToken ct = default)
+	public async Task<Result> LoadRecipeAsync(string filePath)
 	{
-		var loadResult = await _csvService.LoadAsync(filePath, ct);
+		var loadResult = await _csvService.LoadAsync(filePath);
 		if (loadResult.IsFailed)
 		{
 			return loadResult.ToResult();
@@ -223,18 +223,14 @@ public sealed class DomainFacade : IDisposable
 		return Result.Ok().WithReasons(snapshot.Reasons);
 	}
 
-	public async Task<Result> SaveRecipeAsync(string filePath, CancellationToken ct = default)
+	public async Task<Result> SaveRecipeAsync(string filePath)
 	{
 		try
 		{
-			await _csvService.SaveAsync(_stateManager.Current, filePath, ct);
+			await _csvService.SaveAsync(_stateManager.Current, filePath);
 			_stateManager.MarkSaved();
 
 			return Result.Ok();
-		}
-		catch (OperationCanceledException)
-		{
-			throw;
 		}
 		catch (Exception ex)
 		{
@@ -283,9 +279,9 @@ public sealed class DomainFacade : IDisposable
 		await _plcLifecycleManager.DisableSync();
 	}
 
-	public async Task<Result> LoadRecipeFromPlcAsync(CancellationToken ct = default)
+	public async Task<Result> LoadRecipeFromPlcAsync()
 	{
-		var loadResult = await _connectionService.ReadRecipeFromPlcAsync(ct);
+		var loadResult = await _connectionService.ReadRecipeFromPlcAsync();
 		if (loadResult.IsFailed)
 		{
 			return loadResult.ToResult();

--- a/SemiStep/Domain/Facade/PlcLifecycleManager.cs
+++ b/SemiStep/Domain/Facade/PlcLifecycleManager.cs
@@ -129,9 +129,9 @@ internal sealed class PlcLifecycleManager(
 		}
 	}
 
-	private async Task PerformReconnectReconciliationAsync(CancellationToken ct = default)
+	private async Task PerformReconnectReconciliationAsync()
 	{
-		var managingAreaResult = await connectionService.ReadManagingAreaAsync(ct);
+		var managingAreaResult = await connectionService.ReadManagingAreaAsync();
 		if (managingAreaResult.IsFailed)
 		{
 			Log.Warning(
@@ -147,7 +147,7 @@ internal sealed class PlcLifecycleManager(
 			return;
 		}
 
-		var plcRecipeResult = await connectionService.ReadRecipeFromPlcAsync(ct);
+		var plcRecipeResult = await connectionService.ReadRecipeFromPlcAsync();
 		if (plcRecipeResult.IsFailed)
 		{
 			Log.Warning(

--- a/SemiStep/S7/Facade/S7Service.cs
+++ b/SemiStep/S7/Facade/S7Service.cs
@@ -67,15 +67,15 @@ internal sealed class S7Service(
 
 	public event Action<PlcConnectionState>? StateChanged;
 
-	public async Task ConnectAsync(PlcConnectionSettings settings, CancellationToken ct = default)
+	public async Task ConnectAsync(PlcConnectionSettings settings)
 	{
 		_settings = settings;
 		_autoReconnectEnabled = true;
 
-		await ConnectInternalAsync(ct);
+		await ConnectInternalAsync();
 	}
 
-	public async Task DisconnectAsync(CancellationToken ct = default)
+	public async Task DisconnectAsync()
 	{
 		_autoReconnectEnabled = false;
 		var reconnectTaskToAwait = StopReconnectLoop();
@@ -106,30 +106,30 @@ internal sealed class S7Service(
 
 		if (transport.IsConnected)
 		{
-			await transport.DisconnectAsync(ct);
+			await transport.DisconnectAsync();
 		}
 
 		State = PlcConnectionState.Disconnected;
 		Log.Information("Disconnected from PLC");
 	}
 
-	public async Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync(CancellationToken ct = default)
+	public async Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync()
 	{
-		var result = await transactionExecutor.ReadManagingAreaAsync(ct);
+		var result = await transactionExecutor.ReadManagingAreaAsync();
 		if (result.IsFailed)
 		{
-			Log.Warning("Failed to read managing area from PLC: {Reason}", result.Errors[0].Message);
+			Log.Warning("Failed to read managing area from PLC: {Reason}", result.Errors.FirstOrDefault()?.Message ?? "(no message)");
 			return result.ToResult<PlcManagingAreaState>();
 		}
 		return result;
 	}
 
-	public async Task<Result<Recipe>> ReadRecipeFromPlcAsync(CancellationToken ct = default)
+	public async Task<Result<Recipe>> ReadRecipeFromPlcAsync()
 	{
-		var result = await transactionExecutor.ReadRecipeFromPlcAsync(ct);
+		var result = await transactionExecutor.ReadRecipeFromPlcAsync();
 		if (result.IsFailed)
 		{
-			Log.Warning("Failed to read recipe from PLC: {Reason}", result.Errors[0].Message);
+			Log.Warning("Failed to read recipe from PLC: {Reason}", result.Errors.FirstOrDefault()?.Message ?? "(no message)");
 		}
 		return result;
 	}
@@ -158,7 +158,7 @@ internal sealed class S7Service(
 		}
 	}
 
-	private async Task ConnectInternalAsync(CancellationToken ct)
+	private async Task ConnectInternalAsync()
 	{
 		if (_settings is null)
 		{
@@ -170,14 +170,14 @@ internal sealed class S7Service(
 
 		try
 		{
-			await transport.ConnectAsync(_settings, ct);
+			await transport.ConnectAsync(_settings);
 			State = PlcConnectionState.Connected;
 			Log.Information("Connected to PLC at {IpAddress}", _settings.IpAddress);
 
 			executionMonitor.Start();
 			StartKeepAlive();
 		}
-		catch (Exception ex) when (ex is not OperationCanceledException)
+		catch (Exception ex)
 		{
 			State = PlcConnectionState.Disconnected;
 			Log.Error(ex, "Failed to connect to PLC at {IpAddress}", _settings.IpAddress);
@@ -279,7 +279,7 @@ internal sealed class S7Service(
 			try
 			{
 				await Task.Delay(delay, ct);
-				await ConnectInternalAsync(ct);
+				await ConnectInternalAsync();
 
 				lock (_stateLock)
 				{

--- a/SemiStep/S7/IS7Driver.cs
+++ b/SemiStep/S7/IS7Driver.cs
@@ -4,7 +4,7 @@ namespace S7;
 
 internal interface IS7Driver : IS7Transport, IAsyncDisposable
 {
-	Task ConnectAsync(PlcConnectionSettings settings, CancellationToken ct = default);
+	Task ConnectAsync(PlcConnectionSettings settings);
 
-	Task DisconnectAsync(CancellationToken ct = default);
+	Task DisconnectAsync();
 }

--- a/SemiStep/S7/S7Driver.cs
+++ b/SemiStep/S7/S7Driver.cs
@@ -18,7 +18,7 @@ internal sealed class S7Driver : IS7Driver
 		}
 	}
 
-	public async Task ConnectAsync(PlcConnectionSettings settings, CancellationToken ct = default)
+	public async Task ConnectAsync(PlcConnectionSettings settings)
 	{
 		_plc = new Plc(
 			CpuType.S71500,
@@ -27,10 +27,10 @@ internal sealed class S7Driver : IS7Driver
 			(short)settings.Rack,
 			(short)settings.Slot);
 
-		await _plc.OpenAsync(ct);
+		await _plc.OpenAsync();
 	}
 
-	public Task DisconnectAsync(CancellationToken ct = default)
+	public Task DisconnectAsync()
 	{
 		_plc?.Close();
 		_plc = null;

--- a/SemiStep/Tests/Helpers/FailingCsvService.cs
+++ b/SemiStep/Tests/Helpers/FailingCsvService.cs
@@ -7,12 +7,12 @@ namespace Tests.Helpers;
 
 public sealed class FailingCsvService : ICsvService
 {
-	public Task<Result<Recipe>> LoadAsync(string filePath, CancellationToken cancellationToken = default)
+	public Task<Result<Recipe>> LoadAsync(string filePath)
 	{
 		return Task.FromResult(Result.Fail<Recipe>("FailingCsvService does not support loading."));
 	}
 
-	public Task SaveAsync(Recipe recipe, string filePath, CancellationToken cancellationToken = default)
+	public Task SaveAsync(Recipe recipe, string filePath)
 	{
 		throw new IOException("Simulated disk write failure.");
 	}

--- a/SemiStep/Tests/Helpers/StubCsvService.cs
+++ b/SemiStep/Tests/Helpers/StubCsvService.cs
@@ -7,12 +7,12 @@ namespace Tests.Helpers;
 
 public sealed class StubCsvService : ICsvService
 {
-	public Task<Result<Recipe>> LoadAsync(string filePath, CancellationToken cancellationToken = default)
+	public Task<Result<Recipe>> LoadAsync(string filePath)
 	{
 		throw new NotSupportedException("StubCsvService does not support loading.");
 	}
 
-	public Task SaveAsync(Recipe recipe, string filePath, CancellationToken cancellationToken = default)
+	public Task SaveAsync(Recipe recipe, string filePath)
 	{
 		throw new NotSupportedException("StubCsvService does not support saving.");
 	}

--- a/SemiStep/Tests/Helpers/StubIs7Service.cs
+++ b/SemiStep/Tests/Helpers/StubIs7Service.cs
@@ -36,17 +36,17 @@ public sealed class StubIs7Service : IS7Service
 		StateChanged?.Invoke(state);
 	}
 
-	public Task ConnectAsync(PlcConnectionSettings settings, CancellationToken ct = default)
+	public Task ConnectAsync(PlcConnectionSettings settings)
 	{
 		return Task.CompletedTask;
 	}
 
-	public Task DisconnectAsync(CancellationToken ct = default)
+	public Task DisconnectAsync()
 	{
 		return Task.CompletedTask;
 	}
 
-	public Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync(CancellationToken ct = default)
+	public Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync()
 	{
 		if (ManagingAreaToReturn is not null)
 		{
@@ -56,7 +56,7 @@ public sealed class StubIs7Service : IS7Service
 		return Task.FromResult(Result.Fail<PlcManagingAreaState>("Not connected"));
 	}
 
-	public Task<Result<Recipe>> ReadRecipeFromPlcAsync(CancellationToken ct = default)
+	public Task<Result<Recipe>> ReadRecipeFromPlcAsync()
 	{
 		if (RecipeToReturn is not null)
 		{

--- a/SemiStep/Tests/S7/Helpers/FakeS7Driver.cs
+++ b/SemiStep/Tests/S7/Helpers/FakeS7Driver.cs
@@ -45,13 +45,13 @@ internal sealed class FakeS7Driver : IS7Driver
 		_dbReadFactories[dbNumber] = responseFactory;
 	}
 
-	public Task ConnectAsync(PlcConnectionSettings settings, CancellationToken ct = default)
+	public Task ConnectAsync(PlcConnectionSettings settings)
 	{
 		_connected = true;
 		return Task.CompletedTask;
 	}
 
-	public Task DisconnectAsync(CancellationToken ct = default)
+	public Task DisconnectAsync()
 	{
 		_connected = false;
 		return Task.CompletedTask;

--- a/SemiStep/Tests/S7/Helpers/StubIs7ServiceForSync.cs
+++ b/SemiStep/Tests/S7/Helpers/StubIs7ServiceForSync.cs
@@ -31,22 +31,22 @@ internal sealed class StubIs7ServiceForSync : IS7Service
 		_connected = connected;
 	}
 
-	public Task ConnectAsync(PlcConnectionSettings settings, CancellationToken ct = default)
+	public Task ConnectAsync(PlcConnectionSettings settings)
 	{
 		return Task.CompletedTask;
 	}
 
-	public Task DisconnectAsync(CancellationToken ct = default)
+	public Task DisconnectAsync()
 	{
 		return Task.CompletedTask;
 	}
 
-	public Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync(CancellationToken ct = default)
+	public Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync()
 	{
 		return Task.FromResult(Result.Fail<PlcManagingAreaState>("Not connected"));
 	}
 
-	public Task<Result<Recipe>> ReadRecipeFromPlcAsync(CancellationToken ct = default)
+	public Task<Result<Recipe>> ReadRecipeFromPlcAsync()
 	{
 		return Task.FromResult(Result.Fail<Recipe>("Not connected"));
 	}

--- a/SemiStep/TypesShared/Domain/ICsvService.cs
+++ b/SemiStep/TypesShared/Domain/ICsvService.cs
@@ -6,7 +6,7 @@ namespace TypesShared.Domain;
 
 public interface ICsvService
 {
-	Task<Result<Recipe>> LoadAsync(string filePath, CancellationToken cancellationToken = default);
+	Task<Result<Recipe>> LoadAsync(string filePath);
 
-	Task SaveAsync(Recipe recipe, string filePath, CancellationToken cancellationToken = default);
+	Task SaveAsync(Recipe recipe, string filePath);
 }

--- a/SemiStep/TypesShared/Domain/IS7Service.cs
+++ b/SemiStep/TypesShared/Domain/IS7Service.cs
@@ -11,8 +11,8 @@ public interface IS7Service : IAsyncDisposable
 	bool IsRecipeActive { get; }
 	IObservable<PlcExecutionInfo> ExecutionState { get; }
 	event Action<PlcConnectionState>? StateChanged;
-	Task ConnectAsync(PlcConnectionSettings settings, CancellationToken ct = default);
-	Task DisconnectAsync(CancellationToken ct = default);
-	Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync(CancellationToken ct = default);
-	Task<Result<Recipe>> ReadRecipeFromPlcAsync(CancellationToken ct = default);
+	Task ConnectAsync(PlcConnectionSettings settings);
+	Task DisconnectAsync();
+	Task<Result<PlcManagingAreaState>> ReadManagingAreaAsync();
+	Task<Result<Recipe>> ReadRecipeFromPlcAsync();
 }

--- a/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
+++ b/SemiStep/UI/Coordinator/RecipeMutationCoordinator.cs
@@ -9,7 +9,6 @@ using ReactiveUI;
 
 using TypesShared.Config;
 using TypesShared.Core;
-using TypesShared.Domain;
 using TypesShared.Plc;
 
 using UI.MessageService;

--- a/SemiStep/UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/UI/RecipeGrid/RecipeGridViewModel.cs
@@ -151,37 +151,30 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 		{
 			case MutationSignal.PropertyUpdated(var stepIndex):
 				UpdateSingleRowInPlace(recipe, stepIndex);
-
 				break;
 
 			case MutationSignal.StepAppended(var index):
 				AppendRow(recipe, index);
-
 				break;
 
 			case MutationSignal.StepsInserted(var startIndex, var count):
 				InsertRows(recipe, startIndex, count);
-
 				break;
 
 			case MutationSignal.StepRemoved(var removedIndex):
 				RemoveRow(removedIndex);
-
 				break;
 
 			case MutationSignal.StepsRemoved(var removedIndices):
 				RemoveRows(removedIndices);
-
 				break;
 
 			case MutationSignal.StepActionChanged(var stepIndex):
 				RebuildRow(recipe, stepIndex);
-
 				break;
 
 			case MutationSignal.RecipeReplaced:
 				FullRebuild(recipe);
-
 				break;
 
 			case MutationSignal.MetadataChanged:
@@ -189,7 +182,6 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 
 			default:
 				FullRebuild(recipe);
-
 				break;
 		}
 


### PR DESCRIPTION
## Summary

- `CancellationToken` parameters existed on all public API surfaces (`ICsvService`, `IS7Service`, `IS7Driver`, `DomainFacade`, `PlcLifecycleManager`) but were always called with `default` — no real `CancellationTokenSource` was ever created by any caller.
- Their presence created unguarded `OperationCanceledException` escape paths and one silent-swallow bug in `S7Service`.
- Removes all `CancellationToken` parameters from the public API; simplifies the exception filter in `S7Service.ConnectInternalAsync` from `when (ex is not OperationCanceledException)` to a plain `catch`; fixes an unguarded `result.Errors[0]` index access.
- The internal S7 sync/reconnect layer (`PlcTransactionExecutor`, `PlcSyncExecutor`, `PlcExecutionMonitor`, keep-alive and reconnect loops) retains its own real tokens — entirely untouched.

Closes #4
