### PR TITLE
Migrate ComboBox columns to CellTemplate + Avalonia 12 stack modernization

### DIFF
--- a/.github/instructions/csharp.instructions.md
+++ b/.github/instructions/csharp.instructions.md
@@ -8,7 +8,7 @@ applyTo: "**/*.cs"
 # SemiStep — Copilot Code Review Instructions
 
 SemiStep is a recipe table editor/runtime for PLC integration (S7 protocol).
-Platform: .NET 10, C# 14, Avalonia 11.3.13, ReactiveUI (MVVM).
+Platform: .NET 10, C# 14, Avalonia 12.0.3, ReactiveUI.Avalonia (MVVM).
 
 ---
 

--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -3,7 +3,7 @@
 		"label": "Launch SemiStep.UI",
 		"adapter": "netcoredbg",
 		"request": "launch",
-		"program": "${ZED_WORKTREE_ROOT}/SemiStep/Artifacts/bin/SemiStep.UI/debug/UI.dll",
+		"program": "${ZED_WORKTREE_ROOT}/SemiStep/Artifacts/bin/SemiStep.UI/debug/SemiStep.UI.dll",
 		"cwd": "${ZED_WORKTREE_ROOT}/SemiStep/Artifacts/bin/SemiStep.UI/debug",
 		"stopAtEntry": false,
 		"build": "Build UI"

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -2,7 +2,7 @@
   {
     "label": "Build UI",
     "command": "dotnet",
-    "args": ["build", "SemiStep/UI/SemiStep.UI.csproj"],
+    "args": ["build", "SemiStep/SemiStep.UI/SemiStep.UI.csproj"],
     "cwd": "$ZED_WORKTREE_ROOT",
     "reveal": "always",
     "use_new_terminal": false,
@@ -17,7 +17,7 @@
   {
     "label": "Run UI",
     "command": "dotnet",
-    "args": ["run", "--project", "SemiStep/UI/SemiStep.UI.csproj"],
+    "args": ["run", "--project", "SemiStep/SemiStep.UI/SemiStep.UI.csproj"],
     "cwd": "$ZED_WORKTREE_ROOT",
     "reveal": "always",
     "use_new_terminal": true,
@@ -25,7 +25,7 @@
   {
     "label": "Test All",
     "command": "dotnet",
-    "args": ["test", "SemiStep/Tests/Tests.csproj"],
+    "args": ["test", "SemiStep/SemiStep.Tests/SemiStep.Tests.csproj"],
     "cwd": "$ZED_WORKTREE_ROOT",
   },
   {
@@ -33,7 +33,7 @@
     "command": "dotnet",
     "args": [
       "test",
-      "SemiStep/Tests/Tests.csproj",
+      "SemiStep/SemiStep.Tests/SemiStep.Tests.csproj",
       "--filter",
       "FullyQualifiedName~$ZED_STEM",
     ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Agent Instructions for SemiStep
 
 SemiStep is a recipe table editor/runtime for PLC integration (S7 protocol).
-Platform: .NET 10, Windows, C# 14. UI: Avalonia 11.2 + ReactiveUI (MVVM).
+Platform: .NET 10, Windows, C# 14. UI: Avalonia 12.0.3 + ReactiveUI (MVVM).
 Solution: `SemiStep/SemiStep.slnx`. All commands run from repository root.
 
 ## Build
@@ -29,9 +29,7 @@ Test traits: `[Trait("Component", "Core|Config|UI|Domain|Csv|S7")]`, `[Trait("Ar
 Invalid config test cases use an overlay pattern: copy `SemiStep.Tests/YamlConfigs/Standard/` to a temp
 directory and overlay only the differing files from `SemiStep.Tests/YamlConfigs/Invalid/{CaseName}/`.
 
-**Dispatcher flush in tests:** After awaiting `RecipeMutationCoordinator` async methods
-(`LoadRecipeAsync`, `LoadRecipeFromPlcAsync`), call `Dispatcher.UIThread.RunJobs(null)` before
-asserting on `MessagePanelViewModel` state to flush the pending Avalonia dispatcher queue.
+**Avalonia headless tests:** UI tests use `[AvaloniaFact]` / `[AvaloniaTheory]` (from `Avalonia.Headless.XUnit`) which wraps the full test lifecycle, including `IAsyncLifetime.InitializeAsync` and `DisposeAsync`, in the headless dispatcher. No manual `Dispatcher.UIThread.RunJobs(...)` or sync-over-async wrappers are needed.
 
 ## Code Style
 

--- a/Docs/07-non-functional.md
+++ b/Docs/07-non-functional.md
@@ -10,7 +10,7 @@
 |----------|----------|
 | ОС | Windows 10/11 |
 | Framework | .NET 10 |
-| UI Framework | Avalonia 11.2 |
+| UI Framework | Avalonia 12.0.2 |
 | Язык | C# 14 |
 
 ---
@@ -86,6 +86,133 @@
   Поведенческое изменение для рецептов, которые (непреднамеренно) полагались на прежнее суммирование — итоговая длительность таких рецептов уменьшится.
 - ⚠️ **Развёрнутый файл `C:\DISTR\Config\Semistep\connection\connection.yaml` ДОЛЖЕН быть мигрирован
   перед обновлением:** заменить `connection_protocol: S7` на `connection_protocol: "1.0"`. Без миграции загрузчик откажется стартовать.
+
+### Round-4 (Avalonia 11 → 12 миграция)
+
+- Все пакеты семейства Avalonia подняты с `11.3.13` до `12.0.2` (DataGrid — до `12.0.0`).
+  Транзитивно подтянут `Tmds.DBus.Protocol 0.21.3`, закрывающий security-advisory `NU1903`.
+- Пакет `Avalonia.Diagnostics` полностью удалён — в Avalonia 12 он заменён на `AvaloniaUI.DiagnosticsSupport`.
+  Поскольку код не вызывал `AttachDevTools()`, F12-инструментарий разработчика никогда не был задействован,
+  и замена не добавлена — лишний пакет не нужен. Если кому-то понадобится dev tools, добавить
+  `AvaloniaUI.DiagnosticsSupport` и вызов `AttachDeveloperTools()` в `App.axaml.cs`.
+- API клипборда изменился: `IClipboard.GetTextAsync()` → `IClipboard.TryGetTextAsync()`
+  (та же сигнатура `Task<string?>`, без поведенческих отличий). Затронут один call-site
+  (`SemiStep.UI/Clipboard/ClipboardViewModel.cs`); `ClipboardSerializer` (Core) не использует
+  Avalonia clipboard, его не трогали.
+- Compiled bindings включены по умолчанию в Avalonia 12; в `.axaml` файлах добавлены `x:DataType`
+  где требовалось для XAML-компиляции. Loose bindings больше не допустимы.
+- Безопасные сопутствующие bump'ы пакетов: YamlDotNet `16.3.0 → 17.1.0`,
+  System.Reactive `6.0.1 → 6.1.0`, Microsoft.NET.Test.Sdk `18.3.0 → 18.5.1`,
+  Microsoft.Extensions.DependencyInjection / Abstractions `10.0.5 → 10.0.7`,
+  System.IO.Hashing `10.0.5 → 10.0.7`.
+- UI-тесты под headless-режимом Avalonia 12 потребовали правок dispatcher-плана
+  (`SemiStep.Tests/Helpers/HeadlessDispatcher.cs` + три фикстуры с асинхронными
+  `Dispatcher.UIThread.RunJobs`-вызовами; удалён в Round-5). Поведение под windowed-runtime не меняется.
+- Пакет `Avalonia.ReactiveUI` на момент Round-4 оставался на `11.3.8` — его 12.x не публикуется,
+  пакет помечен deprecated. Полноценная миграция на преемника (`ReactiveUI.Avalonia`) выполнена
+  в Round-6.
+
+### Round-5 (xUnit v3 миграция и чистка тестов)
+
+- Тестовый проект `SemiStep.Tests` мигрирован с xUnit v2 (`xunit 2.9.3`) на xUnit v3 (`xunit.v3 3.2.2`)
+  с подключением пакета `Avalonia.Headless.XUnit 12.0.3` (потребовал форс-бамп `Avalonia.Headless`
+  с `12.0.2` до `12.0.3` ради транзитивного ограничения). `xunit.runner.visualstudio` оставлен
+  на `3.1.5` — уже v3-совместим.
+- **Корневая причина починена структурно.** Под Avalonia 12 `Dispatcher.RequestForegroundProcessing`
+  бросает NRE при любой попытке `Dispatcher.UIThread.Post(...)` вне session-scoped dispatcher'а.
+  Прежняя обёртка `HeadlessDispatcher.Run(...)` оборачивала только тело теста, но не
+  `IAsyncLifetime.InitializeAsync` / `DisposeAsync` и не конструктор тест-класса — что и приводило
+  к детерминированному NRE в `RecipeMutationCoordinatorTests` и периодическим зависаниям остальных
+  UI-тестов. Атрибут `[AvaloniaFact]` (из `Avalonia.Headless.XUnit`) оборачивает **весь жизненный
+  цикл теста** — конструктор, `InitializeAsync`, тело, `DisposeAsync` — в headless-диспетчере,
+  устраняя проблему на уровне инфраструктуры.
+- Хелпер `SemiStep.Tests/Helpers/HeadlessDispatcher.cs` удалён вместе со всеми вызовами
+  (`MessagePanelViewModelTests` — 26 сайтов, `RecipeMutationCoordinatorLoadRecipeTests` — 6,
+  `RecipeMutationCoordinatorTests` — 2). Тела тестов восстановлены как плоский `async Task` без
+  sync-over-async обёрток.
+- Атрибут `[assembly: CollectionBehavior(DisableTestParallelization = true)]` добавлен
+  **постоянно**, не как временная мера: `HeadlessUnitTestSession` существует в единственном
+  экземпляре на процесс и не переносит параллельного использования между коллекциями. Параллельный
+  прогон тестов в будущем — отдельная задача (per-collection sessions), не флаг.
+- Чистка тестов: 316 → 307. Сжаты Theory-консолидации в `MessagePanelViewModelTests`
+  (default-state факты), `RecipeRowViewModelTests` (`ColumnUnits_*`, `ColumnFormatKinds_*`)
+  и `CorePropertyStateTests`; удалены тривиальные одиночные assertion'ы. Более глубокое сжатие
+  отклонено сознательно — оставшиеся факты покрывают семантически разные setup-пути.
+- Все `Task.Delay(N)`-опросы наблюдаемого состояния (11 сайтов в `PlcLifecycleManagerReconnectTests`,
+  `S7ServiceTests`, `PlcSyncCoordinatorTests`, `PlcExecutionMonitorTests`) заменены на
+  `TestHelpers.WaitUntilAsync(predicate, timeout, pollInterval, CancellationToken)` — predicate-based
+  ожидание с монотонным `Stopwatch` и поддержкой `CancellationToken`. Две `Task.Delay` оставлены
+  с пояснительными комментариями: один — окно измерения частоты опроса (SUT-внутренний таймер),
+  второй — defensive-settle для негативного утверждения «событие не произошло».
+- Все предупреждения `xUnit1051` (`CancellationToken` не пробрасывается в `await`-вызовы)
+  устранены — суммарно 19 → 0 за счёт явной передачи `TestContext.Current.CancellationToken`.
+- Финальный прогон: 307/307 зелёные, ~8–10 секунд на чистой машине, детерминированно в 3 запусках
+  подряд.
+- Пакет `Avalonia.ReactiveUI` на момент Round-5 ещё оставался на `11.3.8` (deprecated) — миграция
+  на преемника `ReactiveUI.Avalonia` выполнена в Round-6.
+
+### Round-6 (миграция Avalonia.ReactiveUI → ReactiveUI.Avalonia)
+
+- Пакет `Avalonia.ReactiveUI 11.3.8` (поддерживался командой Avalonia, помечен deprecated на NuGet)
+  заменён на его преемника `ReactiveUI.Avalonia 12.0.1` (поддерживается командой ReactiveUI;
+  обратите внимание на перестановку слов в имени пакета). Совместим с Avalonia 12.0.2.
+- Изменение namespace: `using Avalonia.ReactiveUI;` → `using ReactiveUI.Avalonia;` в трёх файлах
+  (`SemiStep.UI/App.axaml.cs`, `SemiStep.UI/MainWindow/MainWindow.axaml.cs`,
+  `SemiStep.Tests/TestAppBuilder.cs`).
+- **Скрытые breaking changes** при апгрейде транзитивно подтянутого `ReactiveUI 23.x`:
+  - Тип `RxApp` удалён, заменён на `RxSchedulers` (тот же namespace `ReactiveUI`).
+    Затронуто 7 ViewModel'ей: `MainWindowViewModel`, `RecipeCommandsViewModel`,
+    `RecipeGridViewModel`, `RecipeFileViewModel`, `ClipboardViewModel`, `PlcMonitorViewModel`,
+    `RecipeMutationCoordinator` — ~18 замен `RxApp.MainThreadScheduler` → `RxSchedulers.MainThreadScheduler`.
+  - `DisposeWith(IDisposable, CompositeDisposable)` extension переехал в namespace
+    `System.Reactive.Disposables.Fluent` (из `System.Reactive.Disposables`). Добавлен новый
+    `using System.Reactive.Disposables.Fluent;` в 8 файлах, использующих `.DisposeWith(disposables)`.
+  - `AppBuilder.UseReactiveUI()` теперь требует обязательный параметр `Action<ReactiveUIBuilder>`.
+    Заменено на `.UseReactiveUI(_ => { })` в `App.axaml.cs:58` и `TestAppBuilder.cs:19`.
+- Прогон тестов после миграции: 307/307 зелёные, поведение не изменилось.
+
+### Round-7 (scroll-perf фиксы и патч-бампы пакетов)
+
+- **Массовые патч-бампы пакетов.** Семейство Avalonia поднято с `12.0.2` до `12.0.3`
+  (`Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`, `Avalonia.Win32`,
+  `Avalonia.HarfBuzz`). Семейство `Microsoft.Extensions.*` унифицировано на `10.0.8`
+  (`Microsoft.Extensions.DependencyInjection` / `.Abstractions` c `10.0.7`,
+  `Microsoft.Extensions.Logging` / `.Abstractions` c `10.0.5` — устранён трёхпатчевый
+  отставание). `FluentAssertions` поднят `8.9.0 → 8.10.0`, `System.IO.Hashing`
+  `10.0.7 → 10.0.8`. `Serilog.Extensions.Logging` обновлён `9.0.2 → 10.0.0` —
+  major-бамп ради выравнивания с MEL10, фактического API-слома нет.
+  `Avalonia.Controls.DataGrid` оставлен на `12.0.0` (свежее не опубликовано),
+  `S7netplus 0.20.0` — последний релиз 2023 года.
+- **Утечка strong-ref в ComboBox-шаблоне action-колонки исправлена.** В
+  `ComboBoxCellFactory` шаблон ячейки действия использовал
+  `comboBox.SelectionChanged += (_, _) => { ... row.SetPropertyValue(...) }`. Лямбда
+  захватывала `row` и никогда не отписывалась: ComboBox удерживал `row` через
+  делегат, `row` удерживал ComboBox через event-handler. При прокрутке грида
+  накапливались осиротевшие ComboBox'ы. Подписка заменена на `SelectedItem`
+  TwoWay-биндинг через `ComboBoxItemSelectionConverter` — жизненным циклом подписки
+  управляет Avalonia, цикл сильных ссылок исчезает.
+- **Re-entry guard в `MainWindow.BuildGrid`.** Добавлено поле `_columnsBuilt` в
+  `MainWindow.axaml.cs`: повторные вызовы `BuildGrid()` (например, при повторном
+  срабатывании `WhenActivated` в сценариях модальных окон / hide-show) возвращаются
+  немедленно, не пересоздавая колонки через `ColumnBuilder.BuildColumns`. Не утечка
+  по сути, но устраняет ненужную gen-0 churn от пересоздания шаблонов и
+  конвертеров. Добавлен идемпотентный тест на `ColumnBuilder.BuildColumns`.
+- **Allocation-hotspots в конвертерах сглажены.**
+  В `PropertyTimeMultiConverter.Convert` LINQ-проход
+  `values.Any(v => v == AvaloniaProperty.UnsetValue)` заменён на индексированный
+  `for`-цикл — устраняет аллокацию enumerator'а на каждую оценку привязки ячейки;
+  `ToString()` пропускается, если значение уже `string`.
+  В `TextCellFactory.CreateDisplayTemplate` для ключа `StepStartTimeColumnKey`
+  добавлен короткий путь: простой `Binding(nameof(RecipeRowViewModel.StepStartTime))`
+  напрямую к `TextBlock.Text` без обёртки `MultiBinding` + `PropertyTimeMultiConverter`.
+  Значение `StepStartTime` уже предформатировано во view-model — повторное форматирование
+  через конвертер было избыточным.
+- **Round-8 follow-up.** Полное включение `supportsRecycling: true` в шаблонах
+  editing/combo-ячеек требует переписывания замыканий по `row` в чистые биндинги.
+  XAML-шаблоны `<DataTemplate x:DataType="vm:RecipeRowViewModel" x:CompileBindings="True">`
+  ради compiled-bindings (вместо текущих reflection-based `new Binding(path)` из кода) —
+  отдельный объём работ. Manual scroll smoke с реальным рецептом ≥100 шагов остаётся
+  обязательной верификацией перед открытием PR (в headless не автоматизируется).
 
 ---
 

--- a/Docs/07-non-functional.md
+++ b/Docs/07-non-functional.md
@@ -277,14 +277,13 @@
   каноническое наблюдаемое — «клик по ячейке → popup открылся с первого раза» — не
   покрывается unit-тестами. Покрытие в Round-8 косвенное: assertion'ы на форму
   колонок (`IsReadOnly == true`, `CellEditingTemplate == null`, `CellTemplate != null`),
-  раунд-трип `ComboBoxItemMultiSelectionConverter`, регрессионная сетка существующих
-  тестов (309 baseline до Round-8, 351 после) обеспечивает биндинг-семантику
-  (action-change wiring, row rebuild, mutation-coordinator flows). Manual scroll/click
-  smoke (7 сценариев из плана —
+  раунд-трип `ComboBoxItemMultiSelectionConverter`, существующие 309 тестов работают
+  как regression-сеть для биндинг-семантики (action-change wiring, row rebuild,
+  mutation-coordinator flows). Manual scroll/click smoke (7 сценариев из плана —
   клик по action-ячейке, смена action → перестроение строки, клик по group-ячейке,
   disabled-state, RecipeActive read-only, скролл рецепта ≥100 шагов 30 сек) остаётся
   обязательной верификацией перед открытием PR.
-- Финальный прогон: 351/351 зелёных, `dotnet format --verify-no-changes` чистый,
+- Финальный прогон: 344/344 зелёных, `dotnet format --verify-no-changes` чистый,
   `dotnet build` 0 ошибок 0 предупреждений.
 
 ---

--- a/Docs/07-non-functional.md
+++ b/Docs/07-non-functional.md
@@ -10,7 +10,7 @@
 |----------|----------|
 | ОС | Windows 10/11 |
 | Framework | .NET 10 |
-| UI Framework | Avalonia 12.0.2 |
+| UI Framework | Avalonia 12.0.3 |
 | Язык | C# 14 |
 
 ---
@@ -213,6 +213,79 @@
   ради compiled-bindings (вместо текущих reflection-based `new Binding(path)` из кода) —
   отдельный объём работ. Manual scroll smoke с реальным рецептом ≥100 шагов остаётся
   обязательной верификацией перед открытием PR (в headless не автоматизируется).
+
+### Round-8 (ComboBox CellTemplate миграция + включение recycling)
+
+- **Регрессия Avalonia 12: `CellEditingTemplate` + ComboBox не работает.** После апгрейда
+  Avalonia 11 → 12 (Round-4) ComboBox внутри `DataGridTemplateColumn.CellEditingTemplate`
+  перестал реагировать на клики — popup не открывается ни при первом, ни при повторных
+  кликах по ячейке. Причина задокументирована в `AvaloniaUI/Avalonia.Controls.DataGrid#236`
+  и закрыта без апстрим-фикса. Промежуточный воркараунд из `dd0d7f7` (синхронная установка
+  `SelectedItem` в editing-template) снимал NRE при первом клике, но не решал основную
+  проблему — popup всё равно не открывался. Единственный рабочий паттерн в Avalonia 12,
+  подтверждённый официальными сэмплами (`NumericUpDown` в `CellEditingTemplate` — да,
+  ComboBox — нет), avalonia-docs и community-обсуждениями `#7086`/`#14103`, — это
+  размещение интерактивных ComboBox'ов **прямо в `CellTemplate`** при выставленном
+  `IsReadOnly = true` на колонке. Ячейка не проходит edit-mode lifecycle DataGrid'а;
+  ComboBox живёт в визуальном дереве с момента материализации строки, владеет своими
+  pointer-events и открывает popup на первом клике.
+- **Миграция шаблонов action/group ComboBox.** В `ComboBoxCellFactory` четыре шаблона
+  (display + edit × action + group) свёрнуты в два (`CellTemplate` × action + group).
+  Колонки помечены `IsReadOnly = true`, `CellEditingTemplate` снят. Шаблоны построены
+  как `FuncDataTemplate<RecipeRowViewModel>` без захвата `row` в замыкание — все
+  per-row данные текут через биндинги к свойствам `DataContext`.
+- **Включение `supportsRecycling: true` — закрытие Round-7 follow-up.** Round-7
+  оставил `supportsRecycling: false` на пяти шаблонах из-за замыканий на `row`
+  (resolving action id, group items list, write-back lambda). Round-8 структурно
+  устранил эти замыкания:
+  - Action items живут как глобальный кэш `_cachedActionItems` в инстансе
+    `ComboBoxCellFactory` — одинаковы для всех строк, лямбда захватывает константу,
+    не строку. `InvalidateCaches()` вызывается **только** из `ColumnBuilder.BuildColumns`
+    сразу после `grid.Columns.Clear()`; очистка колонок уничтожает все материализованные
+    ячейки, переиспользованной ячейки со stale-кэшом не существует.
+  - Group items вынесены из фабрики в view-model: `RecipeRowViewModel.GroupItemsByColumn`
+    (`IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>>`) строится
+    однократно в конструкторе строки рядом с `BuildColumnMetadata`. Action для строки
+    фиксирован на её время жизни (`MutationSignal.StepActionChanged` всегда пересоздаёт
+    строку через `RecipeGridViewModel.RebuildRow`), поэтому словарь иммутабельный.
+    ComboBox в group-шаблоне биндит `ItemsSource` к пути `GroupItemsByColumn[<key>]`.
+  - Для group-колонок введён `ComboBoxItemMultiSelectionConverter` (`IMultiValueConverter`):
+    source 0 — int id из `[<columnKey>]`, source 1 — список айтемов из
+    `GroupItemsByColumn[<columnKey>]`, прямое преобразование возвращает совпавший
+    `ComboBoxItemViewModel`, обратное — `[item.Id, BindingOperations.DoNothing]`.
+    Action-колонка осталась на одиночном `ComboBoxItemSelectionConverter` — у неё
+    список айтемов глобален.
+  - Сознательная регрессия аллокаций: ранее `_groupItemsByGroupName` кэш в фабрике
+    шарил списки между строками с одинаковым action. Теперь каждая строка строит
+    собственный — группы малы (<20 элементов), компромисс оправдан устранением
+    замыканий ради recycling. Если профилирование покажет горячую точку, кэш
+    реинтродуцируется на уровне registry (проекция — чистая функция от
+    `ActionDefinition` и group-данных).
+- **Disable-state через `IsHitTestVisible`, не `IsEnabled`.** Для read-only/disabled
+  ячеек ComboBox биндит `IsHitTestVisible` на `MultiBinding` (`HitTestVisibleMultiConverter`)
+  с двумя источниками: `CellStates[<columnKey>]` проектируется в bool через cell-state →
+  bool логику (Enabled → true), и `DataGrid.IsReadOnly` через `RelativeSource = FindAncestor`
+  с инверсией. Третий фактор — статический `isColumnReadOnly` — короткозамыкается на
+  константный `false`-биндинг при `true` (без MultiBinding'а вовсе). Выбор
+  `IsHitTestVisible` вместо `IsEnabled` сделан сознательно: Fluent-тема Avalonia
+  выкрашивает `IsEnabled = false` в серый — это визуальный регресс UX относительно
+  master. `IsHitTestVisible = false` сохраняет текущий рендер ComboBox'а, игнорируя
+  только клики. Полностью disabled-ячейки скрывают ComboBox целиком через стиль
+  `:cell-disabled > ComboBox { IsVisible: false }` в `Styles/DataGridStyles.axaml` —
+  без изменений.
+- **Headless ограничение.** Avalonia.Headless не симулирует hit-testing, поэтому
+  каноническое наблюдаемое — «клик по ячейке → popup открылся с первого раза» — не
+  покрывается unit-тестами. Покрытие в Round-8 косвенное: assertion'ы на форму
+  колонок (`IsReadOnly == true`, `CellEditingTemplate == null`, `CellTemplate != null`),
+  раунд-трип `ComboBoxItemMultiSelectionConverter`, регрессионная сетка существующих
+  тестов (309 baseline до Round-8, 351 после) обеспечивает биндинг-семантику
+  (action-change wiring, row rebuild, mutation-coordinator flows). Manual scroll/click
+  smoke (7 сценариев из плана —
+  клик по action-ячейке, смена action → перестроение строки, клик по group-ячейке,
+  disabled-state, RecipeActive read-only, скролл рецепта ≥100 шагов 30 сек) остаётся
+  обязательной верификацией перед открытием PR.
+- Финальный прогон: 351/351 зелёных, `dotnet format --verify-no-changes` чистый,
+  `dotnet build` 0 ошибок 0 предупреждений.
 
 ---
 

--- a/Docs/plans/20260514-combobox-celltemplate-migration.md
+++ b/Docs/plans/20260514-combobox-celltemplate-migration.md
@@ -1,0 +1,264 @@
+# ComboBox CellTemplate migration + recycling flip
+
+## Overview
+
+Fix a production-blocking regression introduced by the Avalonia 11 → 12 upgrade: ComboBoxes inside `DataGridTemplateColumn.CellEditingTemplate` no longer respond to clicks at all. This is `AvaloniaUI/Avalonia.Controls.DataGrid#236` — closed without resolution. The earlier NRE on first click (Round-7 + initial migration era) was fixed by setting `SelectedItem` synchronously in the editing-template lambda, but the popup-never-opens issue is structural in Avalonia 12.0.0 and cannot be patched within the `CellEditingTemplate` path.
+
+The canonical Avalonia 12 idiom — confirmed by official samples (only `NumericUpDown` is shown in `CellEditingTemplate`, never `ComboBox`), avalonia-docs, and accepted community answers in discussions #7086 / #14103 — is to put interactive ComboBoxes directly in `CellTemplate` with the column marked `IsReadOnly = true`. The cell does not go through DataGrid's edit-mode lifecycle at all; the ComboBox lives in the visual tree from row materialization, owns its pointer events, and opens its popup on the first click.
+
+In the same pass we close the Round-7-deferred recycling work. Round-7 explicitly left `supportsRecycling: false` on five templates because they captured `row` (action id, group items list, `SelectionChanged` write-back lambda). Round-7 fixed the strong-ref leak via TwoWay binding but kept `supportsRecycling: false` pending closure elimination. Switching to CellTemplate-only ComboBoxes eliminates the remaining `row` captures structurally — the lambda becomes a pure UI-shape factory, all per-row state flows through bindings against the cell's DataContext. `supportsRecycling: true` becomes safe.
+
+## Context (from discovery)
+
+Files involved:
+- `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs` — rewrite. Today: 4 templates (display + edit × action + group). After: 2 templates (CellTemplate × action + group).
+- `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs` — extend. Add a `GroupItemsByColumn` lookup so the group ComboBox binds `ItemsSource` instead of capturing the items list in a closure.
+- `SemiStep/SemiStep.UI/RecipeGrid/CellPresenter.cs` — likely unchanged. Already exposes `:cell-enabled/:cell-readonly/:cell-disabled` pseudo-classes for cell-state styling.
+- `SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs` — no logic change. `CreateActionColumn` / `CreateGroupComboBoxColumn` keep their signatures; the column shape they produce changes inside the factory.
+- `SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml` — likely unchanged. The `:cell-disabled > ComboBox` selector already hides the inner ComboBox; remains valid.
+- `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxItemSelectionConverter.cs` — unchanged. Same TwoWay int ↔ `ComboBoxItemViewModel` mapping.
+- `SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs` — verify still passes; may need an assertion on `IsReadOnly` if added.
+- `SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs`, `RecipeMutationCoordinatorTests.cs` — don't touch the factory; expected to pass unchanged.
+- `Docs/07-non-functional.md` — append Round-8 subsection summarizing this migration.
+
+Related patterns found:
+- `RecipeRowViewModel` already exposes `IReadOnlyDictionary<string, CellState>` (`CellStates`), `IReadOnlyDictionary<string, string?>` (`ColumnUnits`), `IReadOnlyDictionary<string, string>` (`ColumnFormatKinds`) — bindable via `[columnKey]` indexer paths. The new `GroupItemsByColumn` follows the same shape.
+- `RecipeRowViewModel.UpdateStep` raises `PropertyChanged("Item[]")` to invalidate all indexer-path bindings on row mutation. Same mechanism continues to work.
+- On `MutationSignal.StepActionChanged`, `RecipeGridViewModel.RebuildRow` disposes the old VM and constructs a new one with the new action — the new VM has new `GroupItemsByColumn` content. DataGrid sees `CollectionChanged.Replace` and re-renders the row from the CellTemplate against the new DataContext.
+
+Dependencies identified:
+- No package bumps. Avalonia 12.0.3 + `Avalonia.Controls.DataGrid 12.0.0` stay as-is.
+- No DI registration changes. No new services.
+- No XAML changes outside templates produced by the factory.
+
+## Development Approach
+
+- **Testing approach: Regular.** Avalonia headless does not simulate hit-testing, so the canonical observable — "click cell → dropdown opens on first click" — is not unit-testable. Tests verify what they can: factory contract (column has `CellTemplate`, no `CellEditingTemplate`, `IsReadOnly = true`), and indirect data-flow (action change still triggers `ActionChanged` event with new id). Click flow is manual verification at the end.
+- Complete each task fully before moving to the next. Build green and existing 309 tests pass after every task.
+- Run `dotnet build SemiStep/SemiStep.slnx` and `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` after each task; both must be green.
+- One commit per task (5 implementation commits + 1 verify + 1 docs/archive). No bundling — each task is self-contained.
+
+## Testing Strategy
+
+- **Unit tests stay at 309+.** The existing 309 tests already cover the behavioural surface this migration affects: action-change wiring, row rebuild on `StepActionChanged`, mutation-coordinator flows. They are the regression net for binding-equivalence — if our new binding shape diverges from current semantics, those tests fail.
+- **New assertions (Task 5):** add explicit `IsReadOnly == true` assertion on ComboBox columns built by `ColumnBuilder`, and shape-of-CellTemplate assertions where headless can introspect.
+- **No new e2e tests.** Project has no UI-based e2e harness today.
+- **Manual UI smoke (mandatory before PR open):**
+  1. Launch app against a real recipe.
+  2. Click an action cell → ComboBox dropdown opens **on the first click**.
+  3. Pick a different action → row rebuilds, group columns show the new groups, no flicker beyond the rebuild itself.
+  4. Click a group ComboBox cell → dropdown opens on the first click.
+  5. Set a row to a disabled state (via cell-state metadata) → ComboBox renders disabled, click does nothing.
+  6. Open a recipe and start it on PLC (`RecipeActive = true`) → all ComboBoxes disable; click does nothing. Stop the recipe → ComboBoxes re-enable.
+  7. Scroll a recipe with ≥100 rows continuously for ~30s. With recycling on, gen-0 churn should drop noticeably vs Round-7 baseline. Memory should plateau.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with `➕` prefix.
+- Document issues/blockers with `⚠️` prefix.
+- Keep this file in sync with actual work.
+
+## Solution Overview
+
+Replace `DataGridTemplateColumn { CellTemplate=TextBlock, CellEditingTemplate=ComboBox }` with `DataGridTemplateColumn { CellTemplate=ComboBox, IsReadOnly=true }` for action and group columns. The ComboBox is always materialized in the cell. DataGrid never enters edit mode for these columns, so the broken edit-template path is bypassed entirely.
+
+For the recycling flip to be safe, the template lambda must not capture `row`. Today it captures `row` for two purposes:
+1. Computing initial `SelectedItem` (group items list + selected id resolution) — eliminated by binding `SelectedItem` to `[columnKey]` via the existing `ComboBoxItemSelectionConverter`.
+2. Resolving the group items list (`GetOrCreateGroupItems(row, columnKey)`) — eliminated by exposing `row.GroupItemsByColumn[columnKey]` as a bindable property; ComboBox binds `ItemsSource` to that path. The dictionary is built once at row construction (same point where `ColumnUnits` and `ColumnFormatKinds` are built), since the action is fixed for the lifetime of a row VM (`MutationSignal.StepActionChanged` always rebuilds the row).
+
+For disable-when-grid-readonly, the ComboBox binds `IsEnabled` to a multi-source: cell state (from row indexer + converter) AND DataGrid's `IsReadOnly` (via `RelativeSource` ancestor). Column-level readonly is folded in as a static factor at template-build time.
+
+## Technical Details
+
+### New row property — `RecipeRowViewModel.GroupItemsByColumn`
+
+```csharp
+public IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupItemsByColumn { get; }
+```
+
+Built once at row construction by iterating `action.Properties`, resolving each property's `GroupName` through `recipeMetadataRegistry.GetGroup`, materializing the items list with `ComboBoxItemViewModel` projections. For columns with no group (string/numeric properties), the dictionary omits the key entirely — bindings against missing keys yield null which Avalonia treats as empty `ItemsSource`. Lifecycle is identical to `ColumnUnits` / `ColumnFormatKinds`.
+
+The factory-level `_groupItemsByGroupName` cache in `ComboBoxCellFactory` is removed (Task 4). **Deliberate allocation regression:** previously the cache shared group lists across all rows with the same action; now each row builds its own. Group sizes are small (<20 items typically) and the trade is justified by closure elimination — without it `supportsRecycling: true` is unsafe. If post-Round-8 profiling shows this dominates allocation, a registry-level cache can be reintroduced (the items projection is a pure function of `ActionDefinition` and the registry's group data).
+
+### Action ComboBox template (CellTemplate, recycling enabled)
+
+```csharp
+return new FuncDataTemplate<RecipeRowViewModel>((_, _) =>
+{
+    var comboBox = new ComboBox
+    {
+        ItemsSource = _cachedActionItems, // global, same for every row
+        DisplayMemberBinding = new Binding("DisplayText"),
+        Background = Brushes.Transparent,
+        BorderThickness = new Thickness(0),
+        HorizontalAlignment = HorizontalAlignment.Stretch,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    comboBox.Bind(ComboBox.SelectedItemProperty,
+        new Binding(ColumnTypes.ActionIndexerBindingPath)
+        {
+            Mode = BindingMode.TwoWay,
+            Converter = _actionSelectionConverter,
+        });
+
+    comboBox.Bind(ComboBox.IsHitTestVisibleProperty, BuildHitTestVisibleBinding(ColumnTypes.Action, isColumnReadOnly));
+
+    return CellPresenter.Wrap(comboBox, cellStateConverter);
+}, supportsRecycling: true);
+```
+
+`_cachedActionItems` (action items) is global per `ComboBoxCellFactory` instance. With recycling on, the lambda runs once and the ComboBox is reused across rows. `InvalidateCaches()` is called only from `ColumnBuilder.BuildColumns` / `BuildColumnsFromConfiguration` immediately after `grid.Columns.Clear()` — clearing columns destroys all materialized cells, so no recycled cell ever sees a stale cache. Safe.
+
+`BuildHitTestVisibleBinding(columnKey, isColumnReadOnly)` returns a `MultiBinding` combining:
+- `CellStates[columnKey]` (cell state) — projected through a converter to `bool` (true when `Enabled`)
+- `DataGrid.IsReadOnly` via `RelativeSource = new RelativeSource { Mode = FindAncestor, AncestorType = typeof(DataGrid) }` — negated in the multi-converter
+- Static `isColumnReadOnly` factor — when true, short-circuit to a constant `false` binding (skip MultiBinding entirely)
+
+**Visual semantics — keeping `IsHitTestVisible` over `IsEnabled` deliberately.** With `IsHitTestVisible = false` the ComboBox renders identically to the enabled state (same colors, same chrome) but ignores clicks — the current master behavior. With `IsEnabled = false` Avalonia's Fluent theme greys out the control. We preserve the current visual to avoid a UX regression for read-only/disabled cells. `:cell-disabled > ComboBox` style (DataGridStyles.axaml:63-65) still hides the ComboBox entirely for fully-disabled cells.
+
+**RelativeSource note**: ancestor lookup walks the visual tree at binding-attach time. For recycled cells, the binding re-evaluates on each visual-tree attach. Standard Avalonia behavior — no special handling needed.
+
+### Group ComboBox template (CellTemplate, recycling enabled)
+
+```csharp
+return new FuncDataTemplate<RecipeRowViewModel>((_, _) =>
+{
+    var comboBox = new ComboBox
+    {
+        DisplayMemberBinding = new Binding("DisplayText"),
+        Background = Brushes.Transparent,
+        BorderThickness = new Thickness(0),
+        HorizontalAlignment = HorizontalAlignment.Stretch,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    comboBox.Bind(ComboBox.ItemsSourceProperty,
+        new Binding($"GroupItemsByColumn[{columnKey}]"));
+
+    comboBox.Bind(ComboBox.SelectedItemProperty, BuildGroupSelectedItemBinding(columnKey));
+
+    comboBox.Bind(ComboBox.IsHitTestVisibleProperty, BuildHitTestVisibleBinding(columnKey, isColumnReadOnly));
+
+    return CellPresenter.Wrap(comboBox, cellStateConverter);
+}, supportsRecycling: true);
+```
+
+`BuildGroupSelectedItemBinding(columnKey)` returns a TwoWay `MultiBinding` using a new converter `ComboBoxItemMultiSelectionConverter`:
+
+- Source 0: `[columnKey]` — the int id from the row indexer.
+- Source 1: `GroupItemsByColumn[columnKey]` — the row's items list for this column.
+- `Convert(values)`: when `values[0] is int id` and `values[1] is IReadOnlyList<ComboBoxItemViewModel> items` → return `items.FirstOrDefault(x => x.Id == id)`. Otherwise `null`.
+- `ConvertBack(value)`: when `value is ComboBoxItemViewModel item` → return `[item.Id, BindingOperations.DoNothing]` (write only to source 0). Otherwise `[BindingOperations.DoNothing, BindingOperations.DoNothing]`.
+
+This is recycling-safe because both sources refresh on DataContext change. The action template keeps the existing `ComboBoxItemSelectionConverter` (single-binding) because its items list is global, captured in the lambda closure once.
+
+`BuildHitTestVisibleBinding` is the helper introduced in Task 2 (reused as-is — same shape works for both action and group columns).
+
+### Column shape change in `ColumnBuilder`
+
+Inside `CreateColumn`, action and group columns return `DataGridTemplateColumn { CellTemplate = …, IsReadOnly = true, … }`. The numbering column and text columns are untouched.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): row-VM extension, factory rewrite, ColumnBuilder column-shape change, tests for the factory contract, doc update.
+- **Post-Completion** (no checkboxes): manual UI verification scenarios listed in Testing Strategy.
+
+## Implementation Steps
+
+### Task 1: Add `GroupItemsByColumn` to `RecipeRowViewModel`
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs`
+
+- [ ] Add a private `_groupItemsByColumn` backing field populated by a new `BuildGroupItemsByColumn(ActionDefinition, RecipeMetadataRegistry)` static helper, called from the constructor next to the existing `BuildColumnMetadata` call.
+- [ ] Expose public `IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupItemsByColumn { get; }`.
+- [ ] The helper iterates `action.Properties`; for each property with a non-null `GroupName`, resolves the group via `recipeMetadataRegistry.GetGroup`; on success materializes a `List<ComboBoxItemViewModel>` (`new(kvp.Key, kvp.Value)`) ordered by `Id`; on failure inserts an empty list. For properties without a group, omit the key entirely — bindings against missing keys return null which Avalonia treats as empty `ItemsSource`.
+- [ ] Write tests: row with at least one group-bound property exposes a non-empty list under the property key; row with a non-group property has no key for that property; row with an action whose group does not resolve has an empty list under the key (negative path).
+- [ ] Run `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 309/309+ pass.
+
+### Task 2: Rewrite action ComboBox template (CellTemplate, recycling on)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs`
+- Possibly create: `SemiStep/SemiStep.UI/RecipeGrid/CellStateToBoolConverter.cs` (for the hit-test-visible multi-converter component, if no existing converter fits)
+- Possibly create: `SemiStep/SemiStep.UI/RecipeGrid/HitTestVisibleMultiConverter.cs` (multi-converter for the IsHitTestVisible binding)
+
+- [ ] In `ComboBoxCellFactory`, replace `CreateActionColumn` body to build a `DataGridTemplateColumn { Header, Tag, Width, IsReadOnly = true, CanUserSort = false, CellTemplate = CreateActionCellTemplate(columnDef.ReadOnly) }`. Remove `CellEditingTemplate` assignment.
+- [ ] Replace `CreateActionDisplayTemplate` and `CreateActionEditingTemplate` with a single private `CreateActionCellTemplate(bool isColumnReadOnly)` returning a `FuncDataTemplate<RecipeRowViewModel>` with `supportsRecycling: true`. No closure over `row`. ComboBox binds `SelectedItem` TwoWay via `ComboBoxItemSelectionConverter` (action items captured as a closure constant — same for every row, never mutates per-row).
+- [ ] Add `BuildHitTestVisibleBinding(string columnKey, bool isColumnReadOnly)` private helper. Returns either a constant `false` binding (when `isColumnReadOnly == true`) or a `MultiBinding` combining `CellStates[columnKey]` projected to bool (Enabled → true, else false) AND negated `DataGrid.IsReadOnly` from a `RelativeSource = new RelativeSource { Mode = FindAncestor, AncestorType = typeof(DataGrid) }`. The multi-converter ANDs the two sources.
+- [ ] Add unit tests for `HitTestVisibleMultiConverter.Convert`: (Enabled, gridReadOnly=false) → true; (Enabled, gridReadOnly=true) → false; (Disabled, _) → false; (Readonly, _) → false. ConvertBack is OneWay-only; return `BindingOperations.DoNothing` or throw `NotSupportedException`.
+- [ ] Run `dotnet build` + `dotnet test` — all green.
+
+### Task 3: Introduce `ComboBoxItemMultiSelectionConverter` and rewrite group template
+
+**Files:**
+- Create: `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxItemMultiSelectionConverter.cs`
+- Create: `SemiStep/SemiStep.Tests/UI/ComboBoxItemMultiSelectionConverterTests.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs`
+
+- [ ] Create `ComboBoxItemMultiSelectionConverter` implementing `IMultiValueConverter`. `Convert(values, ...)`: source 0 is the int id, source 1 is `IReadOnlyList<ComboBoxItemViewModel>` — return matching item or null. `ConvertBack(value, targetTypes, ...)`: when `value is ComboBoxItemViewModel item` return `new object?[] { item.Id, BindingOperations.DoNothing }`; otherwise both `DoNothing`.
+- [ ] Write tests: round-trip (int 7 with list → matching VM → int 7 back), missing id (int 99 not in list → null), null inputs, non-int source, ConvertBack with non-ComboBoxItemViewModel input → DoNothing.
+- [ ] Replace `CreateGroupComboBoxColumn` body to set `IsReadOnly = true` and only `CellTemplate = CreateGroupCellTemplate(columnDef.Key, columnDef.ReadOnly)`. Drop `CellEditingTemplate` assignment.
+- [ ] Replace `CreateGroupDisplayTemplate` and `CreateGroupEditingTemplate` with a single `CreateGroupCellTemplate(string columnKey, bool isColumnReadOnly)` returning a `FuncDataTemplate<RecipeRowViewModel>` with `supportsRecycling: true`. No closure over `row`.
+- [ ] ComboBox binds `ItemsSource` to path `GroupItemsByColumn[<columnKey>]` (string built once at template-build time).
+- [ ] ComboBox binds `SelectedItem` TwoWay using a `MultiBinding` with the new `ComboBoxItemMultiSelectionConverter`: source 0 is `[<columnKey>]`, source 1 is `GroupItemsByColumn[<columnKey>]`.
+- [ ] ComboBox binds `IsHitTestVisible` via `BuildHitTestVisibleBinding(columnKey, isColumnReadOnly)` from Task 2.
+- [ ] Run `dotnet build` + `dotnet test` — all green.
+
+### Task 4: Remove dead code (factory + row VM)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs`
+
+- [ ] In `ComboBoxCellFactory`: confirm `CreateActionDisplayTemplate`, `CreateActionEditingTemplate`, `CreateGroupDisplayTemplate`, `CreateGroupEditingTemplate`, `ResolveGroupDisplayText`, `GetOrCreateGroupItems`, and the `_groupItemsByGroupName` field are all removed (most should already be gone from Tasks 2–3; this task is the audit pass). `InvalidateCaches()` keeps only `_cachedActionItems = null`.
+- [ ] In `RecipeRowViewModel`: remove `GetGroupNameForColumn(string columnKey)` and `GetGroupItemsForColumn(string columnKey)` — no remaining production consumers after Task 1 added `GroupItemsByColumn` and Task 4 removed the factory's display template that called `GetGroupItemsForColumn` indirectly. Verify with grep before deleting.
+- [ ] In `RecipeRowViewModelTests`: remove tests covering the deleted methods (`RecipeRowViewModelTests.cs:197,207` neighborhood — locate exact tests by scanning the file).
+- [ ] Verify `using` directives in both files — drop unused ones.
+- [ ] Run `dotnet build` — 0 warnings, 0 errors. `dotnet test` — all green.
+
+### Task 5: Tests for column shape and binding wiring
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs` — add assertions on action/group column `IsReadOnly` and absence of `CellEditingTemplate`.
+- Possibly create: `SemiStep/SemiStep.Tests/UI/ComboBoxCellFactoryTests.cs` — direct tests on the factory if the existing `ColumnBuilder`-level coverage is insufficient.
+
+- [ ] In `ColumnBuilderIdempotencyTests`, add a test that the column produced for the action key has `IsReadOnly == true` and `CellEditingTemplate == null` and `CellTemplate != null`. Same for at least one group column.
+- [ ] Add a test that exercises the `ActionChanged` data-flow path: change `SelectedItem` on the ComboBox materialized from the template (use `IDataTemplate.Build(row)`); verify `row.ActionChanged` fires with the expected id. This covers the TwoWay binding contract without needing hit-test simulation.
+- [ ] If headless materialization of the template is awkward (binding evaluation needs visual tree), accept the limitation and document with a one-line `// Manual verification required: …` comment in the test seam.
+- [ ] Run `dotnet test` — all green.
+
+### Task 6: Verify acceptance criteria
+
+- [ ] `dotnet build SemiStep/SemiStep.slnx` — 0 errors, 0 warnings.
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 309/309+ green.
+- [ ] `dotnet format SemiStep/SemiStep.slnx --verify-no-changes` — pass.
+- [ ] `git diff master..HEAD --stat` review — scope confined to `RecipeRowViewModel.cs`, `ComboBoxCellFactory.cs`, `ColumnBuilderIdempotencyTests.cs`, `RecipeRowViewModelTests.cs`, optionally `ColumnBuilder.cs`, plan/docs files. No incidental edits.
+- [ ] Manual UI verification per the Testing Strategy section (7 scenarios). Document any deviation as `⚠️` in this file.
+
+### Task 7: Archive plan + document Round-8
+
+**Files:**
+- Move: `Docs/plans/20260514-combobox-celltemplate-migration.md` → `Docs/plans/completed/`
+- Modify: `Docs/07-non-functional.md`
+
+- [ ] `git mv Docs/plans/20260514-combobox-celltemplate-migration.md Docs/plans/completed/`
+- [ ] In `Docs/07-non-functional.md`, add a Round-8 subsection after Round-7 covering:
+  - Avalonia.Controls.DataGrid#236: `CellEditingTemplate` + ComboBox broken in 12.0.0, no upstream fix planned.
+  - Migration to CellTemplate-only ComboBoxes with `IsReadOnly = true` — the only working pattern in Avalonia 12 per official samples and accepted community answers.
+  - `supportsRecycling: true` flip across all four (now two) ComboBox templates — closes the Round-7-deferred recycling work. `row` closures eliminated by exposing `RecipeRowViewModel.GroupItemsByColumn` as a bindable lookup and introducing `ComboBoxItemMultiSelectionConverter` for the group case (action items remain global, no multi-binding needed).
+  - Disable-state binding switched to `IsHitTestVisible` (not `IsEnabled`) so disabled cells render with the same visual chrome as enabled cells — only clicks are ignored. Preserves master-branch visual UX.
+  - Manual smoke checklist for click flow, disabled-state behaviour, and `RecipeActive` read-only mode.
+
+## Post-Completion
+
+**Manual verification** (required before PR open):
+- The 7-scenario click/scroll smoke listed in Testing Strategy. Run against a real recipe with ≥100 steps.
+- Optional perf measurement: open Task Manager / dotnet-counters during the 30s scroll. Compare gen-0 collection rate vs Round-7 baseline. Bounded memory + lower gen-0 rate is the expected outcome of `supportsRecycling: true`.
+
+**External system updates:**
+- None. Internal UI fix + perf carry-over.

--- a/Docs/plans/completed/20260512-avalonia-12-migration.md
+++ b/Docs/plans/completed/20260512-avalonia-12-migration.md
@@ -1,0 +1,205 @@
+# Avalonia 11 → 12 migration
+
+## Overview
+
+Upgrade SemiStep from Avalonia `11.3.13` to `12.0.2` (current latest stable), plus the rest of the Dependabot batch that was closed automatically when PR #14 merged (`#16`). Reasons:
+
+- Pulls in patched `Tmds.DBus.Protocol` 0.21.3 transitively, closing `NU1903`.
+- Aligns SemiStep with the current Avalonia release line (faster releases promised for 12.x going forward).
+- Picks up the `IClipboard.GetTextAsync()` deprecation fix — currently a `CS0618` warning in `ClipboardViewModel.cs:110`.
+
+Three real breaking-change vectors based on prior research (verified by quick grep):
+
+1. **Clipboard API**: `IClipboard.GetTextAsync()` is gone in 12. Replaced by `IClipboard.TryGetTextAsync()` (returns nullable string). Our only call site is `SemiStep.UI/Clipboard/ClipboardViewModel.cs:110`. `ClipboardSerializer.cs` (Core) does NOT touch the Avalonia clipboard API — it's pure TSV serialization, no migration needed there. Narrower than originally feared.
+2. **`Avalonia.Diagnostics` package removed**: must be swapped for `AvaloniaUI.DiagnosticsSupport`. Note: `App.axaml.cs` does NOT call `AttachDevTools()` today (grep confirmed), so only the csproj reference needs to change. If we want to keep dev tools on `F12` we add `AttachDeveloperTools()` ourselves; otherwise just removing the package is also valid.
+3. **Compiled bindings on by default**: 11 `.axaml` files in `SemiStep.UI/`. Every binding must resolve at XAML compile time. Loose bindings (no `x:DataType`, wrong path, etc.) will fail the build. Audit is "fix until green", count unknown until first build.
+
+The other Avalonia 12 breaking changes do NOT affect SemiStep (verified by grep):
+- No `IBinding` / `InstancedBinding` usages in production code.
+- No `GotFocusEventArgs` / `RoutedEventArgs` for `LostFocus` handlers.
+- No `Direct2D1` references.
+- We don't use `Dispatcher.InvokeAsync` — only `Dispatcher.UIThread.Post` and `Dispatcher.UIThread.RunJobs`, both unchanged.
+
+## Context (from discovery)
+
+- **Branch:** `feature/avalonia-12-migration`, branched off `master` after PR #14 (architecture cleanup) and PR #15 (release-action v3) merged.
+- **Current state:** 316/316 tests green; `Avalonia 11.3.13` everywhere; `Avalonia.Diagnostics 11.3.13` referenced but never invoked.
+- **Clipboard usage** is localised to one file: `SemiStep.UI/Clipboard/ClipboardViewModel.cs` (private `IClipboard? _clipboard;`, `SetClipboard(IClipboard?)`, `var csvText = await _clipboard.GetTextAsync();`).
+- **11 `.axaml` files** under `SemiStep.UI/`: scope of compiled-binding audit.
+- **No Direct2D, no IBinding, no GotFocusEventArgs** in this codebase.
+- **No e2e tests**; UI smoke is manual.
+
+## Development Approach
+
+- **Testing approach:** Regular. Implementation is mostly mechanical (package bumps, API swap, XAML attribute audit). Existing 316 tests are the regression net for non-UI behaviour; XAML compile errors surface UI binding issues at build time.
+- Complete each task fully before moving to the next.
+- Run `dotnet build SemiStep/SemiStep.slnx` and `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` after each task; both must be green.
+- Stage changes per task. New commits land on `feature/avalonia-12-migration`.
+
+## Testing Strategy
+
+- **Unit / integration tests**: existing 316 tests cover Core. They must stay green. The Avalonia migration touches UI mainly — most tests won't even rebuild against the new Avalonia.
+- **XAML compile**: `dotnet build` is the test for binding correctness. If the build is green after Task 3, compiled bindings are happy.
+- **Manual UI smoke** (Post-Completion): launch the app, open a recipe, exercise clipboard copy/paste, verify grid renders, verify dialogs. Avalonia 12 changes have visible effects only at runtime; the suite cannot catch them.
+- **New tests**: not required by this plan — none of the changes introduce new behaviour, only swap APIs. Existing `ClipboardSerializerTests` (if any) keep working because `ClipboardSerializer` does not touch Avalonia.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with `➕` prefix (likely candidate: stray XAML binding fixes discovered during Task 3).
+- Document issues/blockers with `⚠️` prefix.
+- Keep this file in sync with actual work.
+
+## Solution Overview
+
+Sequential migration:
+
+1. Bump all packages in one csproj change (Avalonia family to 12.0.2, DataGrid to 12.0.0, replace Avalonia.Diagnostics with AvaloniaUI.DiagnosticsSupport, plus the seven safe NuGet bumps).
+2. Fix the clipboard call site.
+3. Iterate on XAML compile errors until `dotnet build SemiStep/SemiStep.slnx` is green.
+4. Run tests and manual smoke.
+5. Archive plan and document the upgrade.
+
+After each task the build MUST be green before moving on. Task 1 is the only one allowed to leave the build in a broken state — the package bump itself doesn't compile until Tasks 2 and 3 land. We accept this exception because the alternative (bump packages piecemeal) is impossible — Avalonia 12 packages don't co-exist with 11.x.
+
+## Technical Details
+
+### Package bumps (Task 1)
+
+In `SemiStep/SemiStep.UI/SemiStep.UI.csproj`:
+
+| Package | From | To | Notes |
+|---|---|---|---|
+| Avalonia | 11.3.13 | 12.0.2 | core |
+| Avalonia.Controls.DataGrid | 11.3.13 | 12.0.0 | DataGrid is independent version line |
+| Avalonia.Desktop | 11.3.13 | 12.0.2 | |
+| Avalonia.Themes.Fluent | 11.3.13 | 12.0.2 | |
+| Avalonia.Win32 | 11.3.13 | 12.0.2 | |
+| Avalonia.Diagnostics | 11.3.13 | **REMOVE** | replaced by AvaloniaUI.DiagnosticsSupport |
+| AvaloniaUI.DiagnosticsSupport | n/a | **ADD** (latest) | only if we keep dev tools — decide during task |
+
+In `SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` (or wherever it lives — verify with grep):
+
+| Package | From | To |
+|---|---|---|
+| Microsoft.NET.Test.Sdk | 18.3.0 | 18.5.1 |
+
+In whichever csproj currently references them (likely SemiStep.UI or Core):
+
+| Package | From | To |
+|---|---|---|
+| YamlDotNet | 16.3.0 | 17.1.0 |
+| System.Reactive | 6.0.1 | 6.1.0 |
+| Microsoft.Extensions.DependencyInjection | 10.0.5 | 10.0.7 |
+| Microsoft.Extensions.DependencyInjection.Abstractions | 10.0.5 | 10.0.7 |
+| System.IO.Hashing | 10.0.5 | 10.0.7 |
+
+**Decision point during Task 1:** keep DiagnosticsSupport or drop entirely. SemiStep is a Windows production app; F12 dev tools are a debug convenience. If never used, the simplest choice is to remove `Avalonia.Diagnostics` and not add the replacement. Decide based on whether anyone on the team relies on it.
+
+### Clipboard fix (Task 2)
+
+Current (`SemiStep.UI/Clipboard/ClipboardViewModel.cs:110`):
+
+```csharp
+var csvText = await _clipboard.GetTextAsync();
+```
+
+Avalonia 12 equivalent:
+
+```csharp
+var csvText = await _clipboard.TryGetTextAsync();
+```
+
+`TryGetTextAsync()` returns `Task<string?>` (nullable). The current code likely handles null already (`csvText` is checked downstream). Verify the existing null-handling still applies; if `GetTextAsync` returned empty string for "no text", confirm `TryGetTextAsync` does the same (or returns null — whichever, the caller must handle).
+
+### XAML compiled-binding audit (Task 3)
+
+11 `.axaml` files under `SemiStep.UI/`. The build will surface bindings that the XAML compiler cannot resolve. Typical fixes:
+
+- Add `x:DataType="vm:SomeViewModel"` on the root or container where the DataContext type is known.
+- Replace `{Binding SomeProperty}` with explicit paths if compiled binding fails to infer.
+- Use `{CompiledBinding ...}` markup explicitly only where Avalonia's default heuristic fails.
+- Add `x:CompileBindings="False"` as a targeted escape hatch on specific containers if a binding fundamentally cannot be resolved at compile time (e.g. dynamic DataContext, generic Controls). Use sparingly — defeats the new default.
+
+Iteration loop: build, read error, fix, rebuild. Continue until `dotnet build SemiStep/SemiStep.slnx` is green.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): all package/code/XAML changes inside the repo.
+- **Post-Completion** (no checkboxes): manual UI smoke (cannot be automated), and a note for the project owner about Avalonia 12's diagnostics-package change in case they want F12 dev tools back.
+
+## Implementation Steps
+
+### Task 1: Bump packages to Avalonia 12 + dependent versions
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/SemiStep.UI.csproj`
+- Modify: `SemiStep/SemiStep.Core/SemiStep.Core.csproj`
+- Modify: `SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`
+- Modify: `SemiStep/Directory.Build.props` (if relevant — verify)
+
+- [ ] Grep all `*.csproj` for `Avalonia` references; update each to 12.0.2 (or 12.0.0 for DataGrid).
+- [ ] Remove `Avalonia.Diagnostics` from SemiStep.UI.csproj. Decide whether to add `AvaloniaUI.DiagnosticsSupport` (latest version) — default: do NOT add it unless we know someone uses F12 dev tools. Document the decision in the commit message.
+- [ ] Bump `YamlDotNet` 16.3.0 → 17.1.0 wherever referenced.
+- [ ] Bump `System.Reactive` 6.0.1 → 6.1.0 wherever referenced.
+- [ ] Bump `Microsoft.NET.Test.Sdk` 18.3.0 → 18.5.1 in SemiStep.Tests.csproj.
+- [ ] Bump `Microsoft.Extensions.DependencyInjection` 10.0.5 → 10.0.7 wherever referenced.
+- [ ] Bump `Microsoft.Extensions.DependencyInjection.Abstractions` 10.0.5 → 10.0.7 wherever referenced.
+- [ ] Bump `System.IO.Hashing` 10.0.5 → 10.0.7 wherever referenced.
+- [ ] `dotnet restore SemiStep/SemiStep.slnx`. Build is expected to FAIL at this point — clipboard and XAML errors land in Tasks 2 and 3. **Acceptable for this task only.** Note the failure list and confirm it matches the expected categories (CS0117 / CS0103 for `GetTextAsync`, XAML compile errors). Anything else is unexpected and gets flagged.
+- [ ] **No commit yet** — Task 1 is incomplete by itself (build is red). It will be combined with Tasks 2 and 3 into a single migration commit at the end of Task 3.
+
+### Task 2: Fix Clipboard API call
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs`
+
+- [ ] Replace `await _clipboard.GetTextAsync()` with `await _clipboard.TryGetTextAsync()` at line ~110.
+- [ ] Verify null/empty handling at the call site still makes sense (`TryGetTextAsync` returns `Task<string?>`; if caller treated empty string as "no clipboard data", make sure null is handled the same way — adjust if needed).
+- [ ] Grep `SemiStep/SemiStep.UI` for any other `GetTextAsync`, `SetTextAsync`, `IDataObject`, `DataObject` references that the new API doesn't support. Fix or flag.
+- [ ] `dotnet build SemiStep/SemiStep.slnx` — clipboard CS errors should be gone; XAML errors remain (handled in Task 3).
+- [ ] **No commit yet** — bundled into Task 3 commit.
+
+### Task 3: XAML compiled-binding audit and fix
+
+**Files:**
+- Modify: every `.axaml` under `SemiStep/SemiStep.UI/` that produces compile errors after Tasks 1 + 2.
+
+- [ ] `dotnet build SemiStep/SemiStep.slnx` — capture the full list of XAML compile errors.
+- [ ] For each error, apply the smallest fix: usually `x:DataType=...` on the root, occasionally explicit `{CompiledBinding ...}`, rarely `x:CompileBindings="False"` on a container.
+- [ ] Rebuild after each fix until `dotnet build` is fully green.
+- [ ] List in the plan body all `.axaml` files touched and the kind of fix applied (DataType / explicit binding / escape hatch). If escape hatch was used, justify briefly.
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — must stay 316/316 green. (Tests don't load XAML but DI graph composition could break if Avalonia bumps broke ReactiveUI/Avalonia integration.)
+- [ ] Commit ONE migration commit bundling Tasks 1 + 2 + 3:
+  pwsh -NoProfile -File C:\Users\admin\.claude\skills\exec\scripts\stage-and-commit.ps1 "refactor: migrate to Avalonia 12.0.2 and bump related packages" <files>
+
+### Task 4: Verify acceptance criteria
+
+- [ ] `dotnet build SemiStep/SemiStep.slnx` green, 0 errors, 0 NU1903 (Tmds.DBus warning gone — confirm via build log).
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` 316/316 green.
+- [ ] `git diff master...HEAD --stat` review — scope confined to csproj files + ClipboardViewModel.cs + .axaml files + plan files. No incidental edits.
+- [ ] Manual UI smoke (will be marked `[x] manual UI smoke (skipped - not automatable)` if executed in autonomous mode): launch app, open a recipe, copy-paste cells via clipboard, verify grid renders, verify dialogs (PLC conflict / exit confirmation) open and close correctly, verify F12 behaviour matches the diagnostics decision from Task 1.
+
+### Task 5: Archive plan and update documentation
+
+- [ ] Move this plan to `Docs/plans/completed/20260512-avalonia-12-migration.md` via `git mv`.
+- [ ] Update `Docs/07-non-functional.md` with a brief Round-4 subsection: Avalonia 11 → 12 migration, what was clipboard / dev-tools-related, NU1903 closed.
+- [ ] Update `CLAUDE.md` only if a new convention emerged (none expected — this is a dependency upgrade, not a convention change).
+- [ ] Commit:
+  pwsh -NoProfile -File C:\Users\admin\.claude\skills\exec\scripts\stage-and-commit.ps1 "docs: archive avalonia 12 migration plan" <files>
+
+## Post-Completion
+
+**Manual verification (REQUIRED before merge):**
+- Launch `dotnet run --project SemiStep/SemiStep.UI/SemiStep.UI.csproj` against a real config. Confirm:
+  - Recipe grid renders with all columns and styles intact.
+  - Clipboard copy from the grid into a system text editor produces correct TSV.
+  - Clipboard paste from a system text editor into the grid works (this exercises the `TryGetTextAsync` change directly).
+  - PLC conflict dialog opens when triggered (subscribers + Dispatcher behaviour).
+  - Exit confirmation dialog opens and closes cleanly.
+  - Theme (FluentTheme) renders correctly — no visual regressions.
+  - F12 dev tools behaviour matches the Task 1 decision (either opens via `AttachDeveloperTools()` or is absent if we removed the package without replacement).
+
+**External system updates:**
+- None. This is a code-only dependency upgrade; deployed configs are unaffected.
+- Inform the team that `Avalonia.Diagnostics` package is gone — replaced by `AvaloniaUI.DiagnosticsSupport` (only if we kept dev tools) or removed entirely (default decision).

--- a/Docs/plans/completed/20260513-reactiveui-avalonia-migration.md
+++ b/Docs/plans/completed/20260513-reactiveui-avalonia-migration.md
@@ -1,0 +1,166 @@
+# Migrate Avalonia.ReactiveUI 11.3.8 → ReactiveUI.Avalonia 12.0.1
+
+## Overview
+
+Replace the deprecated `Avalonia.ReactiveUI 11.3.8` package with its maintained successor `ReactiveUI.Avalonia 12.0.1`. The two packages share the same author intent (ReactiveUI integration with Avalonia) but differ in package name and namespace; the public type/method API is unchanged at v12.0.1.
+
+Motivation:
+- `Avalonia.ReactiveUI` is marked deprecated on NuGet. No further 12.x releases. Future Avalonia patch/minor bumps risk transient incompatibility.
+- `ReactiveUI.Avalonia 12.0.1` (released 2026-04-20) is the maintained replacement, taught by the ReactiveUI team, targets Avalonia 12.0.1+. Compatible with our Avalonia 12.0.2.
+- Closes a documentation lie in `Docs/07-non-functional.md` Round-4 / Round-5 which currently claims "no 12.x release exists" — wrong, it just lives under a different package name.
+
+## Context (from discovery)
+
+- **Inventory of `using Avalonia.ReactiveUI`** (3 sites):
+  - `SemiStep/SemiStep.UI/App.axaml.cs:4`
+  - `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs:7`
+  - `SemiStep/SemiStep.Tests/TestAppBuilder.cs:3`
+- **Inventory of `using ReactiveUI`** (10 sites) — these all come from the `ReactiveUI` package (the core library, separate from the Avalonia integration). No change needed.
+- **`ReactiveWindow<TViewModel>` base class:** one usage at `SemiStep.UI/MainWindow/MainWindow.axaml.cs:18`. Type and signature unchanged at v12.0.1.
+- **`AppBuilder.UseReactiveUI()`:** two sites (`App.axaml.cs`, `TestAppBuilder.cs`). Extension method unchanged.
+- **No XAML uses the `Avalonia.ReactiveUI` XML namespace.** Grep confirmed.
+- **No direct Splat usage.** Splat is a transitive dependency only; whatever version the new package pulls in is fine.
+- **Branch state:** `feature/avalonia-12-migration` is currently 2 commits ahead of master (Avalonia 12 migration + xUnit v3 + test cleanup, after squash). This plan adds a 3rd commit before the PR opens.
+
+## Development Approach
+
+- **Testing approach:** Regular. The migration is a package + namespace swap with zero API surface change at v12.0.1. The existing 307-test suite is the regression net — every test must stay green.
+- Complete each task fully before moving to the next.
+- `dotnet build SemiStep/SemiStep.slnx` and `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` after each task; both must be green.
+- No new tests required — this is not new behaviour, only a package rename. If the suite stays at 307/307, the migration is verified.
+- Stage changes per task; final commit lands on `feature/avalonia-12-migration`.
+
+## Testing Strategy
+
+- **Existing 307 tests** are the regression net. Must stay green at every checkpoint.
+- **No new tests** required — no new behaviour.
+- **Manual 1x `dotnet test`** is enough; the xUnit v3 migration already proved suite is deterministic, so 1 run + smoke check covers it.
+- **Manual UI smoke** still pending from the parent Avalonia 12 plan — doesn't change here; Round-4 notes already cover it.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with `➕` prefix.
+- Document issues/blockers with `⚠️` prefix.
+- Keep this file in sync with actual work.
+
+## Solution Overview
+
+Three tasks:
+
+1. **Package swap + namespace edits** — replace `Avalonia.ReactiveUI 11.3.8` with `ReactiveUI.Avalonia 12.0.1` in csproj, update 3 `using` directives. Single mechanical change. Build green, 307/307 tests pass.
+2. **Documentation fix** — Update `Docs/07-non-functional.md` Round-4 and Round-5 subsections: replace the "no 12.x release" claim with the migration to `ReactiveUI.Avalonia`. Also update `CLAUDE.md` if it mentions the package by name (verify).
+3. **Verify acceptance + archive plan**.
+
+Single atomic commit recommended (per research findings) covering tasks 1+2; task 3 is verify + archive.
+
+## Technical Details
+
+### Package change (Task 1)
+
+`SemiStep/SemiStep.UI/SemiStep.UI.csproj`:
+
+```xml
+<!-- before -->
+<PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8"/>
+
+<!-- after -->
+<PackageReference Include="ReactiveUI.Avalonia" Version="12.0.1"/>
+```
+
+### Namespace edits (Task 1)
+
+Three files, one line each:
+
+```csharp
+// before
+using Avalonia.ReactiveUI;
+
+// after
+using ReactiveUI.Avalonia;
+```
+
+Files:
+- `SemiStep/SemiStep.UI/App.axaml.cs`
+- `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs`
+- `SemiStep/SemiStep.Tests/TestAppBuilder.cs`
+
+### What stays unchanged
+
+These types live in the `ReactiveUI` namespace (from the core `ReactiveUI` package) and are unaffected:
+- `ReactiveObject`, `RaiseAndSetIfChanged`, `RaisePropertyChanged`
+- `ReactiveCommand`, `WhenAnyValue`, `WhenActivated`
+- `RxApp.MainThreadScheduler`, `RxApp.TaskpoolScheduler`
+
+These types move to the new `ReactiveUI.Avalonia` namespace (from the new package):
+- `ReactiveWindow<T>`, `ReactiveUserControl<T>`
+- `AppBuilder.UseReactiveUI()` extension
+
+### Docs to update (Task 2)
+
+`Docs/07-non-functional.md` Round-4 subsection currently says:
+
+> Пакет `Avalonia.ReactiveUI` намеренно оставлен на версии `11.3.8` — релиз `12.x` на NuGet ещё не опубликован (latest на nuget.org — `11.3.8`). Бинарная совместимость с Avalonia 12.0.2 подтверждена сборкой и полным прогоном тестов. Обновить при появлении 12.x.
+
+Replace with a retrospective note that this was the state at Round-4 time; Round-5 documented that the package is deprecated; Round-6 (this round) migrated to `ReactiveUI.Avalonia 12.0.1`.
+
+`Docs/07-non-functional.md` Round-5 has a similar claim about Avalonia.ReactiveUI retention — annotate as "(superseded in Round-6)".
+
+Add a Round-6 subsection summarizing the migration.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): csproj + 3 using directives + docs.
+- **Post-Completion** (no checkboxes): nothing externally. The parent Avalonia 12 plan's manual UI smoke is still pending; doesn't change.
+
+## Implementation Steps
+
+### Task 1: Swap package and update using directives
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/SemiStep.UI.csproj`
+- Modify: `SemiStep/SemiStep.UI/App.axaml.cs`
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs`
+- Modify: `SemiStep/SemiStep.Tests/TestAppBuilder.cs`
+
+- [ ] In `SemiStep.UI.csproj`: replace `<PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8"/>` with `<PackageReference Include="ReactiveUI.Avalonia" Version="12.0.1"/>`.
+- [ ] Replace `using Avalonia.ReactiveUI;` with `using ReactiveUI.Avalonia;` in all three files.
+- [ ] Run `dotnet restore SemiStep/SemiStep.slnx` — should succeed; transitive dependencies may bump (e.g. Splat). Confirm no unexpected major bumps.
+- [ ] `dotnet build SemiStep/SemiStep.slnx` — green, 0 warnings, 0 errors. If any binding fails to compile, surface the error and pause.
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 307/307 green. Kill leftover testhost first if needed (`cmd //c "taskkill /F /IM testhost.exe"`).
+- [ ] Grep across the repo for any remaining `Avalonia.ReactiveUI` reference — must be zero.
+
+### Task 2: Update documentation
+
+**Files:**
+- Modify: `Docs/07-non-functional.md`
+- Possibly modify: `CLAUDE.md` (only if it names the package; verify by grep)
+
+- [ ] Edit `Docs/07-non-functional.md` Round-4 subsection: replace the "Avalonia.ReactiveUI намеренно оставлен на 11.3.8 — релиз 12.x не опубликован" paragraph with a retrospective note ("на момент Round-4 пакет оставался на 11.3.8; в Round-6 мигрирован на `ReactiveUI.Avalonia 12.0.1`").
+- [ ] Edit `Docs/07-non-functional.md` Round-5 subsection: same retrospective annotation if it duplicates the claim.
+- [ ] Add a new Round-6 subsection after Round-5 documenting the migration: package rename `Avalonia.ReactiveUI` → `ReactiveUI.Avalonia`, version `11.3.8 → 12.0.1`, namespace change in 3 files, API surface unchanged.
+- [ ] Grep `CLAUDE.md` for `Avalonia.ReactiveUI`; update if present. Likely no mention.
+- [ ] No tests changed by this task — docs only.
+
+### Task 3: Verify + commit + archive
+
+**Files:**
+- Modify: this plan (Task 3 checkboxes + final state)
+- Move: this plan to `Docs/plans/completed/`
+
+- [ ] `dotnet build SemiStep/SemiStep.slnx` green, 0 warnings, 0 NU1903.
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` 307/307 green. Single run is enough — xUnit v3 + AvaloniaFact has already proven the suite is deterministic.
+- [ ] `git diff master..HEAD --stat` — confirm scope: 4 code files (csproj + 3 using directives) + 2 docs files + this plan. No incidental changes.
+- [ ] Commit ALL Tasks 1+2+3 changes as ONE atomic commit:
+  ```
+  refactor: migrate from deprecated Avalonia.ReactiveUI to ReactiveUI.Avalonia 12.0.1
+  ```
+  Body: explain that the package is renamed (same authors, same API surface at v12.0.1), namespace `Avalonia.ReactiveUI` → `ReactiveUI.Avalonia`, only 3 using directives touched, build/tests unchanged at 307/307.
+- [ ] `git mv Docs/plans/20260513-reactiveui-avalonia-migration.md Docs/plans/completed/`.
+- [ ] Amend the commit to include the plan move (or do as a follow-up `chore: archive plan` commit if cleaner).
+
+## Post-Completion
+
+**Manual verification (optional):** Launch the app once to confirm `WhenActivated` and `ReactiveWindow<MainWindowViewModel>` lifecycle work as before. If the previous Avalonia 12 manual smoke is still pending from the parent plan, fold this into the same session.
+
+**External system updates:** None. Pure dependency rename; no deployment changes.

--- a/Docs/plans/completed/20260513-round7-perf-and-bumps.md
+++ b/Docs/plans/completed/20260513-round7-perf-and-bumps.md
@@ -1,0 +1,301 @@
+# Round-7: scroll perf fixes and dependency bumps
+
+## Overview
+
+Four targeted fixes addressing the memory growth + GC pressure observed during active scrolling of the recipe grid, plus a mass dependency bump to close out the modernization round. Built on top of the existing `feature/avalonia-12-migration` branch (3 commits: Avalonia 12, xUnit v3, ReactiveUI.Avalonia).
+
+Scope is constrained: no `supportsRecycling: true` flip and no XAML-based compiled-binding refactor — those are Round-8. The git history (`91241b8` → `dc85fee`) shows the recycling flip was reverted previously without explanation; the working hypothesis is that ComboBox and editing templates close over `row` instance state (`row.ColumnFormatKinds`, `row.ActionId`, `SelectionChanged` lambda) making recycling visually unsafe. Round-7 fixes only what can land without touching that closure machinery.
+
+Expected outcome:
+- One real strong-ref leak gone (ComboBox event handler ↔ row).
+- Lower gen-0 churn from converter hot paths.
+- Defensive guard against repeat-activation rebuild.
+- All dependencies on the latest stable.
+- 307/307 tests stay green.
+
+## Context (from discovery)
+
+Source audits in this session (4 subagents):
+1. **Reactive subscription audit — clean.** `RecipeRowViewModel` holds no subscriptions, `RaiseAndSetIfChanged` only. Not the leak source. Minor `.DisposeWith(_disposables)` polish on a few command ownerships is unrelated to scroll.
+2. **Allocation hotspots audit:** main churn in `PropertyTimeMultiConverter.Convert` (LINQ `.Any()` + boxing + per-cell string format), `TimeFormatHelper.FormatValue` (per-cell interpolation), and `StepStartTime` double-formatted through both the VM and the converter.
+3. **DataGrid virtualization audit:** `supportsRecycling: false` on 5 of 6 cell templates is the dominant churn driver. Plus a **real strong-ref leak** at `ComboBoxCellFactory.cs:99-106` — `comboBox.SelectionChanged += (_, _) => { ... row.SetPropertyValue(...) }` captures `row`, never unsubscribes; ComboBox holds row through event, row holds ComboBox through delegate; orphan ComboBoxes accumulate on every scroll.
+4. **Avalonia 12 / ReactiveUI 23 perf gotchas:** code-built `new Binding(path)` is always reflection-based (compiled bindings only for XAML); allocations during virtualization realisation. `Avalonia.Controls.DataGrid 12.0.0` is the latest published — no newer patch available.
+
+Defensive verification subagents:
+- **RecipeRows mutation:** verified `ObservableCollection<RecipeRowViewModel>` is get-only, mutated in place across `AppendRow` / `InsertRows` / `RebuildRow` / `FullRebuild` (Clear+Add). Avalonia DataGrid `Items` reassignment leak (issue #87) does NOT apply.
+- **BuildGrid re-entry:** `ColumnBuilder.BuildColumns` already does `grid.Columns.Clear()` + `InvalidateCaches()` first — columns don't accumulate. But `WhenActivated` may fire repeatedly (modal interactions, hide/show), triggering full column rebuild + template re-allocation. Not a leak, but unnecessary gen-0 churn. Minimal guard: `_columnsBuilt` flag in MainWindow.
+
+Git history audit: `91241b8` (2026-02-25) flipped `supportsRecycling: true` along with attach/detach handler plumbing; `dc85fee` (2026-03-02) silently reverted with "UI refactoring, bug fixes" — no explanation, no issue cited. The pattern is preserved in `TextCellFactory.CreateDisplayTemplate` (pure MultiBinding, no closures — safely `true`) and reverted everywhere else (closures over `row` make recycled cells visually stale).
+
+Package bump audit produced a clean list (see Task 1).
+
+## Development Approach
+
+- **Testing approach: Regular.** Existing 307 tests are the regression net — they cover DI graph composition, ReactiveUI command bindings, recipe analysis, config loading. Headless tests don't measure scroll allocation; that's manual. New tests added only where new logic appears (Task 3 guard).
+- Complete each task fully before moving to the next.
+- Run `dotnet build SemiStep/SemiStep.slnx` and `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` after each task; both must be green.
+- Commit per task (4 task commits + 1 verify + 1 archive). No bundling — each task is self-contained.
+
+## Testing Strategy
+
+- **Unit / integration tests:** existing 307 tests stay green. No new tests for Task 1 (bumps) or Task 4 (converter perf cleanup — output unchanged, only allocation pattern differs).
+- **Task 2 (ComboBox leak):** at least one new `[AvaloniaFact]` asserting that picking an item in the action ComboBox still triggers the same row state update (regression net for the lambda → binding rewrite). Existing `RecipeGridViewModelTests` or `RecipeRowViewModelTests` may already cover this — check first.
+- **Task 3 (BuildGrid guard):** one unit test asserting `BuildGrid()` invokes `_columnBuilder.BuildColumns` exactly once across repeated calls.
+- **Manual UI smoke (Task 5):** launch the app, scroll a recipe of ≥100 rows up/down repeatedly. Observe memory in Task Manager / dotnet-counters. Pre-fix: linear growth + frequent gen-0 collections. Post-fix: bounded memory + lower gen-0 rate. Document baseline-vs-after numbers in commit message or progress log if measurable.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with `➕` prefix.
+- Document issues/blockers with `⚠️` prefix.
+- Keep this file in sync with actual work.
+
+## Solution Overview
+
+Six tasks executed sequentially on `feature/avalonia-12-migration`:
+
+1. **Task 1 — Bumps.** Patch versions across Avalonia, MEL, FluentAssertions, Serilog. Single commit.
+2. **Task 2 — ComboBox event-handler leak.** Replace the `SelectionChanged += lambda` pattern with a `SelectedItem` binding using a converter that maps `ActionDefinition` ↔ action key. Eliminates the strong ref cycle. Single commit.
+3. **Task 3 — BuildGrid re-entry guard.** `_columnsBuilt` boolean field in MainWindow.axaml.cs, early return in `BuildGrid()`. Trivial. Single commit.
+4. **Task 4 — Converter allocation hotspots.** Three targeted fixes inside `PropertyTimeMultiConverter` and `TimeFormatHelper`, plus removing `StepStartTime`'s second pass through MultiConverter. Single commit.
+5. **Task 5 — Verify.** Build, tests, manual UI smoke. Plan checkbox-only commit.
+6. **Task 6 — Archive plan + Round-7 docs.** Move plan to `Docs/plans/completed/`, extend `Docs/07-non-functional.md` with a Round-7 subsection. Single commit.
+
+After Task 6 the PR is ready to open.
+
+## Technical Details
+
+### Task 1 — Package bumps
+
+In `SemiStep/SemiStep.Core/SemiStep.Core.csproj`, `SemiStep/SemiStep.UI/SemiStep.UI.csproj`, `SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`:
+
+| Package | From | To | Notes |
+|---|---|---|---|
+| `Avalonia` | 12.0.2 | 12.0.3 | patch |
+| `Avalonia.Desktop` | 12.0.2 | 12.0.3 | patch |
+| `Avalonia.Themes.Fluent` | 12.0.2 | 12.0.3 | patch |
+| `Avalonia.Win32` | 12.0.2 | 12.0.3 | patch |
+| `Avalonia.HarfBuzz` | 12.0.2 | 12.0.3 | patch |
+| `Microsoft.Extensions.DependencyInjection` | 10.0.7 | 10.0.8 | patch |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | 10.0.7 | 10.0.8 | patch |
+| `Microsoft.Extensions.Logging` | 10.0.5 | 10.0.8 | patch (3 behind) |
+| `Microsoft.Extensions.Logging.Abstractions` | 10.0.5 | 10.0.8 | patch (3 behind) |
+| `System.IO.Hashing` | 10.0.7 | 10.0.8 | patch |
+| `FluentAssertions` | 8.9.0 | 8.10.0 | minor |
+| `Serilog.Extensions.Logging` | 9.0.2 | 10.0.0 | major (MEL10 alignment — not a real API break) |
+
+NOT bumped:
+- `Avalonia.Controls.DataGrid 12.0.0` — latest published, no newer patch.
+- `S7netplus 0.20.0` — last release 2023, no newer.
+- Everything else verified at latest.
+
+### Task 2 — ComboBox event-handler leak
+
+Current (`ComboBoxCellFactory.cs:74-110` approximately):
+
+```csharp
+return new FuncDataTemplate<RecipeRowViewModel>((row, _) =>
+{
+    var comboBox = new ComboBox { ... ItemsSource = row.ActionItems, ... };
+    comboBox.SelectionChanged += (_, _) =>
+    {
+        if (comboBox.SelectedItem is ActionDefinition action)
+        {
+            row.SetPropertyValue(columnKey, action.Id);
+        }
+    };
+    return comboBox;
+}, supportsRecycling: false);
+```
+
+After (target shape, mirroring the group editing template at ComboBoxCellFactory.cs:161):
+
+```csharp
+return new FuncDataTemplate<RecipeRowViewModel>((row, _) =>
+{
+    var converter = new ComboBoxItemSelectionConverter(row.ActionItems);
+    var comboBox = new ComboBox { ItemsSource = row.ActionItems };
+    comboBox.Bind(ComboBox.SelectedItemProperty, new Binding($"[{columnKey}]")
+    {
+        Mode = BindingMode.TwoWay,
+        Converter = converter,
+    });
+    return comboBox;
+}, supportsRecycling: false);
+```
+
+Key decisions per plan-review:
+- **Reuse `ComboBoxItemSelectionConverter`** (already exists in the file). Its `ConvertBack` returns `int` (action id); confirm `RecipeRowViewModel`'s indexer setter accepts int directly (or wraps to `PropertyValue`-compatible type). The current leak code writes `selected.Id.ToString()` — the new path writes the int from `ConvertBack`. Verify the indexer write path handles both; adjust `ConvertBack` to return string if the indexer demands it.
+- **Constructor-injected converter, NOT `ConverterParameter`.** For the action column, `row.ActionItems` is the globally cached list (`GetOrCreateActionItems` returns `_cachedActionItems`), so one converter instance per row is fine — same pattern the group editing template already uses.
+- **`BindingMode.TwoWay`** so the ComboBox writes back to the row property when the user picks an item.
+- **`supportsRecycling: false` STAYS** — this task fixes the strong-ref leak only. Recycling is Round-8 (requires eliminating closures over `row` more broadly). Document this in the commit body so reviewers understand the gen-0 churn from re-allocating ComboBox per scroll persists until Round-8.
+
+The TwoWay binding replaces both the `SelectionChanged += lambda` and any manual `SetPropertyValue` write. Binding lifecycle is managed by Avalonia: when the ComboBox is detached/finalized the binding subscription releases — no strong-ref cycle survives.
+
+### Task 3 — BuildGrid re-entry guard
+
+In `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs`:
+
+```csharp
+private bool _columnsBuilt;
+
+private void BuildGrid()
+{
+    if (_columnsBuilt || _columnBuilder is null || ViewModel is null)
+    {
+        return;
+    }
+    _columnBuilder.BuildColumns(RecipeGrid);
+    _columnsBuilt = true;
+}
+```
+
+The flag is private, not reset anywhere — if dynamic column rebuild is ever needed (config reload), the call site that triggers it must reset `_columnsBuilt = false` explicitly. Today there is no such path; document via XML comment on the field.
+
+### Task 4 — Converter allocation hotspots
+
+**4a. `PropertyTimeMultiConverter.Convert` (`SemiStep.UI/RecipeGrid/PropertyTimeMultiConverter.cs`):**
+
+Replace `values.Any(v => v == AvaloniaProperty.UnsetValue)` with a `for (var i = 0; i < values.Count; i++)` loop. Eliminates the LINQ enumerator/closure allocation per cell binding evaluation.
+
+If `values[0]` is already a `string`, skip `ToString()` — assign directly.
+
+**4b. `StepStartTime` direct binding** (the column routing already exists — this task only trims the MultiBinding wrap):
+
+`TextCellFactory.ResolveBindingPath` already special-cases `columnKey == TimeFormatHelper.StepStartTimeColumnKey` and returns `nameof(StepStartTime)` as the binding path. The constant is hard-coded — config-supplied alternative keys would already break today, independent of this round; no new coupling is introduced here.
+
+What changes: in `TextCellFactory.CreateDisplayTemplate`, when `columnKey == StepStartTimeColumnKey`, build a simple `new Binding(nameof(StepStartTime))` directly bound to `TextBlock.Text` — bypass `PropertyTimeMultiConverter` entirely on this branch. Saves one MultiConverter invocation per visible row per scroll frame, and `StepStartTime` is pre-formatted by `RecipeRowViewModel` so no re-formatting needed.
+
+**Task 4b (memoization) explicitly DROPPED.** Original plan proposed `Dictionary<(double, string, string), string>` cache with `lock` + `Clear()` overflow. Per plan-review: this is premature optimization (per CLAUDE.md YAGNI rule). The `lock` is unjustified (Avalonia value converters run on UI thread by contract). After 4a + 4c, `time_hms` formatting is no longer on the StepStartTime hot path; remaining call sites are rare. Real allocation win is 4a (LINQ removal) + 4c (StepStartTime direct bind). If post-Round-7 profiling still shows `FormatValue` allocations dominating, revisit then with profiling evidence.
+
+### Task 5 — Verify
+
+- `dotnet build SemiStep/SemiStep.slnx` — 0 errors, 0 warnings.
+- `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 307/307 (or slightly higher if Task 2/3 added tests).
+- Manual UI smoke: open a recipe with ≥100 rows, scroll continuously for 30+ seconds. Observe memory in Task Manager. Pre-fix baseline (if measured before this round): linear growth, ~X MB/min. Post-fix expectation: bounded memory, stabilises after warm-up.
+- `git diff master..HEAD --stat` — confirm scope confined to UI cell factories + 1 main window file + converters + csprojs + plan/docs. No incidental edits.
+
+### Task 6 — Archive plan + docs
+
+- `git mv Docs/plans/20260513-round7-perf-and-bumps.md Docs/plans/completed/`.
+- Extend `Docs/07-non-functional.md` with a Round-7 subsection after Round-6, summarising: package patch bumps, ComboBox event-handler leak fix (real strong-ref leak, not just churn), BuildGrid re-entry guard, converter allocation hotspots flattened. Note Round-8 follow-up: `supportsRecycling: true` requires rewriting cell template closures to pure bindings; XAML data templates for compiled bindings is a separate effort.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): csproj bumps, ComboBox binding refactor, MainWindow guard, converter edits, docs.
+- **Post-Completion** (no checkboxes): manual scroll smoke is on the user (Task 5 marks it `[x] manual scroll smoke (skipped - not automatable in headless)`).
+
+## Implementation Steps
+
+### Task 1: Mass package bumps
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/SemiStep.Core.csproj`
+- Modify: `SemiStep/SemiStep.UI/SemiStep.UI.csproj`
+- Modify: `SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`
+
+- [x] Apply the version table from Technical Details. Verify each PackageReference Version attribute in each csproj individually — some packages appear in multiple csprojs (Microsoft.Extensions.Logging.Abstractions etc.) and must unify.
+- [x] Run `dotnet restore SemiStep/SemiStep.slnx`. Confirm no unexpected transitive bumps. **Specifically check for `NU1608` (version conflict) or `NU1605` (downgrade) warnings caused by `Avalonia.Controls.DataGrid 12.0.0` vs `Avalonia 12.0.3` skew** — Avalonia controls packages are normally version-locked. If a warning appears, the fallback is to pin Avalonia back to 12.0.2 until DataGrid catches up; record the decision in commit message.
+- [x] `dotnet build SemiStep/SemiStep.slnx` — 0 errors, 0 warnings.
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 307/307 green. Kill testhost first if file locks block rebuild.
+- [x] Commit:
+  ```
+  chore(deps): bump dependencies to latest stable
+  ```
+  Body: list bump table.
+
+### Task 2: Fix ComboBox event-handler leak
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs`
+- Possibly modify / extend: `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxItemSelectionConverter.cs`
+- Possibly add tests: `SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs` or `RecipeRowViewModelTests.cs`
+
+- [x] Read `ComboBoxCellFactory.cs` around lines 74-110 and 135 (group editing template — reference shape using binding).
+- [x] Reuse `ComboBoxItemSelectionConverter` (decided per plan-review — do NOT add a sibling class). Verify it accepts a list of items via ctor and does `ActionDefinition ↔ int id` mapping. If its current contract only matches the group editing path, extend the same converter to handle the action case.
+- [x] Replace the `comboBox.SelectionChanged += lambda` block with `comboBox.Bind(ComboBox.SelectedItemProperty, new Binding(...))` per Technical Details. The binding path is the indexer `[{columnKey}]` (existing convention).
+- [x] `dotnet build` green.
+- [x] Locate or write a test: when an action is selected in the row's combo column, `row.GetPropertyValue(columnKey)` returns the new action id. The test must NOT touch the actual ComboBox control — it asserts the data flow through `SetPropertyValue` ↔ binding ↔ converter ↔ ComboBox. May be straightforward via `RecipeRowViewModel` directly if `SetPropertyValue` is the binding target.
+- [x] `dotnet test` green.
+- [x] Commit:
+  ```
+  fix: remove ComboBox event-handler leak in action column template
+  ```
+  Body: explain that `SelectionChanged += lambda` captured `row`, never unsubscribed, accumulated orphan ComboBoxes during scroll. Replaced with `SelectedItem` binding to the row indexer using a value converter — Avalonia manages binding lifecycle so no strong-ref cycle survives.
+
+### Task 3: BuildGrid re-entry guard
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/...` — add idempotency test (locate the test class that exercises ColumnBuilder, or create a focused one).
+
+- [x] Add `private bool _columnsBuilt;` field to `MainWindow`.
+- [x] Add early return in `BuildGrid()` per Technical Details. Set `_columnsBuilt = true` after a successful build.
+- [x] Add XML doc comment on `_columnsBuilt`: "Guards against repeat column rebuild on re-activation. If dynamic column rebuild is ever needed, reset to false at the call site."
+- [x] **Add idempotency test for `ColumnBuilder.BuildColumns`** at the existing test seam. The test instantiates the builder with the standard fixture, calls `BuildColumns(grid)` twice in a row, and asserts that the column count after the second call equals the count after the first (no duplication). This is the regression net for the guard's intent. If testing the MainWindow code-behind field directly is awkward, an alternative: add an `internal` method or test seam that exposes the guard. Prefer the ColumnBuilder-level test — it covers the actual concern (column count stability) without coupling to the MainWindow widget.
+- [x] `dotnet build` + `dotnet test` green.
+- [x] Commit:
+  ```
+  fix: guard MainWindow.BuildGrid against repeat invocation on re-activation
+  ```
+  Body: WhenActivated may fire on hide/show or modal interactions; without this guard, ColumnBuilder.BuildColumns re-allocates all columns + templates + converters on every activation, churning gen-0.
+
+### Task 4: Converter allocation hotspots
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeMultiConverter.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/TimeFormatHelper.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs` and/or `TextCellFactory.cs` (for StepStartTime direct binding)
+
+- [x] **4a.** In `PropertyTimeMultiConverter.Convert`, replace `values.Any(v => v == AvaloniaProperty.UnsetValue)` with a `for` loop over `values.Count`. If `values[0]` is already `string`, skip `ToString()` — cast directly.
+- [x] **4b.** In `TextCellFactory.CreateDisplayTemplate`, when `columnKey == TimeFormatHelper.StepStartTimeColumnKey`, build a plain `new Binding(nameof(RecipeRowViewModel.StepStartTime))` directly to `TextBlock.Text` — bypass `PropertyTimeMultiConverter` entirely on this branch. The routing already special-cases the key in `ResolveBindingPath`; we just stop wrapping it in MultiBinding. `StepStartTime` is pre-formatted by the view model, so no converter is needed on this path.
+- [x] (memoization Task 4b dropped from original plan per review — see Technical Details for rationale.)
+- [ ] `dotnet build` + `dotnet test` green.
+- [ ] Run a quick eyeball test: confirm `StepStartTime` still displays correctly in the grid (the bound property is already pre-formatted).
+- [ ] Commit:
+  ```
+  perf: trim allocation hotspots in PropertyTimeMultiConverter and TimeFormatHelper
+  ```
+
+### Task 5: Verify acceptance
+
+- [x] `dotnet build SemiStep/SemiStep.slnx` — 0 errors, 0 warnings.
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 309/309 green.
+- [x] `git diff master..HEAD --stat` review — scope confined (Round-7 files: 3 csprojs, ComboBoxCellFactory.cs, MainWindow.axaml.cs + ColumnBuilderIdempotencyTests.cs, PropertyTimeMultiConverter.cs, TextCellFactory.cs, plan file; remaining diff is prior migrations baseline on feature/avalonia-12-migration).
+- [x] manual scroll smoke (skipped - not automatable in headless)
+- [ ] Commit:
+  ```
+  chore: verify Round-7 acceptance criteria
+  ```
+
+### Task 6: Archive plan and document Round-7
+
+**Files:**
+- Move: `Docs/plans/20260513-round7-perf-and-bumps.md` → `Docs/plans/completed/`
+- Modify: `Docs/07-non-functional.md`
+
+- [x] `git mv Docs/plans/20260513-round7-perf-and-bumps.md Docs/plans/completed/`.
+- [x] In `Docs/07-non-functional.md`, add a Round-7 subsection after Round-6 with:
+  - Package patch bumps (Avalonia 12.0.2→12.0.3, MEL family to 10.0.8, etc.).
+  - ComboBox action-column event-handler strong-ref leak fix (`SelectionChanged += lambda` → `SelectedItem` binding).
+  - BuildGrid re-entry guard against re-activation churn.
+  - Converter allocation hotspots flattened (LINQ `.Any()` → for-loop; StepStartTime bound directly without MultiBinding wrap).
+  - Round-8 follow-up note: `supportsRecycling: true` requires rewriting closures over `row` in cell templates to pure bindings; XAML-based data templates with compiled bindings is a separate effort.
+- [x] Commit:
+  ```
+  docs: archive Round-7 plan and document scroll perf fixes
+  ```
+
+## Post-Completion
+
+**Manual verification (required before PR open):**
+- Launch the app against a real recipe with ≥100 steps. Scroll continuously for ≥30 seconds in both directions. Memory should plateau, not grow linearly. Gen-0 collections should be less frequent. Document the observation in PR description.
+- Confirm action ComboBox selection still works in the recipe grid — the Task 2 rewrite is the main behavioural risk.
+
+**External system updates:**
+- None. Internal performance work + dep bumps.
+
+**Round-8 deferred work (recorded for follow-up PR):**
+- Rewrite ComboBox/editing cell templates to eliminate closures over `row`; enable `supportsRecycling: true` on all of them. This is what eliminates the structural per-scroll allocation, not just the strong-ref leak.
+- Move cell templates to XAML `<DataTemplate>` with `x:DataType="vm:RecipeRowViewModel"` and `x:CompileBindings="True"` to enable compiled bindings (currently all code-built `new Binding(...)` paths are reflection-based).
+- These two together address the remaining gen-0 churn after Round-7 lands.

--- a/Docs/plans/completed/20260513-xunit-v3-migration-and-test-cleanup.md
+++ b/Docs/plans/completed/20260513-xunit-v3-migration-and-test-cleanup.md
@@ -1,0 +1,382 @@
+# xUnit v2 → v3 migration with AvaloniaFact and test cleanup
+
+## Overview
+
+Three coupled objectives on the same branch (`feature/avalonia-12-migration`, on top of the in-flight Avalonia 12 work):
+
+1. **Fix the hang/NRE root cause.** `RecipeMutationCoordinatorTests.UpdateStepProperty_Failure_ReturnsFailed` fails deterministically in a clean shell (NRE in `Dispatcher.RequestForegroundProcessing` during xUnit `InitializeAsync`), and other UI tests intermittently hang because `xUnit IAsyncLifetime.InitializeAsync` runs outside `HeadlessDispatcher.Run(...)` while initializing code that posts to the dispatcher. Avalonia 12 turned the silent-no-op into a hard error.
+2. **Migrate to xUnit v3 + `Avalonia.Headless.XUnit`.** `[AvaloniaFact]` wraps the *entire* test lifecycle (constructor, `InitializeAsync`, body, `DisposeAsync`) in the session dispatcher — exactly the scope the current `HeadlessDispatcher.Run` wrapper cannot reach. This is the structural fix; deletes the `HeadlessDispatcher` helper.
+3. **Drop low-value / risky tests.** Per audit: ~40 near-duplicate one-property facts in `MessagePanelViewModelTests` / `RecipeRowViewModelTests` should be collapsed into `[Theory]` rows or removed. ~10 `Task.Delay(1200)` polling calls in S7/Domain tests waste runtime and are flaky — replace with the existing `WaitForPendingSyncAsync` or equivalent quiescence hook.
+
+After this round: `dotnet test` produces ~250–280 deterministic tests (down from 316), no `HeadlessDispatcher` wrappers, no `Task.Delay`-based race-sensitive assertions, suite runtime under 10 s on a clean machine.
+
+## Context (from discovery)
+
+- **Test stack today** (`SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`): `xunit 2.9.3`, `xunit.runner.visualstudio 3.1.5` (already v3-capable), `Microsoft.NET.Test.Sdk 18.5.1`, `Avalonia.Headless 12.0.2`. No `Avalonia.Headless.XUnit`.
+- **IAsyncLifetime users** (6 files needing `Task → ValueTask` signature change in v3):
+  - `Csv/Helpers/CsvFixture.cs`
+  - `Core/Helpers/CoreFixture.cs`
+  - `UI/Helpers/UIFixture.cs`
+  - `UI/RecipeRowViewModelTests.cs`
+  - `UI/RecipeMutationCoordinatorTests.cs`
+  - `UI/RecipeGridViewModelTests.cs`
+- **HeadlessDispatcher call sites** (3 UI files, 34 wrapper invocations to remove):
+  - `UI/MessagePanelViewModelTests.cs` — 26 sites
+  - `UI/RecipeMutationCoordinatorLoadRecipeTests.cs` — 6 sites
+  - `UI/RecipeMutationCoordinatorTests.cs` — 2 sites (plus the implicit need for `InitializeAsync` wrapping that doesn't currently exist)
+- **App startup** (`SemiStep.UI/App.axaml.cs:53-60`): `BuildAvaloniaApp` calls `.UseWin32()`. For headless tests this must be replaced with `.UseHeadless(...)`. May require a separate `TestApp` class if `OnFrameworkInitializationCompleted` casts `ApplicationLifetime` to desktop unconditionally (check during Task 2).
+- **Test parallelization**: no `[Collection]` / `[CollectionDefinition]` attributes anywhere. xUnit v2 default is parallel; xUnit v3 still parallel by default but with different scheduling. The shared static `HeadlessUnitTestSession` does not tolerate true parallel use across collections, so we add `[assembly: CollectionBehavior(DisableTestParallelization = true)]` initially.
+- **Audit findings on low-value tests** (Task 6 cleanup scope):
+  - `MessagePanelViewModelTests` — 25 facts where ~10 cover the same ground (collapse `HasErrors_*`, `HasWarnings_*`, `HasEntries_*` initial-state facts; collapse 5 `ColumnUnits_*` and 5 `ColumnFormatKinds_*` into Theories).
+  - `RecipeRowViewModelTests.Indexer_Get_DelegatesToGetPropertyValue` — trivial.
+  - S7/Domain tests: `Task.Delay(200)`–`Task.Delay(1200)` in `Domain/PlcLifecycleManagerReconnectTests`, `S7/PlcExecutionMonitorTests`, `S7/PlcSyncCoordinatorTests`, `S7/S7ServiceTests` — total ~5–10 s of wall-clock waste, race-prone on slow CI.
+- **Why it didn't hang in 11.x**: Avalonia 11.x backed `Dispatcher.UIThread` with a permissive ambient dispatcher; `Post` was a silent no-op when no processing host existed. Avalonia 12 replaced it with a session-scoped dispatcher that NREs on `Post` outside `Dispatch`.
+
+## Development Approach
+
+- **Testing approach**: Regular. The suite *is* the work — we're editing tests themselves. Each task ends with `dotnet build` green and `dotnet test` green (test count adjusts per task; final acceptance is "every remaining test passes deterministically, no hangs across 3 consecutive runs").
+- Complete each task fully before moving to the next.
+- Run `dotnet build SemiStep/SemiStep.slnx` and `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` after each task; both must be green.
+- After Tasks 1–5, run the suite **3 times in a row** to confirm no hanging. After Task 6+7, the test count drops; that's expected.
+- Kill leftover `testhost.exe` between runs if file-lock errors appear (`cmd //c "taskkill /F /IM testhost.exe"`).
+- Stage changes per task. Commits land on `feature/avalonia-12-migration` (still pre-merge for the Avalonia 12 work — both efforts land in the same PR).
+
+## Testing Strategy
+
+- **Existing 316 tests** are the regression net. They must stay green at every checkpoint that didn't intentionally remove them.
+- **New tests** are not required by this plan — the work *is* test refactoring.
+- **Manual 3x consecutive `dotnet test` runs** are the proof of no-hang. The currently observed hang is the failure mode we are eliminating.
+- **`dotnet test --filter "FullyQualifiedName~RecipeMutationCoordinatorTests"`** specifically — should turn green after Task 4 lands.
+- **No e2e tests**; UI smoke remains manual (already covered by the prior Avalonia 12 plan's Post-Completion).
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with `➕` prefix.
+- Document issues/blockers with `⚠️` prefix.
+- Keep this file in sync with actual work.
+
+## Solution Overview
+
+Sequential migration in 8 tasks:
+
+1. Bump packages (xunit.v3, Avalonia.Headless.XUnit).
+2. Build the headless test application bootstrap.
+3. Convert `IAsyncLifetime` signatures from `Task` to `ValueTask`.
+4. Switch UI test attributes from `[Fact]` to `[AvaloniaFact]`, remove `HeadlessDispatcher.Run` wrappers, restore `async Task` test signatures.
+5. Delete `HeadlessDispatcher.cs`, update `CLAUDE.md`.
+6. Collapse / remove ~40 redundant UI facts (Theory consolidation + deletion of one-property assertion tests).
+7. Replace `Task.Delay` polling in S7/Domain tests with `WaitForPendingSyncAsync` or equivalent.
+8. Verify + archive.
+
+Tasks 1–5 are tightly coupled (none compiles green by itself). They land as one logical "infrastructure migration" commit at the end of Task 5. Tasks 6, 7 are each their own commit. Task 8 archives.
+
+## Technical Details
+
+### Package bumps (Task 1)
+
+In `SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`:
+
+| Package | From | To | Notes |
+|---|---|---|---|
+| `xunit` | 2.9.3 | **REMOVE** | replaced by xunit.v3 |
+| `xunit.v3` | n/a | **3.1.0** | latest stable; avoid 4.0.0-pre |
+| `xunit.runner.visualstudio` | 3.1.5 | keep | already v3-capable |
+| `Microsoft.NET.Test.Sdk` | 18.5.1 | keep | xunit.v3 still uses VSTest adapter |
+| `Avalonia.Headless.XUnit` | n/a | **12.0.2** | aligns with Avalonia 12.0.2 |
+| `Avalonia.Headless` | 12.0.2 | keep | |
+
+### TestAppBuilder (Task 2)
+
+New file `SemiStep/SemiStep.Tests/TestAppBuilder.cs`:
+
+```csharp
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.ReactiveUI;
+
+using SemiStep.Tests;
+
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+
+namespace SemiStep.Tests;
+
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<SemiStep.UI.App>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions())
+            .UseReactiveUI();
+}
+```
+
+**Verification step before committing**: try to run *any* test under the new attribute, e.g.
+
+```csharp
+[AvaloniaFact]
+public void HeadlessApp_StartsCleanly() { Assert.NotNull(Application.Current); }
+```
+
+If `SemiStep.UI.App.OnFrameworkInitializationCompleted` throws when `ApplicationLifetime` is not desktop, introduce a minimal `TestApp : Application` instead and reference that in the builder. Decide at runtime; document the decision in the commit message.
+
+### IAsyncLifetime conversion (Task 3)
+
+xUnit v3 changes `IAsyncLifetime` from `Task` to `ValueTask`. In each of the 6 files:
+
+```csharp
+// before (v2)
+public Task InitializeAsync() { ... return Task.CompletedTask; }
+public Task DisposeAsync() { ... return Task.CompletedTask; }
+
+// after (v3)
+public ValueTask InitializeAsync() { ... return ValueTask.CompletedTask; }
+public ValueTask DisposeAsync() { ... return ValueTask.CompletedTask; }
+```
+
+For `async` methods: `async Task` → `async ValueTask`. Callers don't change.
+
+### UI test attribute switch (Task 4)
+
+Per-file checklist:
+
+| File | Test count | Action |
+|---|---|---|
+| `UI/MessagePanelViewModelTests.cs` | 25 (after Task 6 cleanup ~10) | Replace `[Fact]` with `[AvaloniaFact]`. Remove every `HeadlessDispatcher.Run(() => { ... })` wrapper — body becomes the method body directly. Restore `async Task` where currently `void` with sync-over-async. |
+| `UI/RecipeMutationCoordinatorLoadRecipeTests.cs` | 6 | Same. |
+| `UI/RecipeMutationCoordinatorTests.cs` | 23 | Same. Remove the 2 inner `HeadlessDispatcher.Run` blocks (lines 248, 287). |
+| `UI/RecipeGridViewModelTests.cs` | 19 | `[AvaloniaFact]` (currently constructs `MessagePanelViewModel` in `InitializeAsync` — needs dispatcher context). |
+| `UI/RecipeRowViewModelTests.cs` | 21 (after Task 6 cleanup ~10) | `[AvaloniaFact]` — confirmed touches dispatcher via `MessagePanelViewModel` references in plan-review grep. Apply unconditionally. |
+
+Non-UI tests (`Core/*`, `Config/*`, `Csv/*`, `S7/*`, `Domain/*`) stay on plain `[Fact]` — no dispatcher dependency.
+
+### Parallelization guard (Task 4 or 5)
+
+Add a new file `SemiStep/SemiStep.Tests/AssemblyAttributes.cs` (or extend `TestAppBuilder.cs`):
+
+```csharp
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+```
+
+This protects the shared static `HeadlessUnitTestSession` from cross-collection contention. **Treat as permanent**, not provisional: Avalonia's docs themselves recommend serial execution for the headless session because it is single-instance. If parallel test execution is wanted later, it is a separate design effort (per-collection sessions or per-test `HeadlessUnitTestSession`), not a config tweak.
+
+### UI test cleanup targets (Task 6)
+
+Collapse / remove:
+
+- `MessagePanelViewModelTests.HasErrors_IsFalse_WhenNoErrors`, `HasWarnings_IsFalse_WhenNoWarnings`, `HasEntries_False_Initially` → one `[Theory]` over `(string flagName, bool expected)` or simply delete two of the three (they assert default state of a fresh VM).
+- `RecipeRowViewModelTests.ColumnUnits_*` (5 facts) and `ColumnFormatKinds_*` (5 facts) → `[Theory]` with `[InlineData]` rows.
+- `RecipeRowViewModelTests.Indexer_Get_DelegatesToGetPropertyValue` → delete (trivial wiring assertion).
+- `CorePropertyStateTests` — 4 near-duplicate constructor-property assertions; consolidate into one Theory or keep only the most representative.
+
+Expected delta: ~40 fact removals + ~10 theories. New count target: ~250–280 tests.
+
+### Task.Delay polling replacement (Task 7)
+
+Files with `Task.Delay`-based polling waiting for async state convergence:
+
+- `Domain/PlcLifecycleManagerReconnectTests.cs:96, 119`
+- `S7/PlcExecutionMonitorTests.cs:124, 152, 168, 199, 234`
+- `S7/PlcSyncCoordinatorTests.cs:149, 168, 186` (1200 ms each)
+- `S7/S7ServiceTests.cs:85, 107, 134`
+
+For each call site:
+1. Identify what observable state the delay is waiting for (e.g. `PlcSyncCoordinator.SyncStatus == PlcSyncStatus.Idle`).
+2. If the SUT exposes `WaitForPendingSyncAsync()` (or similar quiescence API), replace `Task.Delay(N)` with that.
+3. If no such hook exists, replace with a bounded poll: `await TestHelpers.WaitUntilAsync(() => predicate(), timeout: 2s, pollMs: 20)` — fail fast on timeout, succeed as soon as predicate is true.
+4. If the delay is genuinely a "let the async noise settle" wait with no observable predicate, leave it but flag with a TODO and the actual reason.
+
+Add a new file `SemiStep/SemiStep.Tests/Helpers/WaitUntilAsync.cs` (or extend `TestHelpers.cs`):
+
+```csharp
+public static class TestHelpers
+{
+    public static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout, TimeSpan pollInterval, [CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(pollInterval);
+        }
+        throw new TimeoutException($"Predicate did not become true within {timeout}: {predicateExpression}");
+    }
+}
+```
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): all package/code/test edits inside the repo.
+- **Post-Completion** (no checkboxes): nothing externally — this is purely test infra. The Avalonia 12 manual UI smoke is still pending from the parent plan; doesn't change.
+
+## Implementation Steps
+
+### Task 1: Bump test packages to xUnit v3
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`
+
+- [x] **Resolve actual latest stable versions on NuGet at execution time** (do not blindly trust the plan's "3.1.0" / "12.0.2" — record the chosen versions in the eventual commit message):
+  - `xunit.v3` — pick the latest stable from `nuget.org`. If only `2.x` / `3.x-preview` are listed, fall back to the highest 3.x stable; if no 3.x stable exists yet, stop and report — the whole plan depends on this. **Resolved: 3.2.2.**
+  - `Avalonia.Headless.XUnit` — match Avalonia version. If exact `12.0.2` is not published, fall back to the closest 12.x (the headless surface is stable across point releases). Confirm the version range against `Avalonia.Headless 12.0.2` already in the project. **Resolved: 12.0.3 (forced bump of `Avalonia.Headless` from 12.0.2 → 12.0.3 to satisfy transitive constraint).**
+- [x] Remove `<PackageReference Include="xunit" Version="2.9.3"/>`.
+- [x] Add `<PackageReference Include="xunit.v3" Version="3.2.2"/>`.
+- [x] Add `<PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.3"/>`.
+- [x] Verify `FluentAssertions 8.9.0` (already in project) has no hard `xunit` v2 dependency. Should be fine — FA is xunit-agnostic since v6. If `dotnet restore` complains, recheck. **FA caused no restore complaint.**
+- [x] Run `dotnet restore SemiStep/SemiStep.slnx`. Build is expected to FAIL until Task 3 lands (IAsyncLifetime signature mismatches). Acceptable for this task only. **Restore green; build red with exactly 12 CS0738 errors (Task → ValueTask) across the 6 expected files — no other categories.**
+- [x] No commit yet — bundled with Tasks 2–5 into one "test infrastructure" commit.
+
+### Task 2: TestAppBuilder + AvaloniaTestApplication attribute
+
+**Files:**
+- Create: `SemiStep/SemiStep.Tests/TestAppBuilder.cs`
+- Modify: `SemiStep/SemiStep.Tests/AssemblyAttributes.cs` (or create) — add `CollectionBehavior(DisableTestParallelization = true)`.
+
+- [x] Create `TestAppBuilder` with `BuildAvaloniaApp()` returning `AppBuilder.Configure<SemiStep.UI.App>().UseHeadless(...).UseReactiveUI()`.
+- [x] Add `[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]`.
+- [x] Add `[assembly: CollectionBehavior(DisableTestParallelization = true)]`.
+- [x] **Reuse `SemiStep.UI.App` directly.** Pre-decided based on plan-review verification: `App.axaml.cs:29` already gates `OnFrameworkInitializationCompleted` with `if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) { ... }`, so under headless lifetime the body is skipped. No `TestApp` shim needed. If the first `[AvaloniaFact]` test run unexpectedly throws from `OnFrameworkInitializationCompleted` (e.g. some headless config flavor reports as classic-desktop), introduce a minimal `TestApp : Application` fallback then.
+- [x] No commit yet.
+
+### Task 3: Convert IAsyncLifetime to ValueTask in 6 files
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/Csv/Helpers/CsvFixture.cs`
+- Modify: `SemiStep/SemiStep.Tests/Core/Helpers/CoreFixture.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs`
+
+- [x] Change every `public Task InitializeAsync()` to `public ValueTask InitializeAsync()` (or `async ValueTask` if the body awaits).
+- [x] Change every `public Task DisposeAsync()` to `public ValueTask DisposeAsync()`.
+- [x] Replace `return Task.CompletedTask;` with `return ValueTask.CompletedTask;`.
+- [x] Verify all callers of `await fixture.InitializeAsync()` / `await fixture.DisposeAsync()` still compile.
+- [x] No commit yet.
+
+### Task 4: Switch UI tests to [AvaloniaFact] and remove HeadlessDispatcher wrappers
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs` (if it touches dispatcher — verify)
+
+- [x] In each of the 5 UI files: replace `[Fact]` with `[AvaloniaFact]` on every test method.
+- [x] Remove every `HeadlessDispatcher.Run(() => { ... })` wrapper — body becomes flat method body.
+- [x] Remove every `HeadlessDispatcher.RunAsync(async () => { ... })` wrapper — restore `async Task` signature.
+- [x] Remove every `void` method that hid an async body via `.GetAwaiter().GetResult()` — restore `async Task`.
+- [x] Remove `using SemiStep.Tests.Helpers;` lines that only existed for `HeadlessDispatcher`.
+- [x] No commit yet.
+
+### Task 5: Delete HeadlessDispatcher.cs, update CLAUDE.md, commit Tasks 1–5
+
+**Files:**
+- Delete: `SemiStep/SemiStep.Tests/Helpers/HeadlessDispatcher.cs`
+- Modify: `CLAUDE.md` (root) — update the "Dispatcher flush in tests" paragraph to describe `[AvaloniaFact]` pattern instead.
+
+- [x] Grep `HeadlessDispatcher` across the repo — must be zero references after Task 4.
+- [x] Delete `Helpers/HeadlessDispatcher.cs` via `git rm`.
+- [x] Update CLAUDE.md to describe the new test pattern: "UI tests use `[AvaloniaFact]` (from `Avalonia.Headless.XUnit`) which wraps the full test lifecycle, including `InitializeAsync`/`DisposeAsync`, in the headless dispatcher. No manual `Dispatcher.UIThread.RunJobs(...)` is needed."
+- [x] **Clear stale VSTest adapter cache** before the first v3 run: `git clean -fdx SemiStep/SemiStep.Tests/bin SemiStep/SemiStep.Tests/obj` (or equivalent). Stale v2-adapter artifacts can produce phantom "no tests found" or wrong discovery on the first run.
+- [x] `dotnet build SemiStep/SemiStep.slnx` — must be green.
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — must be green. Run 3 times in a row, no hangs, no flake. Kill leftover `testhost.exe` between runs if file-lock errors appear. **3 runs: 316/316 each, ~11-12s, deterministic.**
+- [x] Commit Tasks 1–5 as ONE infrastructure commit:
+  ```
+  refactor: migrate test project to xUnit v3 and Avalonia.Headless.XUnit
+  ```
+  Body lists the package changes, the IAsyncLifetime conversion, the new TestAppBuilder, deletion of HeadlessDispatcher.
+
+### Task 6: Collapse / remove redundant UI test facts
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/Core/Unit/Properties/CorePropertyStateTests.cs` (if its 4 near-duplicates remain)
+
+- [x] `MessagePanelViewModelTests`: collapse default-state facts (`HasErrors_*`, `HasWarnings_*`, `HasEntries_*` etc.) into a single `[Theory]` or delete redundant ones. Keep only the tests that exercise non-trivial state transitions.
+- [x] `RecipeRowViewModelTests`: convert 5 `ColumnUnits_*` and 5 `ColumnFormatKinds_*` facts into two `[Theory]` methods with `[InlineData]` rows. Delete `Indexer_Get_DelegatesToGetPropertyValue` (trivial).
+- [x] `CorePropertyStateTests`: collapse 4 near-duplicates into one Theory or keep the most representative one.
+- [x] Run `dotnet test` — count drops by ~40 (target ~275 tests). All remaining must be green. **Result: 316 → 307 green; deeper collapse rejected because remaining facts cover meaningfully distinct setup paths (per plan's own "KEEP them — don't force-merge for the sake of count" guidance).**
+- [x] Commit:
+  ```
+  test: collapse redundant UI facts into theories; drop trivial assertions
+  ```
+
+### Task 7: Replace Task.Delay polling with quiescence hooks
+
+**Files:**
+- Create: `SemiStep/SemiStep.Tests/Helpers/TestHelpers.cs` (or extend if exists) with `WaitUntilAsync` per Technical Details.
+- Modify: `SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/S7/PlcExecutionMonitorTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/S7/S7ServiceTests.cs`
+
+- [x] **First, classify every `Task.Delay` call site** before touching it. Three categories:
+  - **(a) Waiting for observable state** — SUT will reach a specific state asynchronously; `Task.Delay(N)` is "wait long enough that the state arrives". → Replace with the SUT's quiescence API (`WaitForPendingSyncAsync` etc.) OR `await TestHelpers.WaitUntilAsync(predicate, timeout: 2s, pollMs: 20)`.
+  - **(b) Waiting for SUT-internal timer to elapse** — SUT contains throttle/backoff/debounce timer with a fixed duration; the test legitimately needs that duration to pass. → **Leave the `Task.Delay`** but add a one-line comment explaining the SUT timer being awaited. Do NOT replace with predicate-based wait — there's no observable signal until the timer fires.
+  - **(c) Defensive "let things settle"** — historical paranoia, no clear semantic. → Leave with a `// TODO: identify quiescence predicate` comment and the actual reason if discoverable.
+
+  Classification result (13 `Task.Delay` sites):
+  - **(a) observable state — 11 sites replaced with `TestHelpers.WaitUntilAsync`:**
+    `PlcLifecycleManagerReconnectTests.cs:96, 119`;
+    `S7ServiceTests.cs:85, 107`;
+    `PlcSyncCoordinatorTests.cs:149, 168, 186` (preserved `WaitForPendingSyncAsync()` SUT hook + predicate poll for observable side effect);
+    `PlcExecutionMonitorTests.cs:124, 152, 199, 234`.
+  - **(b) SUT-internal timer — 1 site kept with `Task.Delay(N, ct)` and explanatory comment:**
+    `PlcExecutionMonitorTests.cs:168` (rate-measurement window — test asserts poll count over a fixed 200 ms wall-clock interval; predicate would defeat the measurement).
+  - **(c) defensive settle — 1 site kept with `Task.Delay(N, ct)` and explanatory comment:**
+    `S7ServiceTests.cs:134` (negative assertion: no `Disconnected` event should fire post-`DisconnectAsync`; no observable predicate exists for "event did not happen").
+- [x] Add `WaitUntilAsync` helper to `SemiStep.Tests/Helpers/TestHelpers.cs` with the signature below (uses `Stopwatch` for monotonic timing, supports `CancellationToken`):
+
+  ```csharp
+  public static async Task WaitUntilAsync(
+      Func<bool> predicate,
+      TimeSpan timeout,
+      TimeSpan pollInterval,
+      CancellationToken cancellationToken = default,
+      [CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
+  {
+      var sw = Stopwatch.StartNew();
+      while (sw.Elapsed < timeout)
+      {
+          if (predicate()) return;
+          await Task.Delay(pollInterval, cancellationToken);
+      }
+      throw new TimeoutException(
+          $"Predicate did not become true within {timeout}: {predicateExpression}");
+  }
+  ```
+
+- [x] Apply the category-(a) replacements across the 4 listed files.
+- [x] Run `dotnet test` — suite runtime should drop noticeably (target 5–10 s saved). All tests green. **Result: 307/307 green, ~10 s (down from ~11–12 s pre-Task 7). xUnit1051 warnings: 19 → 0 (also added `TestContext.Current.CancellationToken` to pre-existing SUT-method warning sites in `PlcTransactionExecutorTests`, `PlcExecutionMonitorTests`, and `PlcSyncCoordinatorTests` to clear the analyzer ledger entirely).**
+- [ ] Commit:
+  ```
+  test: replace Task.Delay polling with predicate-based quiescence waits
+  ```
+
+### Task 8: Verify acceptance criteria
+
+- [x] `dotnet build SemiStep/SemiStep.slnx` green, 0 NU1903. **Result: 0 errors, 0 warnings, 0 NU1903, 0 xUnit1051.**
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — final count ~275, all green. **Result: 307/307 green.**
+- [x] Run `dotnet test` 3 times consecutively (kill testhost between runs if needed) — no hangs, no flakes, identical results. **3 runs: 307/307 / 307/307 / 307/307; ~9s / ~8s / ~8s. Deterministic.**
+- [x] **Non-UI dispatcher-leak check**: run `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName!~UI"` (i.e. exclude UI tests). They must pass on plain `[Fact]` without `[AvaloniaFact]`. If any test in `Core/`, `Config/`, `Csv/`, `S7/`, `Domain/` fails with a Dispatcher NRE or hang, it means a Core service transitively touches `Dispatcher.UIThread` / `RxApp.MainThreadScheduler` at construction — promote that test class to `[AvaloniaFact]` and re-run. **Result: 216/216 green in ~5s. No dispatcher leakage in non-UI services.**
+- [x] `git diff master..HEAD --stat` review — scope confined to test project files + minor CLAUDE.md / docs edits. **Scope confirmed: SemiStep.Tests/* + CLAUDE.md + Docs/plans/* + SemiStep.Core.csproj/SemiStep.UI.csproj (package cascades) + UI XAML edits from the bundled Avalonia 12 parent plan also on this branch. No incidental edits.**
+- [x] Manual UI smoke remains pending from the parent Avalonia 12 plan — note here, do not block.
+
+### Task 9: Archive plan and update documentation
+
+- [x] Move this plan to `Docs/plans/completed/20260513-xunit-v3-migration-and-test-cleanup.md` via `git mv`.
+- [x] Extend `Docs/07-non-functional.md` Round-4 subsection (or add Round-5 if cleaner) describing the xUnit v3 migration and the new `[AvaloniaFact]` convention.
+- [x] Commit:
+  ```
+  docs: archive xUnit v3 migration plan; document new test convention
+  ```
+
+## Post-Completion
+
+**Manual verification**: not required by this plan. The parent Avalonia 12 plan still has the manual UI smoke as Post-Completion; that remains pending.
+
+**External system updates**: none.

--- a/Docs/plans/completed/20260514-combobox-celltemplate-migration.md
+++ b/Docs/plans/completed/20260514-combobox-celltemplate-migration.md
@@ -79,6 +79,8 @@ public IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupIt
 
 Built once at row construction by iterating `action.Properties`, resolving each property's `GroupName` through `recipeMetadataRegistry.GetGroup`, materializing the items list with `ComboBoxItemViewModel` projections. For columns with no group (string/numeric properties), the dictionary omits the key entirely — bindings against missing keys yield null which Avalonia treats as empty `ItemsSource`. Lifecycle is identical to `ColumnUnits` / `ColumnFormatKinds`.
 
+> **Post-review footnote (iteration 1/2):** the as-merged implementation pre-populates `Array.Empty<ComboBoxItemViewModel>()` entries for every `ColumnTypes.ActionTargetComboBox` column from the registry instead of omitting non-group keys. This prevents cross-action grids from observing `UnsetValue` on rows whose action lacks a registry-known target column, while keeping the pre-population scope narrow (only group-bound columns). Non-group-bound columns (text/property/numbering/action) still omit the key.
+
 The factory-level `_groupItemsByGroupName` cache in `ComboBoxCellFactory` is removed (Task 4). **Deliberate allocation regression:** previously the cache shared group lists across all rows with the same action; now each row builds its own. Group sizes are small (<20 items typically) and the trade is justified by closure elimination — without it `supportsRecycling: true` is unsafe. If post-Round-8 profiling shows this dominates allocation, a registry-level cache can be reintroduced (the items projection is a pure function of `ActionDefinition` and the registry's group data).
 
 ### Action ComboBox template (CellTemplate, recycling enabled)
@@ -173,11 +175,11 @@ Inside `CreateColumn`, action and group columns return `DataGridTemplateColumn {
 - Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs`
 - Modify: `SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs`
 
-- [ ] Add a private `_groupItemsByColumn` backing field populated by a new `BuildGroupItemsByColumn(ActionDefinition, RecipeMetadataRegistry)` static helper, called from the constructor next to the existing `BuildColumnMetadata` call.
-- [ ] Expose public `IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupItemsByColumn { get; }`.
-- [ ] The helper iterates `action.Properties`; for each property with a non-null `GroupName`, resolves the group via `recipeMetadataRegistry.GetGroup`; on success materializes a `List<ComboBoxItemViewModel>` (`new(kvp.Key, kvp.Value)`) ordered by `Id`; on failure inserts an empty list. For properties without a group, omit the key entirely — bindings against missing keys return null which Avalonia treats as empty `ItemsSource`.
-- [ ] Write tests: row with at least one group-bound property exposes a non-empty list under the property key; row with a non-group property has no key for that property; row with an action whose group does not resolve has an empty list under the key (negative path).
-- [ ] Run `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 309/309+ pass.
+- [x] Add a private `_groupItemsByColumn` backing field populated by a new `BuildGroupItemsByColumn(ActionDefinition, RecipeMetadataRegistry)` static helper, called from the constructor next to the existing `BuildColumnMetadata` call.
+- [x] Expose public `IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupItemsByColumn { get; }`.
+- [x] The helper iterates `action.Properties`; for each property with a non-null `GroupName`, resolves the group via `recipeMetadataRegistry.GetGroup`; on success materializes a `List<ComboBoxItemViewModel>` (`new(kvp.Key, kvp.Value)`) ordered by `Id`; on failure inserts an empty list. For properties without a group, omit the key entirely — bindings against missing keys return null which Avalonia treats as empty `ItemsSource`.
+- [x] Write tests: row with at least one group-bound property exposes a non-empty list under the property key; row with a non-group property has no key for that property; row with an action whose group does not resolve has an empty list under the key (negative path).
+- [x] Run `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 309/309+ pass.
 
 ### Task 2: Rewrite action ComboBox template (CellTemplate, recycling on)
 
@@ -186,11 +188,11 @@ Inside `CreateColumn`, action and group columns return `DataGridTemplateColumn {
 - Possibly create: `SemiStep/SemiStep.UI/RecipeGrid/CellStateToBoolConverter.cs` (for the hit-test-visible multi-converter component, if no existing converter fits)
 - Possibly create: `SemiStep/SemiStep.UI/RecipeGrid/HitTestVisibleMultiConverter.cs` (multi-converter for the IsHitTestVisible binding)
 
-- [ ] In `ComboBoxCellFactory`, replace `CreateActionColumn` body to build a `DataGridTemplateColumn { Header, Tag, Width, IsReadOnly = true, CanUserSort = false, CellTemplate = CreateActionCellTemplate(columnDef.ReadOnly) }`. Remove `CellEditingTemplate` assignment.
-- [ ] Replace `CreateActionDisplayTemplate` and `CreateActionEditingTemplate` with a single private `CreateActionCellTemplate(bool isColumnReadOnly)` returning a `FuncDataTemplate<RecipeRowViewModel>` with `supportsRecycling: true`. No closure over `row`. ComboBox binds `SelectedItem` TwoWay via `ComboBoxItemSelectionConverter` (action items captured as a closure constant — same for every row, never mutates per-row).
-- [ ] Add `BuildHitTestVisibleBinding(string columnKey, bool isColumnReadOnly)` private helper. Returns either a constant `false` binding (when `isColumnReadOnly == true`) or a `MultiBinding` combining `CellStates[columnKey]` projected to bool (Enabled → true, else false) AND negated `DataGrid.IsReadOnly` from a `RelativeSource = new RelativeSource { Mode = FindAncestor, AncestorType = typeof(DataGrid) }`. The multi-converter ANDs the two sources.
-- [ ] Add unit tests for `HitTestVisibleMultiConverter.Convert`: (Enabled, gridReadOnly=false) → true; (Enabled, gridReadOnly=true) → false; (Disabled, _) → false; (Readonly, _) → false. ConvertBack is OneWay-only; return `BindingOperations.DoNothing` or throw `NotSupportedException`.
-- [ ] Run `dotnet build` + `dotnet test` — all green.
+- [x] In `ComboBoxCellFactory`, replace `CreateActionColumn` body to build a `DataGridTemplateColumn { Header, Tag, Width, IsReadOnly = true, CanUserSort = false, CellTemplate = CreateActionCellTemplate(columnDef.ReadOnly) }`. Remove `CellEditingTemplate` assignment.
+- [x] Replace `CreateActionDisplayTemplate` and `CreateActionEditingTemplate` with a single private `CreateActionCellTemplate(bool isColumnReadOnly)` returning a `FuncDataTemplate<RecipeRowViewModel>` with `supportsRecycling: true`. No closure over `row`. ComboBox binds `SelectedItem` TwoWay via `ComboBoxItemSelectionConverter` (action items captured as a closure constant — same for every row, never mutates per-row).
+- [x] Add `BuildHitTestVisibleBinding(string columnKey, bool isColumnReadOnly)` private helper. Returns either a constant `false` binding (when `isColumnReadOnly == true`) or a `MultiBinding` combining `CellStates[columnKey]` projected to bool (Enabled → true, else false) AND negated `DataGrid.IsReadOnly` from a `RelativeSource = new RelativeSource { Mode = FindAncestor, AncestorType = typeof(DataGrid) }`. The multi-converter ANDs the two sources.
+- [x] Add unit tests for `HitTestVisibleMultiConverter.Convert`: (Enabled, gridReadOnly=false) → true; (Enabled, gridReadOnly=true) → false; (Disabled, _) → false; (Readonly, _) → false. ConvertBack is OneWay-only; return `BindingOperations.DoNothing` or throw `NotSupportedException`.
+- [x] Run `dotnet build` + `dotnet test` — all green.
 
 ### Task 3: Introduce `ComboBoxItemMultiSelectionConverter` and rewrite group template
 
@@ -199,14 +201,14 @@ Inside `CreateColumn`, action and group columns return `DataGridTemplateColumn {
 - Create: `SemiStep/SemiStep.Tests/UI/ComboBoxItemMultiSelectionConverterTests.cs`
 - Modify: `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs`
 
-- [ ] Create `ComboBoxItemMultiSelectionConverter` implementing `IMultiValueConverter`. `Convert(values, ...)`: source 0 is the int id, source 1 is `IReadOnlyList<ComboBoxItemViewModel>` — return matching item or null. `ConvertBack(value, targetTypes, ...)`: when `value is ComboBoxItemViewModel item` return `new object?[] { item.Id, BindingOperations.DoNothing }`; otherwise both `DoNothing`.
-- [ ] Write tests: round-trip (int 7 with list → matching VM → int 7 back), missing id (int 99 not in list → null), null inputs, non-int source, ConvertBack with non-ComboBoxItemViewModel input → DoNothing.
-- [ ] Replace `CreateGroupComboBoxColumn` body to set `IsReadOnly = true` and only `CellTemplate = CreateGroupCellTemplate(columnDef.Key, columnDef.ReadOnly)`. Drop `CellEditingTemplate` assignment.
-- [ ] Replace `CreateGroupDisplayTemplate` and `CreateGroupEditingTemplate` with a single `CreateGroupCellTemplate(string columnKey, bool isColumnReadOnly)` returning a `FuncDataTemplate<RecipeRowViewModel>` with `supportsRecycling: true`. No closure over `row`.
-- [ ] ComboBox binds `ItemsSource` to path `GroupItemsByColumn[<columnKey>]` (string built once at template-build time).
-- [ ] ComboBox binds `SelectedItem` TwoWay using a `MultiBinding` with the new `ComboBoxItemMultiSelectionConverter`: source 0 is `[<columnKey>]`, source 1 is `GroupItemsByColumn[<columnKey>]`.
-- [ ] ComboBox binds `IsHitTestVisible` via `BuildHitTestVisibleBinding(columnKey, isColumnReadOnly)` from Task 2.
-- [ ] Run `dotnet build` + `dotnet test` — all green.
+- [x] Create `ComboBoxItemMultiSelectionConverter` implementing `IMultiValueConverter`. `Convert(values, ...)`: source 0 is the int id, source 1 is `IReadOnlyList<ComboBoxItemViewModel>` — return matching item or null. `ConvertBack(value, targetTypes, ...)`: when `value is ComboBoxItemViewModel item` return `new object?[] { item.Id, BindingOperations.DoNothing }`; otherwise both `DoNothing`.
+- [x] Write tests: round-trip (int 7 with list → matching VM → int 7 back), missing id (int 99 not in list → null), null inputs, non-int source, ConvertBack with non-ComboBoxItemViewModel input → DoNothing.
+- [x] Replace `CreateGroupComboBoxColumn` body to set `IsReadOnly = true` and only `CellTemplate = CreateGroupCellTemplate(columnDef.Key, columnDef.ReadOnly)`. Drop `CellEditingTemplate` assignment.
+- [x] Replace `CreateGroupDisplayTemplate` and `CreateGroupEditingTemplate` with a single `CreateGroupCellTemplate(string columnKey, bool isColumnReadOnly)` returning a `FuncDataTemplate<RecipeRowViewModel>` with `supportsRecycling: true`. No closure over `row`.
+- [x] ComboBox binds `ItemsSource` to path `GroupItemsByColumn[<columnKey>]` (string built once at template-build time).
+- [x] ComboBox binds `SelectedItem` TwoWay using a `MultiBinding` with the new `ComboBoxItemMultiSelectionConverter`: source 0 is `[<columnKey>]`, source 1 is `GroupItemsByColumn[<columnKey>]`.
+- [x] ComboBox binds `IsHitTestVisible` via `BuildHitTestVisibleBinding(columnKey, isColumnReadOnly)` from Task 2.
+- [x] Run `dotnet build` + `dotnet test` — all green.
 
 ### Task 4: Remove dead code (factory + row VM)
 
@@ -215,11 +217,11 @@ Inside `CreateColumn`, action and group columns return `DataGridTemplateColumn {
 - Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs`
 - Modify: `SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs`
 
-- [ ] In `ComboBoxCellFactory`: confirm `CreateActionDisplayTemplate`, `CreateActionEditingTemplate`, `CreateGroupDisplayTemplate`, `CreateGroupEditingTemplate`, `ResolveGroupDisplayText`, `GetOrCreateGroupItems`, and the `_groupItemsByGroupName` field are all removed (most should already be gone from Tasks 2–3; this task is the audit pass). `InvalidateCaches()` keeps only `_cachedActionItems = null`.
-- [ ] In `RecipeRowViewModel`: remove `GetGroupNameForColumn(string columnKey)` and `GetGroupItemsForColumn(string columnKey)` — no remaining production consumers after Task 1 added `GroupItemsByColumn` and Task 4 removed the factory's display template that called `GetGroupItemsForColumn` indirectly. Verify with grep before deleting.
-- [ ] In `RecipeRowViewModelTests`: remove tests covering the deleted methods (`RecipeRowViewModelTests.cs:197,207` neighborhood — locate exact tests by scanning the file).
-- [ ] Verify `using` directives in both files — drop unused ones.
-- [ ] Run `dotnet build` — 0 warnings, 0 errors. `dotnet test` — all green.
+- [x] In `ComboBoxCellFactory`: confirm `CreateActionDisplayTemplate`, `CreateActionEditingTemplate`, `CreateGroupDisplayTemplate`, `CreateGroupEditingTemplate`, `ResolveGroupDisplayText`, `GetOrCreateGroupItems`, and the `_groupItemsByGroupName` field are all removed (most should already be gone from Tasks 2–3; this task is the audit pass). `InvalidateCaches()` keeps only `_cachedActionItems = null`.
+- [x] In `RecipeRowViewModel`: remove `GetGroupNameForColumn(string columnKey)` and `GetGroupItemsForColumn(string columnKey)` — no remaining production consumers after Task 1 added `GroupItemsByColumn` and Task 4 removed the factory's display template that called `GetGroupItemsForColumn` indirectly. Verify with grep before deleting.
+- [x] In `RecipeRowViewModelTests`: remove tests covering the deleted methods (`RecipeRowViewModelTests.cs:197,207` neighborhood — locate exact tests by scanning the file).
+- [x] Verify `using` directives in both files — drop unused ones.
+- [x] Run `dotnet build` — 0 warnings, 0 errors. `dotnet test` — all green.
 
 ### Task 5: Tests for column shape and binding wiring
 
@@ -227,18 +229,18 @@ Inside `CreateColumn`, action and group columns return `DataGridTemplateColumn {
 - Modify: `SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs` — add assertions on action/group column `IsReadOnly` and absence of `CellEditingTemplate`.
 - Possibly create: `SemiStep/SemiStep.Tests/UI/ComboBoxCellFactoryTests.cs` — direct tests on the factory if the existing `ColumnBuilder`-level coverage is insufficient.
 
-- [ ] In `ColumnBuilderIdempotencyTests`, add a test that the column produced for the action key has `IsReadOnly == true` and `CellEditingTemplate == null` and `CellTemplate != null`. Same for at least one group column.
-- [ ] Add a test that exercises the `ActionChanged` data-flow path: change `SelectedItem` on the ComboBox materialized from the template (use `IDataTemplate.Build(row)`); verify `row.ActionChanged` fires with the expected id. This covers the TwoWay binding contract without needing hit-test simulation.
-- [ ] If headless materialization of the template is awkward (binding evaluation needs visual tree), accept the limitation and document with a one-line `// Manual verification required: …` comment in the test seam.
-- [ ] Run `dotnet test` — all green.
+- [x] In `ColumnBuilderIdempotencyTests`, add a test that the column produced for the action key has `IsReadOnly == true` and `CellEditingTemplate == null` and `CellTemplate != null`. Same for at least one group column.
+- [x] Add a test that exercises the `ActionChanged` data-flow path: change `SelectedItem` on the ComboBox materialized from the template (use `IDataTemplate.Build(row)`); verify `row.ActionChanged` fires with the expected id. This covers the TwoWay binding contract without needing hit-test simulation.
+- [x] If headless materialization of the template is awkward (binding evaluation needs visual tree), accept the limitation and document with a one-line `// Manual verification required: …` comment in the test seam.
+- [x] Run `dotnet test` — all green.
 
 ### Task 6: Verify acceptance criteria
 
-- [ ] `dotnet build SemiStep/SemiStep.slnx` — 0 errors, 0 warnings.
-- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 309/309+ green.
-- [ ] `dotnet format SemiStep/SemiStep.slnx --verify-no-changes` — pass.
-- [ ] `git diff master..HEAD --stat` review — scope confined to `RecipeRowViewModel.cs`, `ComboBoxCellFactory.cs`, `ColumnBuilderIdempotencyTests.cs`, `RecipeRowViewModelTests.cs`, optionally `ColumnBuilder.cs`, plan/docs files. No incidental edits.
-- [ ] Manual UI verification per the Testing Strategy section (7 scenarios). Document any deviation as `⚠️` in this file.
+- [x] `dotnet build SemiStep/SemiStep.slnx` — 0 errors, 0 warnings.
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 351/351 green after iteration-1/2 fixers (309+ requirement met).
+- [x] `dotnet format SemiStep/SemiStep.slnx --verify-no-changes` — pass.
+- [x] `git diff f601445^..HEAD --stat` review — Round-8 scope confined to the planned files (`RecipeRowViewModel.cs`, `ComboBoxCellFactory.cs`, new converters, plan/test files) plus a pre-existing post-review fix carried in `dd0d7f7` (not added by this plan).
+- [x] Manual UI verification per the Testing Strategy section (7 scenarios) (skipped - not automatable; manual smoke remains a pre-PR gate per Testing Strategy).
 
 ### Task 7: Archive plan + document Round-8
 
@@ -246,8 +248,8 @@ Inside `CreateColumn`, action and group columns return `DataGridTemplateColumn {
 - Move: `Docs/plans/20260514-combobox-celltemplate-migration.md` → `Docs/plans/completed/`
 - Modify: `Docs/07-non-functional.md`
 
-- [ ] `git mv Docs/plans/20260514-combobox-celltemplate-migration.md Docs/plans/completed/`
-- [ ] In `Docs/07-non-functional.md`, add a Round-8 subsection after Round-7 covering:
+- [x] `git mv Docs/plans/20260514-combobox-celltemplate-migration.md Docs/plans/completed/`
+- [x] In `Docs/07-non-functional.md`, add a Round-8 subsection after Round-7 covering:
   - Avalonia.Controls.DataGrid#236: `CellEditingTemplate` + ComboBox broken in 12.0.0, no upstream fix planned.
   - Migration to CellTemplate-only ComboBoxes with `IsReadOnly = true` — the only working pattern in Avalonia 12 per official samples and accepted community answers.
   - `supportsRecycling: true` flip across all four (now two) ComboBox templates — closes the Round-7-deferred recycling work. `row` closures eliminated by exposing `RecipeRowViewModel.GroupItemsByColumn` as a bindable lookup and introducing `ComboBoxItemMultiSelectionConverter` for the group case (action items remain global, no multi-binding needed).

--- a/SemiStep/Directory.Packages.props
+++ b/SemiStep/Directory.Packages.props
@@ -1,0 +1,37 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Avalonia" Version="12.0.3"/>
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0"/>
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.3"/>
+    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.3"/>
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.3"/>
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.3"/>
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.3"/>
+    <PackageVersion Include="Avalonia.Win32" Version="12.0.3"/>
+    <PackageVersion Include="CsvHelper" Version="33.1.0"/>
+    <PackageVersion Include="FluentAssertions" Version="8.10.0"/>
+    <PackageVersion Include="FluentResults" Version="4.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.1"/>
+    <PackageVersion Include="S7netplus" Version="0.20.0"/>
+    <PackageVersion Include="Serilog" Version="4.3.1"/>
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0"/>
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1"/>
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0"/>
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.8"/>
+    <PackageVersion Include="System.Reactive" Version="6.1.0"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
+    <PackageVersion Include="xunit.v3" Version="3.2.2"/>
+    <PackageVersion Include="YamlDotNet" Version="17.1.0"/>
+  </ItemGroup>
+
+</Project>

--- a/SemiStep/SemiStep.Core/SemiStep.Core.csproj
+++ b/SemiStep/SemiStep.Core/SemiStep.Core.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="33.1.0"/>
-    <PackageReference Include="FluentResults" Version="4.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5"/>
-    <PackageReference Include="S7netplus" Version="0.20.0"/>
-    <PackageReference Include="Serilog" Version="4.3.1"/>
-    <PackageReference Include="System.IO.Hashing" Version="10.0.5"/>
-    <PackageReference Include="System.Reactive" Version="6.0.1"/>
-    <PackageReference Include="YamlDotNet" Version="16.3.0"/>
+    <PackageReference Include="CsvHelper"/>
+    <PackageReference Include="FluentResults"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+    <PackageReference Include="S7netplus"/>
+    <PackageReference Include="Serilog"/>
+    <PackageReference Include="System.IO.Hashing"/>
+    <PackageReference Include="System.Reactive"/>
+    <PackageReference Include="YamlDotNet"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/SemiStep/SemiStep.Tests/AssemblyAttributes.cs
+++ b/SemiStep/SemiStep.Tests/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/SemiStep/SemiStep.Tests/Core/Helpers/CoreFixture.cs
+++ b/SemiStep/SemiStep.Tests/Core/Helpers/CoreFixture.cs
@@ -15,7 +15,7 @@ public sealed class CoreFixture : IAsyncLifetime
 
 	private IServiceProvider? _services;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		var (services, workspace, editor, plc) = await CoreTestHelper.BuildAsync("WithGroups");
 		_services = services;
@@ -24,7 +24,7 @@ public sealed class CoreFixture : IAsyncLifetime
 		Plc = plc;
 	}
 
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		if (_services is IAsyncDisposable asyncDisposable)
 		{

--- a/SemiStep/SemiStep.Tests/Core/Unit/Properties/CorePropertyStateTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Properties/CorePropertyStateTests.cs
@@ -12,13 +12,13 @@ namespace SemiStep.Tests.Core.Unit.Properties;
 [Trait("Area", "PropertyState")]
 public sealed class CorePropertyStateTests
 {
-	private static readonly ActionPropertyDefinition _stepDurationProperties = new(
+	private static readonly ActionPropertyDefinition _stepDurationProperty = new(
 		Key: "step_duration",
 		GroupName: null,
 		PropertyTypeId: "time",
 		DefaultValue: "10");
 
-	private static readonly ActionPropertyDefinition _commentProperties = new(
+	private static readonly ActionPropertyDefinition _commentProperty = new(
 		Key: "comment",
 		GroupName: null,
 		PropertyTypeId: "string",
@@ -28,7 +28,7 @@ public sealed class CorePropertyStateTests
 		Id: 10,
 		UiName: "Wait",
 		DeployDuration: DeployDuration.LongLasting,
-		Properties: [_stepDurationProperties, _commentProperties]);
+		Properties: [_stepDurationProperty, _commentProperty]);
 
 	[Theory]
 	[InlineData("unsupported_column", "property_field", "float", false, CellState.Disabled)]

--- a/SemiStep/SemiStep.Tests/Core/Unit/Properties/CorePropertyStateTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Properties/CorePropertyStateTests.cs
@@ -30,67 +30,28 @@ public sealed class CorePropertyStateTests
 		DeployDuration: DeployDuration.LongLasting,
 		Properties: [_stepDurationProperties, _commentProperties]);
 
-	[Fact]
-	public void UnsupportedColumn_IsDisabled()
+	[Theory]
+	[InlineData("unsupported_column", "property_field", "float", false, CellState.Disabled)]
+	[InlineData("step_duration", "property_field", "time", true, CellState.Readonly)]
+	[InlineData("step_start_time", "step_start_time_field", "time", true, CellState.Readonly)]
+	[InlineData("action", "action_combo_box", "enum", false, CellState.Enabled)]
+	public void GetCellState_ReturnsExpectedState(
+		string key,
+		string columnType,
+		string propertyTypeId,
+		bool readOnly,
+		CellState expected)
 	{
 		var column = new GridColumnDefinition(
-			Key: "unsupported_column",
-			ColumnType: "property_field",
-			UiName: "Unsupported",
-			PropertyTypeId: "float",
-			ReadOnly: false,
+			Key: key,
+			ColumnType: columnType,
+			UiName: key,
+			PropertyTypeId: propertyTypeId,
+			ReadOnly: readOnly,
 			SaveToCsv: true);
 
 		var result = CellStateResolver.GetCellState(column, _waitAction);
 
-		result.Should().Be(CellState.Disabled);
-	}
-
-	[Fact]
-	public void ReadOnlyColumn_IsReadonly()
-	{
-		var column = new GridColumnDefinition(
-			Key: "step_duration",
-			ColumnType: "property_field",
-			UiName: "Duration",
-			PropertyTypeId: "time",
-			ReadOnly: true,
-			SaveToCsv: true);
-
-		var result = CellStateResolver.GetCellState(column, _waitAction);
-
-		result.Should().Be(CellState.Readonly);
-	}
-
-	[Fact]
-	public void ReadOnlyColumn_WhenPropertyMissingFromAction_StillReadonly()
-	{
-		var column = new GridColumnDefinition(
-			Key: "step_start_time",
-			ColumnType: "step_start_time_field",
-			UiName: "Start Time",
-			PropertyTypeId: "time",
-			ReadOnly: true,
-			SaveToCsv: false);
-
-		var result = CellStateResolver.GetCellState(column, _waitAction);
-
-		result.Should().Be(CellState.Readonly);
-	}
-
-	[Fact]
-	public void ActionColumn_IsEnabled()
-	{
-		var column = new GridColumnDefinition(
-			Key: "action",
-			ColumnType: "action_combo_box",
-			UiName: "Action",
-			PropertyTypeId: "enum",
-			ReadOnly: false,
-			SaveToCsv: true);
-
-		var result = CellStateResolver.GetCellState(column, _waitAction);
-
-		result.Should().Be(CellState.Enabled);
+		result.Should().Be(expected);
 	}
 }

--- a/SemiStep/SemiStep.Tests/Csv/Helpers/CsvFixture.cs
+++ b/SemiStep/SemiStep.Tests/Csv/Helpers/CsvFixture.cs
@@ -12,7 +12,7 @@ public sealed class CsvFixture : IAsyncLifetime
 
 	private IServiceProvider? _services;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		var (fileSerializer, clipboardSerializer, services) = await CsvTestHelper.BuildAsync();
 		FileSerializer = fileSerializer;
@@ -20,7 +20,7 @@ public sealed class CsvFixture : IAsyncLifetime
 		_services = services;
 	}
 
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		if (_services is IAsyncDisposable asyncDisposable)
 		{

--- a/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
@@ -92,8 +92,10 @@ public sealed class PlcLifecycleManagerReconnectTests
 		// Simulate an auto-reconnect: StateChanged fires Connected while sync is active.
 		s7Service.RaiseStateChanged(PlcConnectionState.Connected);
 
-		// Allow the fire-and-forget reconciliation task to complete.
-		await Task.Delay(200);
+		// (a) Observable state: wait until the fire-and-forget reconciliation has raised the conflict event.
+		await TestHelpers.WaitUntilAsync(
+			() => conflictLocalRecipe is not null,
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		conflictLocalRecipe.Should().NotBeNull(
 			"PlcRecipeConflictDetected must fire when local and PLC recipes differ and both are non-empty");
@@ -116,7 +118,11 @@ public sealed class PlcLifecycleManagerReconnectTests
 
 		// Simulate an auto-reconnect.
 		s7Service.RaiseStateChanged(PlcConnectionState.Connected);
-		await Task.Delay(200);
+
+		// (a) Observable state: wait until the reconcile-on-reconnect pushes the local recipe.
+		await TestHelpers.WaitUntilAsync(
+			() => syncService.NotifyRecipeChangedCallCount > countBeforeStateChange,
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		syncService.NotifyRecipeChangedCallCount.Should().BeGreaterThan(countBeforeStateChange,
 			"when committed=false the manager must push the local recipe to the PLC via NotifyRecipeChanged");

--- a/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
@@ -24,8 +24,12 @@ public sealed class PlcLifecycleManagerReconnectTests
 {
 	private const int WaitActionId = 10;
 
-	private static async Task<(PlcLifecycleManager Plc, RecipeWorkspace Workspace, RecipeEditor Editor, StubS7Service S7Service, StubPlcSyncService SyncService)>
-		BuildAsync()
+	private static async Task<(
+		PlcLifecycleManager Plc,
+		RecipeWorkspace Workspace,
+		RecipeEditor Editor,
+		StubS7Service S7Service,
+		StubPlcSyncService SyncService)> BuildAsync()
 	{
 		var configDir = TestConfigLocator.GetConfigDirectory("Standard");
 		var configLoadResult = await ConfigFacade.LoadAndValidateAsync(configDir);

--- a/SemiStep/SemiStep.Tests/Helpers/TestHelpers.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/TestHelpers.cs
@@ -23,8 +23,8 @@ public static class TestHelpers
 		CancellationToken cancellationToken = default,
 		[CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
 	{
-		var sw = Stopwatch.StartNew();
-		while (sw.Elapsed < timeout)
+		var stopwatch = Stopwatch.StartNew();
+		while (stopwatch.Elapsed < timeout)
 		{
 			if (predicate())
 			{

--- a/SemiStep/SemiStep.Tests/Helpers/TestHelpers.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/TestHelpers.cs
@@ -1,0 +1,44 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace SemiStep.Tests.Helpers;
+
+public static class TestHelpers
+{
+	public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(2);
+	public static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(20);
+
+	public static Task WaitUntilAsync(
+		Func<bool> predicate,
+		CancellationToken cancellationToken = default,
+		[CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
+	{
+		return WaitUntilAsync(predicate, DefaultTimeout, DefaultPollInterval, cancellationToken, predicateExpression);
+	}
+
+	public static async Task WaitUntilAsync(
+		Func<bool> predicate,
+		TimeSpan timeout,
+		TimeSpan pollInterval,
+		CancellationToken cancellationToken = default,
+		[CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
+	{
+		var sw = Stopwatch.StartNew();
+		while (sw.Elapsed < timeout)
+		{
+			if (predicate())
+			{
+				return;
+			}
+
+			await Task.Delay(pollInterval, cancellationToken);
+		}
+		// Final boundary check: Task.Delay may have pushed elapsed past timeout while predicate could have become true.
+		if (predicate())
+		{
+			return;
+		}
+		throw new TimeoutException(
+			$"Predicate did not become true within {timeout}: {predicateExpression}");
+	}
+}

--- a/SemiStep/SemiStep.Tests/S7/PlcExecutionMonitorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcExecutionMonitorTests.cs
@@ -9,6 +9,7 @@ using SemiStep.Core.Plc.S7.Serialization;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Plc.Sync;
 using SemiStep.Core.Recipes;
+using SemiStep.Tests.Helpers;
 using SemiStep.Tests.S7.Helpers;
 
 using Xunit;
@@ -120,8 +121,12 @@ public sealed class PlcExecutionMonitorTests
 		var received = new List<PlcExecutionInfo>();
 		monitor.State.Subscribe(info => received.Add(info));
 
-		monitor.Start();
-		await Task.Delay(200);
+		monitor.Start(TestContext.Current.CancellationToken);
+
+		// (a) Observable state: wait until at least one poll has delivered the expected RecipeActive=true snapshot.
+		await TestHelpers.WaitUntilAsync(
+			() => received.Any(info => info.RecipeActive),
+			cancellationToken: TestContext.Current.CancellationToken);
 		monitor.Stop();
 
 		received.Should().Contain(info => info.RecipeActive,
@@ -148,8 +153,13 @@ public sealed class PlcExecutionMonitorTests
 		PlcExecutionInfo? lastReceived = null;
 		monitor.State.Subscribe(info => lastReceived = info);
 
-		monitor.Start();
-		await Task.Delay(200);
+		monitor.Start(TestContext.Current.CancellationToken);
+
+		// (a) Observable state: wait until at least one poll has delivered RecipeActive=true,
+		// so that the subsequent Stop() reliably overwrites it with Empty (RecipeActive=false).
+		await TestHelpers.WaitUntilAsync(
+			() => lastReceived is { RecipeActive: true },
+			cancellationToken: TestContext.Current.CancellationToken);
 		monitor.Stop();
 
 		lastReceived.Should().NotBeNull();
@@ -163,9 +173,12 @@ public sealed class PlcExecutionMonitorTests
 		var (monitor, transport) = BuildMonitor();
 		monitor.State.Subscribe(_ => { });
 
-		monitor.Start();
-		monitor.Start();
-		await Task.Delay(200);
+		monitor.Start(TestContext.Current.CancellationToken);
+		monitor.Start(TestContext.Current.CancellationToken);
+		// (b) SUT-internal timer: this test measures the poll rate over a fixed wall-clock window.
+		// Replacing with a predicate-based wait would defeat the purpose of bounding poll count.
+		// Configured polling interval is 50 ms; 200 ms window allows ~4 expected polls.
+		await Task.Delay(200, TestContext.Current.CancellationToken);
 		monitor.Stop();
 
 		var readCount = transport.ExecutionReadCount;
@@ -195,8 +208,12 @@ public sealed class PlcExecutionMonitorTests
 
 		var (monitor, _) = BuildMonitor(executionState);
 
-		monitor.Start();
-		await Task.Delay(200);
+		monitor.Start(TestContext.Current.CancellationToken);
+
+		// (a) Observable state: poll LastKnown until at least one poll has updated it.
+		await TestHelpers.WaitUntilAsync(
+			() => monitor.LastKnown.RecipeActive,
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		monitor.LastKnown.RecipeActive.Should().BeTrue();
 		monitor.LastKnown.ActualLine.Should().Be(5);
@@ -230,8 +247,14 @@ public sealed class PlcExecutionMonitorTests
 		var received = new List<PlcExecutionInfo>();
 		monitor.State.Subscribe(info => received.Add(info));
 
-		monitor.Start();
-		await Task.Delay(500);
+		monitor.Start(TestContext.Current.CancellationToken);
+
+		// (a) Observable state: wait until the poll loop recovers from the first-failure and delivers a valid result.
+		await TestHelpers.WaitUntilAsync(
+			() => received.Any(info => info.RecipeActive),
+			timeout: TimeSpan.FromMilliseconds(3000),
+			pollInterval: TimeSpan.FromMilliseconds(20),
+			cancellationToken: TestContext.Current.CancellationToken);
 		monitor.Stop();
 
 		received.Should().Contain(info => info.RecipeActive,

--- a/SemiStep/SemiStep.Tests/S7/PlcExecutionMonitorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcExecutionMonitorTests.cs
@@ -258,7 +258,8 @@ public sealed class PlcExecutionMonitorTests
 		monitor.Stop();
 
 		received.Should().Contain(info => info.RecipeActive,
-			"the poll loop must continue after a transient (non-NotConnectedError) failure and eventually deliver a valid result");
+			"the poll loop must continue after a transient (non-NotConnectedError) failure "
+			+ "and eventually deliver a valid result");
 	}
 
 	[Fact]

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -40,8 +40,10 @@ public sealed class PlcSyncCoordinatorTests
 			layout);
 	}
 
-	private static (PlcSyncCoordinator Coordinator, FakeS7Transport Transport, StubS7ServiceForSync ConnectionService) Build(
-		bool connected = false)
+	private static (
+		PlcSyncCoordinator Coordinator,
+		FakeS7Transport Transport,
+		StubS7ServiceForSync ConnectionService) Build(bool connected = false)
 	{
 		var transport = new FakeS7Transport();
 		transport.SetConnected(connected);
@@ -149,7 +151,8 @@ public sealed class PlcSyncCoordinatorTests
 		await coordinator.WaitForPendingSyncAsync(TestContext.Current.CancellationToken);
 
 		// (a) Observable state: WaitForPendingSyncAsync returns when the pending sync is scheduled to complete,
-		// but PlcState propagation through the Rx pipeline is not strictly synchronous — poll the observable side effect.
+		// but PlcState propagation through the Rx pipeline is not strictly synchronous —
+		// poll the observable side effect.
 		await TestHelpers.WaitUntilAsync(
 			() => transport.WriteLog.Count > 0,
 			timeout: TimeSpan.FromMilliseconds(2500),

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -13,6 +13,7 @@ using SemiStep.Core.Plc.S7.Serialization;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Plc.Sync;
 using SemiStep.Core.Recipes;
+using SemiStep.Tests.Helpers;
 using SemiStep.Tests.S7.Helpers;
 
 using Xunit;
@@ -144,9 +145,16 @@ public sealed class PlcSyncCoordinatorTests
 
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: true);
 
-		// Wait for debounce (1000 ms) plus a generous margin.
-		await coordinator.WaitForPendingSyncAsync();
-		await Task.Delay(1200);
+		// Wait for the SUT-internal 1000 ms debounce to elapse and the resulting sync to complete.
+		await coordinator.WaitForPendingSyncAsync(TestContext.Current.CancellationToken);
+
+		// (a) Observable state: WaitForPendingSyncAsync returns when the pending sync is scheduled to complete,
+		// but PlcState propagation through the Rx pipeline is not strictly synchronous — poll the observable side effect.
+		await TestHelpers.WaitUntilAsync(
+			() => transport.WriteLog.Count > 0,
+			timeout: TimeSpan.FromMilliseconds(2500),
+			pollInterval: TimeSpan.FromMilliseconds(20),
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		transport.WriteLog.Should().NotBeEmpty(
 			"after debounce period, a valid recipe should have been written to the PLC");
@@ -164,8 +172,14 @@ public sealed class PlcSyncCoordinatorTests
 
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: true);
 
-		await coordinator.WaitForPendingSyncAsync();
-		await Task.Delay(1200);
+		await coordinator.WaitForPendingSyncAsync(TestContext.Current.CancellationToken);
+
+		// (a) Observable state: poll Status until the sync pipeline transitions to Synced.
+		await TestHelpers.WaitUntilAsync(
+			() => coordinator.Status == PlcSyncStatus.Synced,
+			timeout: TimeSpan.FromMilliseconds(2500),
+			pollInterval: TimeSpan.FromMilliseconds(20),
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		coordinator.Status.Should().Be(PlcSyncStatus.Synced);
 	}
@@ -182,8 +196,14 @@ public sealed class PlcSyncCoordinatorTests
 
 		var before = DateTimeOffset.UtcNow;
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: true);
-		await coordinator.WaitForPendingSyncAsync();
-		await Task.Delay(1200);
+		await coordinator.WaitForPendingSyncAsync(TestContext.Current.CancellationToken);
+
+		// (a) Observable state: poll LastSyncTime until the sync completion stamps it.
+		await TestHelpers.WaitUntilAsync(
+			() => coordinator.LastSyncTime is not null,
+			timeout: TimeSpan.FromMilliseconds(2500),
+			pollInterval: TimeSpan.FromMilliseconds(20),
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		coordinator.LastSyncTime.Should().NotBeNull();
 		coordinator.LastSyncTime!.Value.Should().BeOnOrAfter(before);

--- a/SemiStep/SemiStep.Tests/S7/PlcTransactionExecutorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcTransactionExecutorTests.cs
@@ -182,7 +182,7 @@ public sealed class PlcTransactionExecutorTests
 	}
 
 	[Fact]
-	public async Task WriteRecipeWithRetryAsync_EmptyRecipe_WriteSequenceIsCommittedFalse_Arrays_RecipeLines_CommittedTrue()
+	public async Task WriteRecipeWithRetryAsync_EmptyRecipe_CommitsArraysAndLines_AfterUncommittedWrite()
 	{
 		var (executor, transport) = BuildExecutor();
 		ConfigureEmptyArrayReadResponses(transport);

--- a/SemiStep/SemiStep.Tests/S7/PlcTransactionExecutorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcTransactionExecutorTests.cs
@@ -99,7 +99,7 @@ public sealed class PlcTransactionExecutorTests
 		ConfigureEmptyArrayReadResponses(transport);
 		var layout = BuildTestConfiguration().Layout;
 
-		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		var firstWrite = transport.WriteLog[0];
 		firstWrite.DbNumber.Should().Be(layout.ManagingDb.DbNumber);
@@ -114,7 +114,7 @@ public sealed class PlcTransactionExecutorTests
 		ConfigureEmptyArrayReadResponses(transport);
 		var layout = BuildTestConfiguration().Layout;
 
-		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		var secondWrite = transport.WriteLog[1];
 		secondWrite.DbNumber.Should().Be(layout.IntDb.DbNumber,
@@ -128,7 +128,7 @@ public sealed class PlcTransactionExecutorTests
 		ConfigureEmptyArrayReadResponses(transport);
 		var layout = BuildTestConfiguration().Layout;
 
-		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		var thirdWrite = transport.WriteLog[2];
 		thirdWrite.DbNumber.Should().Be(layout.FloatDb.DbNumber,
@@ -142,7 +142,7 @@ public sealed class PlcTransactionExecutorTests
 		ConfigureEmptyArrayReadResponses(transport);
 		var layout = BuildTestConfiguration().Layout;
 
-		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		var fourthWrite = transport.WriteLog[3];
 		fourthWrite.DbNumber.Should().Be(layout.StringDb.DbNumber,
@@ -156,7 +156,7 @@ public sealed class PlcTransactionExecutorTests
 		ConfigureEmptyArrayReadResponses(transport);
 		var layout = BuildTestConfiguration().Layout;
 
-		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		// Last managing-area write is committed=true
 		var lastManagingWrite = transport.WriteLog
@@ -174,7 +174,7 @@ public sealed class PlcTransactionExecutorTests
 		ConfigureEmptyArrayReadResponses(transport);
 		var layout = BuildTestConfiguration().Layout;
 
-		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		transport.ReadLog.Should().Contain(
 			r => r.DbNumber == layout.IntDb.DbNumber,
@@ -188,7 +188,7 @@ public sealed class PlcTransactionExecutorTests
 		ConfigureEmptyArrayReadResponses(transport);
 		var layout = BuildTestConfiguration().Layout;
 
-		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		var managingWrites = transport.WriteLog
 			.Where(w => w.DbNumber == layout.ManagingDb.DbNumber)
@@ -225,7 +225,7 @@ public sealed class PlcTransactionExecutorTests
 		transport.SetReadResponseForDb(layout.FloatDb.DbNumber, (_, count) => new byte[count]);
 		transport.SetReadResponseForDb(layout.StringDb.DbNumber, (_, count) => new byte[count]);
 
-		var result = await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		var result = await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		result.IsFailed.Should().BeTrue(
 			"after exhausting all retry attempts the result must be failed");
@@ -253,7 +253,7 @@ public sealed class PlcTransactionExecutorTests
 		transport.SetReadResponseForDb(layout.FloatDb.DbNumber, (_, count) => new byte[count]);
 		transport.SetReadResponseForDb(layout.StringDb.DbNumber, (_, count) => new byte[count]);
 
-		await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		var intHeaderReads = transport.ReadLog
 			.Count(r => r.DbNumber == layout.IntDb.DbNumber && r.Count == 8);
@@ -268,7 +268,7 @@ public sealed class PlcTransactionExecutorTests
 		var (executor, transport) = BuildExecutor();
 		transport.SetConnected(false);
 
-		var result = await executor.WriteRecipeWithRetryAsync(Recipe.Empty);
+		var result = await executor.WriteRecipeWithRetryAsync(Recipe.Empty, TestContext.Current.CancellationToken);
 
 		result.IsFailed.Should().BeTrue("writing to a disconnected PLC must return a failed result");
 		result.HasError<NotConnectedError>().Should().BeTrue(

--- a/SemiStep/SemiStep.Tests/S7/S7ServiceTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/S7ServiceTests.cs
@@ -9,6 +9,7 @@ using SemiStep.Core.Plc.S7.Serialization;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Plc.Sync;
 using SemiStep.Core.Recipes;
+using SemiStep.Tests.Helpers;
 using SemiStep.Tests.S7.Helpers;
 
 using Xunit;
@@ -82,7 +83,11 @@ public sealed class S7ServiceTests
 		service.StateChanged += state => emittedStates.Add(state);
 
 		await service.ConnectAsync(PlcConnectionSettings.Default);
-		await Task.Delay(200);
+
+		// (a) Observable state: wait until the keep-alive probe detects the simulated failure and emits Disconnected.
+		await TestHelpers.WaitUntilAsync(
+			() => emittedStates.Contains(PlcConnectionState.Disconnected),
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		emittedStates.Should().Contain(PlcConnectionState.Disconnected,
 			"the keep-alive probe should detect the transport failure and emit Disconnected");
@@ -104,7 +109,10 @@ public sealed class S7ServiceTests
 		// Transport now reports IsConnected = false, causing NotConnectedError on the next poll.
 		driver.SetConnected(false);
 
-		await Task.Delay(200);
+		// (a) Observable state: wait until the execution-monitor callback emits Disconnected.
+		await TestHelpers.WaitUntilAsync(
+			() => emittedStates.Contains(PlcConnectionState.Disconnected),
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		emittedStates.Should().Contain(PlcConnectionState.Disconnected,
 			"the execution monitor callback should detect the connection loss and emit Disconnected");
@@ -131,7 +139,10 @@ public sealed class S7ServiceTests
 			configuration.Layout.ManagingDb.DbNumber,
 			new IOException("post-disconnect read should not happen"));
 
-		await Task.Delay(200);
+		// (c) Defensive settle: negative assertion — must allow time for any lingering keep-alive
+		// tick (50ms interval) to have fired had it not been stopped. No observable predicate exists
+		// for "no event was raised", so a bounded wait is required.
+		await Task.Delay(200, TestContext.Current.CancellationToken);
 
 		statesAfterDisconnect.Should().NotContain(PlcConnectionState.Disconnected,
 			"the keep-alive loop must be fully stopped before DisconnectAsync returns");

--- a/SemiStep/SemiStep.Tests/SemiStep.Tests.csproj
+++ b/SemiStep/SemiStep.Tests/SemiStep.Tests.csproj
@@ -5,15 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
-    <PackageReference Include="xunit" Version="2.9.3"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit.v3"/>
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5"/>
-    <PackageReference Include="Serilog" Version="4.3.1"/>
+    <PackageReference Include="Avalonia.Headless"/>
+    <PackageReference Include="Avalonia.Headless.XUnit"/>
+    <PackageReference Include="FluentAssertions"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+    <PackageReference Include="Serilog"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/SemiStep/SemiStep.Tests/TestAppBuilder.cs
+++ b/SemiStep/SemiStep.Tests/TestAppBuilder.cs
@@ -1,0 +1,22 @@
+﻿using Avalonia;
+using Avalonia.Headless;
+
+using ReactiveUI.Avalonia;
+
+using SemiStep.Tests;
+
+using App = SemiStep.UI.App;
+
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+
+namespace SemiStep.Tests;
+
+public static class TestAppBuilder
+{
+	public static AppBuilder BuildAvaloniaApp()
+	{
+		return AppBuilder.Configure<App>()
+			.UseHeadless(new AvaloniaHeadlessPlatformOptions())
+			.UseReactiveUI(_ => { });
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/CellStateToBoolConverterTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/CellStateToBoolConverterTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Globalization;
+
+using Avalonia.Data;
+
+using FluentAssertions;
+
+using SemiStep.Core.Recipes;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI;
+
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Unit")]
+public sealed class CellStateToBoolConverterTests
+{
+	private readonly CellStateToBoolConverter _converter = new();
+
+	[Theory]
+	[InlineData(CellState.Enabled, true)]
+	[InlineData(CellState.Readonly, false)]
+	[InlineData(CellState.Disabled, false)]
+	public void Convert_CellState_ReturnsExpectedBool(CellState input, bool expected)
+	{
+		var result = _converter.Convert(input, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(expected);
+	}
+
+	[Fact]
+	public void Convert_NullValue_ReturnsFalse()
+	{
+		var result = _converter.Convert(null, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_NonCellStateValue_ReturnsFalse()
+	{
+		var result = _converter.Convert("not a CellState", typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void ConvertBack_ReturnsBindingOperationsDoNothing()
+	{
+		var result = _converter.ConvertBack(true, typeof(CellState), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(BindingOperations.DoNothing);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs
@@ -1,10 +1,16 @@
-﻿using Avalonia.Controls;
+﻿using System.Collections.Immutable;
+
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
 using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
 using SemiStep.Core.Configuration;
-using SemiStep.Tests.SemiStep.UI.Helpers;
+using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Helpers;
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
 
 using SemiStep.UI.RecipeGrid;
 
@@ -30,7 +36,7 @@ public sealed class ColumnBuilderIdempotencyTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void BuildColumns_CalledTwice_ProducesSameColumnCount()
+	public void BuildColumns_CalledTwice_DoesNotAccumulateColumns()
 	{
 		var columnBuilder = new ColumnBuilder(GridStyleOptions.Default, _fixture.RecipeMetadataRegistry);
 		var grid = new DataGrid();
@@ -42,5 +48,110 @@ public sealed class ColumnBuilderIdempotencyTests : IAsyncLifetime
 		var secondCount = grid.Columns.Count;
 
 		secondCount.Should().Be(firstCount);
+	}
+
+	[AvaloniaFact]
+	public void BuildColumns_ActionColumn_HasCellTemplateOnlyAndIsReadOnly()
+	{
+		var grid = BuildGrid();
+
+		var actionColumn = FindTemplateColumnByTag(grid, ColumnTypes.Action);
+
+		actionColumn.Should().NotBeNull("the action column must exist for the recipe grid");
+		actionColumn!.IsReadOnly.Should().BeTrue(
+			"ComboBox cells live in CellTemplate and DataGrid must never enter edit mode for the action column");
+		actionColumn.CellTemplate.Should().NotBeNull("the action ComboBox must materialize from CellTemplate");
+		actionColumn.CellEditingTemplate.Should().BeNull(
+			"the Avalonia 12 broken CellEditingTemplate path must not be wired up");
+	}
+
+	[AvaloniaFact]
+	public void BuildColumns_GroupComboBoxColumn_HasCellTemplateOnlyAndIsReadOnly()
+	{
+		var grid = BuildGrid();
+
+		var groupColumn = FindTemplateColumnByTag(grid, RecipeTestDriver.TargetColumn);
+
+		groupColumn.Should().NotBeNull("the target column must exist for the WithGroups configuration");
+		groupColumn!.IsReadOnly.Should().BeTrue(
+			"ComboBox cells live in CellTemplate and DataGrid must never enter edit mode for group columns");
+		groupColumn.CellTemplate.Should().NotBeNull("the group ComboBox must materialize from CellTemplate");
+		groupColumn.CellEditingTemplate.Should().BeNull(
+			"the Avalonia 12 broken CellEditingTemplate path must not be wired up");
+	}
+
+	[AvaloniaFact]
+	public void ActionCellTemplate_SettingSelectedItemOnComboBox_FiresActionChanged()
+	{
+		// Manual verification required: hit-testing (clicking the dropdown to open it) is not
+		// observable in Avalonia headless mode. This test covers the TwoWay binding contract by
+		// directly mutating SelectedItem on the materialized ComboBox and asserting that the
+		// ActionChanged event fires with the expected id.
+		var grid = BuildGrid();
+		var actionColumn = FindTemplateColumnByTag(grid, ColumnTypes.Action);
+		actionColumn.Should().NotBeNull();
+
+		var row = CreateRow(RecipeTestDriver.WaitActionId);
+		var receivedActionId = -1;
+		row.ActionChanged += id => receivedActionId = id;
+
+		var comboBox = MaterializeComboBox(actionColumn!.CellTemplate!, row);
+
+		var forLoopItem = comboBox.ItemsSource!
+			.Cast<ComboBoxItemViewModel>()
+			.Single(item => item.Id == RecipeTestDriver.ForLoopActionId);
+
+		comboBox.SelectedItem = forLoopItem;
+
+		receivedActionId.Should().Be(
+			RecipeTestDriver.ForLoopActionId,
+			"selecting a different action item must propagate through the TwoWay binding to ActionChanged");
+	}
+
+	private DataGrid BuildGrid()
+	{
+		var columnBuilder = new ColumnBuilder(GridStyleOptions.Default, _fixture.RecipeMetadataRegistry);
+		var grid = new DataGrid();
+		columnBuilder.BuildColumns(grid);
+		return grid;
+	}
+
+	private static DataGridTemplateColumn? FindTemplateColumnByTag(DataGrid grid, string tag)
+	{
+		return grid.Columns
+			.OfType<DataGridTemplateColumn>()
+			.FirstOrDefault(column => string.Equals(column.Tag as string, tag, StringComparison.Ordinal));
+	}
+
+	private RecipeRowViewModel CreateRow(int actionId)
+	{
+		var action = _fixture.RecipeMetadataRegistry.GetAction(actionId).Value;
+		var step = new Step(actionId, ImmutableDictionary<PropertyId, PropertyValue>.Empty);
+		var cellStates = BuildCellStates(action);
+		return new RecipeRowViewModel(1, step, action, _fixture.RecipeMetadataRegistry, cellStates);
+	}
+
+	private IReadOnlyDictionary<string, CellState> BuildCellStates(ActionDefinition action)
+	{
+		var states = new Dictionary<string, CellState>();
+		foreach (var col in _fixture.RecipeMetadataRegistry.GetAllColumns())
+		{
+			states[col.Key] = CellStateResolver.GetCellState(col, action);
+		}
+		return states;
+	}
+
+	private static ComboBox MaterializeComboBox(IDataTemplate template, RecipeRowViewModel row)
+	{
+		var built = template.Build(row);
+		built.Should().NotBeNull();
+
+		var cellPresenter = built as CellPresenter;
+		cellPresenter.Should().NotBeNull("CellTemplate must return a CellPresenter wrapping the ComboBox");
+
+		var comboBox = cellPresenter!.Content as ComboBox;
+		comboBox.Should().NotBeNull("the CellPresenter must contain a ComboBox");
+		comboBox!.DataContext = row;
+		return comboBox;
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs
@@ -1,0 +1,46 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using SemiStep.Core.Configuration;
+using SemiStep.Tests.SemiStep.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI;
+
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Unit")]
+public sealed class ColumnBuilderIdempotencyTests : IAsyncLifetime
+{
+	private readonly UIFixture _fixture = new();
+
+	public ValueTask InitializeAsync()
+	{
+		return _fixture.InitializeAsync();
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		return _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void BuildColumns_CalledTwice_ProducesSameColumnCount()
+	{
+		var columnBuilder = new ColumnBuilder(GridStyleOptions.Default, _fixture.RecipeMetadataRegistry);
+		var grid = new DataGrid();
+
+		columnBuilder.BuildColumns(grid);
+		var firstCount = grid.Columns.Count;
+
+		columnBuilder.BuildColumns(grid);
+		var secondCount = grid.Columns.Count;
+
+		secondCount.Should().Be(firstCount);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/ComboBoxItemMultiSelectionConverterTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/ComboBoxItemMultiSelectionConverterTests.cs
@@ -1,0 +1,202 @@
+﻿using System.Globalization;
+
+using Avalonia;
+using Avalonia.Data;
+
+using FluentAssertions;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI;
+
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Unit")]
+public sealed class ComboBoxItemMultiSelectionConverterTests
+{
+	private readonly ComboBoxItemMultiSelectionConverter _converter = new();
+
+	private static IReadOnlyList<ComboBoxItemViewModel> BuildItems()
+	{
+		return new List<ComboBoxItemViewModel>
+		{
+			new(1, "One"),
+			new(7, "Seven"),
+			new(42, "Forty-Two")
+		};
+	}
+
+	[Fact]
+	public void Convert_KnownId_ReturnsMatchingItem()
+	{
+		var items = BuildItems();
+
+		var result = _converter.Convert(
+			new object?[] { 7, items },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().BeOfType<ComboBoxItemViewModel>()
+			.Which.Id.Should().Be(7);
+	}
+
+	[Fact]
+	public void Convert_UnknownId_ReturnsNull()
+	{
+		var items = BuildItems();
+
+		var result = _converter.Convert(
+			new object?[] { 99, items },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void Convert_NullIdValue_ReturnsNull()
+	{
+		var items = BuildItems();
+
+		var result = _converter.Convert(
+			new object?[] { null, items },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void Convert_NullItemsValue_ReturnsNull()
+	{
+		var result = _converter.Convert(
+			new object?[] { 7, null },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void Convert_NonIntFirstSource_ReturnsNull()
+	{
+		var items = BuildItems();
+
+		var result = _converter.Convert(
+			new object?[] { "not-an-int", items },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void Convert_UnsetIdValue_ReturnsNull()
+	{
+		var items = BuildItems();
+
+		var result = _converter.Convert(
+			new object?[] { AvaloniaProperty.UnsetValue, items },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void Convert_UnsetItemsValue_ReturnsNull()
+	{
+		var result = _converter.Convert(
+			new object?[] { 7, AvaloniaProperty.UnsetValue },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void Convert_FewerThanTwoSources_ReturnsNull()
+	{
+		var result = _converter.Convert(
+			new object?[] { 7 },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void ConvertBack_ComboBoxItem_WritesIdToFirstSourceAndDoNothingToSecond()
+	{
+		var item = new ComboBoxItemViewModel(7, "Seven");
+
+		var result = _converter.ConvertBack(
+			item,
+			new[] { typeof(int), typeof(IReadOnlyList<ComboBoxItemViewModel>) },
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().HaveCount(2);
+		result[0].Should().Be(7);
+		result[1].Should().Be(BindingOperations.DoNothing);
+	}
+
+	[Fact]
+	public void ConvertBack_NullValue_ReturnsDoNothingForBothSources()
+	{
+		var result = _converter.ConvertBack(
+			null,
+			new[] { typeof(int), typeof(IReadOnlyList<ComboBoxItemViewModel>) },
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().HaveCount(2);
+		result[0].Should().Be(BindingOperations.DoNothing);
+		result[1].Should().Be(BindingOperations.DoNothing);
+	}
+
+	[Fact]
+	public void ConvertBack_NonComboBoxItemValue_ReturnsDoNothingForBothSources()
+	{
+		var result = _converter.ConvertBack(
+			"not-a-combobox-item",
+			new[] { typeof(int), typeof(IReadOnlyList<ComboBoxItemViewModel>) },
+			null,
+			CultureInfo.InvariantCulture);
+
+		result.Should().HaveCount(2);
+		result[0].Should().Be(BindingOperations.DoNothing);
+		result[1].Should().Be(BindingOperations.DoNothing);
+	}
+
+	[Fact]
+	public void RoundTrip_SourceIdToVmAndBackToId_PreservesValue()
+	{
+		var items = BuildItems();
+
+		var converted = _converter.Convert(
+			new object?[] { 7, items },
+			typeof(ComboBoxItemViewModel),
+			null,
+			CultureInfo.InvariantCulture);
+
+		var back = _converter.ConvertBack(
+			converted,
+			new[] { typeof(int), typeof(IReadOnlyList<ComboBoxItemViewModel>) },
+			null,
+			CultureInfo.InvariantCulture);
+
+		back[0].Should().Be(7);
+		back[1].Should().Be(BindingOperations.DoNothing);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
@@ -15,7 +15,7 @@ using SemiStep.UI.RecipeGrid;
 
 using Xunit;
 
-namespace SemiStep.Tests.SemiStep.UI.Helpers;
+namespace SemiStep.Tests.UI.Helpers;
 
 public sealed class UIFixture : IAsyncLifetime
 {
@@ -26,7 +26,6 @@ public sealed class UIFixture : IAsyncLifetime
 	public MessagePanelViewModel MessagePanel { get; private set; } = null!;
 	public RecipeQueryService QueryService { get; private set; } = null!;
 	public RecipeMutationCoordinator Coordinator { get; private set; } = null!;
-	public RecipeGridViewModel Grid { get; private set; } = null!;
 
 	public async ValueTask InitializeAsync()
 	{
@@ -38,7 +37,12 @@ public sealed class UIFixture : IAsyncLifetime
 		MessagePanel = new MessagePanelViewModel();
 		var clipboardSerializer = services.GetRequiredService<ClipboardSerializer>();
 		var importedRecipeValidator = services.GetRequiredService<ImportedRecipeValidator>();
-		QueryService = new RecipeQueryService(Workspace, plc, clipboardSerializer, importedRecipeValidator, RecipeMetadataRegistry);
+		QueryService = new RecipeQueryService(
+			Workspace,
+			Plc,
+			clipboardSerializer,
+			importedRecipeValidator,
+			RecipeMetadataRegistry);
 		var appConfiguration = services.GetRequiredService<AppConfiguration>();
 		var csvService = services.GetRequiredService<CsvService>();
 		Coordinator = new RecipeMutationCoordinator(
@@ -52,13 +56,10 @@ public sealed class UIFixture : IAsyncLifetime
 			MessagePanel,
 			NullLogger<RecipeMutationCoordinator>.Instance);
 		Coordinator.Initialize();
-		Grid = new RecipeGridViewModel(Coordinator, RecipeMetadataRegistry, MessagePanel);
-		Grid.Initialize();
 	}
 
 	public ValueTask DisposeAsync()
 	{
-		Grid.Dispose();
 		Coordinator.Dispose();
 		MessagePanel.Dispose();
 		return ValueTask.CompletedTask;

--- a/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
@@ -28,7 +28,7 @@ public sealed class UIFixture : IAsyncLifetime
 	public RecipeMutationCoordinator Coordinator { get; private set; } = null!;
 	public RecipeGridViewModel Grid { get; private set; } = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		var (services, workspace, editor, plc) = await CoreTestHelper.BuildAsync("WithGroups");
 		Workspace = workspace;
@@ -56,11 +56,11 @@ public sealed class UIFixture : IAsyncLifetime
 		Grid.Initialize();
 	}
 
-	public Task DisposeAsync()
+	public ValueTask DisposeAsync()
 	{
 		Grid.Dispose();
 		Coordinator.Dispose();
 		MessagePanel.Dispose();
-		return Task.CompletedTask;
+		return ValueTask.CompletedTask;
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/HitTestVisibleMultiConverterTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/HitTestVisibleMultiConverterTests.cs
@@ -1,0 +1,129 @@
+﻿using System.Globalization;
+
+using Avalonia;
+
+using FluentAssertions;
+
+using SemiStep.Core.Recipes;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI;
+
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Unit")]
+public sealed class HitTestVisibleMultiConverterTests
+{
+	private readonly HitTestVisibleMultiConverter _converter = new();
+	private readonly CellStateToBoolConverter _cellStateToBoolConverter = new();
+
+	[Fact]
+	public void Convert_CellEnabled_GridNotReadOnly_ReturnsTrue()
+	{
+		var result = _converter.Convert(new object?[] { true, false }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(true);
+	}
+
+	[Fact]
+	public void Convert_CellEnabled_GridReadOnly_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { true, true }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_CellDisabled_GridNotReadOnly_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { false, false }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_CellDisabled_GridReadOnly_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { false, true }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_FewerThanTwoSources_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { true }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_UnsetSourceZero_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { AvaloniaProperty.UnsetValue, false }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_UnsetSourceOne_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { true, AvaloniaProperty.UnsetValue }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_NullSourceZero_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { null, false }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_NullSourceOne_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { true, null }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_NonBoolSourceOne_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { true, "not-a-bool" }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Fact]
+	public void Convert_NonBoolSourceZero_ReturnsFalse()
+	{
+		var result = _converter.Convert(new object?[] { "not-a-bool", false }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(false);
+	}
+
+	[Theory]
+	[InlineData(CellState.Enabled, false, true)]
+	[InlineData(CellState.Enabled, true, false)]
+	[InlineData(CellState.Disabled, false, false)]
+	[InlineData(CellState.Disabled, true, false)]
+	[InlineData(CellState.Readonly, false, false)]
+	[InlineData(CellState.Readonly, true, false)]
+	public void Convert_FullPipeline_CellStateAndGridReadOnly_ProducesExpectedResult(
+		CellState cellState,
+		bool gridReadOnly,
+		bool expected)
+	{
+		var cellEnabled = _cellStateToBoolConverter.Convert(cellState, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		var result = _converter.Convert(new object?[] { cellEnabled, gridReadOnly }, typeof(bool), null, CultureInfo.InvariantCulture);
+
+		result.Should().Be(expected);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Threading;
+﻿using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
@@ -17,295 +17,170 @@ namespace SemiStep.Tests.UI;
 [Trait("Category", "Unit")]
 public sealed class MessagePanelViewModelTests
 {
-	[Fact]
-	public void AddError_IncreasesErrorCountByOne()
+	[AvaloniaFact]
+	public void FreshPanel_HasCleanInitialState()
+	{
+		var panel = new MessagePanelViewModel();
+
+		panel.HasErrors.Should().BeFalse();
+		panel.HasWarnings.Should().BeFalse();
+		panel.HasEntries.Should().BeFalse();
+		panel.ErrorCount.Should().Be(0);
+		panel.WarningCount.Should().Be(0);
+		panel.StatusErrorSummary.Should().Be(string.Empty);
+	}
+
+	[AvaloniaFact]
+	public void AddError_IncrementsCount_AddsErrorEntry_SetsHasErrorsAndHasEntries()
 	{
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("msg", "src");
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ErrorCount.Should().Be(1);
-	}
-
-	[Fact]
-	public void AddError_AddsEntryWithErrorSeverity()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.AddError("test error", "src");
-		Dispatcher.UIThread.RunJobs(null);
-
+		panel.HasErrors.Should().BeTrue();
+		panel.HasEntries.Should().BeTrue();
 		panel.Entries.Should().ContainSingle(e => e.IsError);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AddInfo_DoesNotIncrementErrorOrWarningCount()
 	{
 		var panel = new MessagePanelViewModel();
 
 		panel.AddInfo("msg", "src");
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ErrorCount.Should().Be(0);
 		panel.WarningCount.Should().Be(0);
 	}
 
-	[Fact]
-	public void AddError_SetsHasErrorsTrue()
+	[AvaloniaTheory]
+	[InlineData(1, "1 Error")]
+	[InlineData(2, "2 Errors")]
+	public void ErrorCountText_UsesSingularOrPlural(int errorCount, string expected)
 	{
 		var panel = new MessagePanelViewModel();
 
-		panel.AddError("msg", "src");
-		Dispatcher.UIThread.RunJobs(null);
+		for (var i = 0; i < errorCount; i++)
+		{
+			panel.AddError($"msg{i}", "src");
+		}
 
-		panel.HasErrors.Should().BeTrue();
+		panel.ErrorCountText.Should().Be(expected);
 	}
 
-	[Fact]
-	public void HasErrors_IsFalse_WhenNoErrors()
+	[AvaloniaTheory]
+	[InlineData(1, 1, "1 Error, 1 Warning")]
+	[InlineData(2, 0, "2 Errors")]
+	[InlineData(0, 1, "1 Warning")]
+	public void StatusErrorSummary_CombinesErrorsAndWarnings(int errorCount, int warningCount, string expected)
 	{
 		var panel = new MessagePanelViewModel();
 
-		panel.HasErrors.Should().BeFalse();
+		for (var i = 0; i < errorCount; i++)
+		{
+			panel.AddError($"e{i}", "src");
+		}
+		if (warningCount > 0)
+		{
+			var warnings = Enumerable.Range(0, warningCount).Select(IReason (i) => new Warning($"w{i}")).ToList();
+			panel.RefreshReasons(warnings);
+		}
+
+		panel.StatusErrorSummary.Should().Be(expected);
 	}
 
-	[Fact]
-	public void HasWarnings_IsFalse_WhenNoWarnings()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.HasWarnings.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ErrorCountText_Singular_WhenOneError()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.AddError("msg", "src");
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.ErrorCountText.Should().Be("1 Error");
-	}
-
-	[Fact]
-	public void ErrorCountText_Plural_WhenTwoErrors()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.AddError("msg1", "src");
-		Dispatcher.UIThread.RunJobs(null);
-		panel.AddError("msg2", "src");
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.ErrorCountText.Should().Be("2 Errors");
-	}
-
-	[Fact]
-	public void WarningCountText_Singular_WhenOneWarning()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.RefreshReasons([new Warning("msg")]);
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.WarningCountText.Should().Be("1 Warning");
-	}
-
-	[Fact]
-	public void StatusErrorSummary_BothErrorsAndWarnings()
+	[AvaloniaFact]
+	public void Clear_ResetsCountsEntriesAndFlags()
 	{
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("e", "src");
-		Dispatcher.UIThread.RunJobs(null);
 		panel.RefreshReasons([new Warning("w")]);
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.StatusErrorSummary.Should().Be("1 Error, 1 Warning");
-	}
-
-	[Fact]
-	public void StatusErrorSummary_OnlyErrors()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.AddError("e1", "src");
-		Dispatcher.UIThread.RunJobs(null);
-		panel.AddError("e2", "src");
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.StatusErrorSummary.Should().Be("2 Errors");
-	}
-
-	[Fact]
-	public void StatusErrorSummary_OnlyWarnings()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.RefreshReasons([new Warning("w")]);
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.StatusErrorSummary.Should().Be("1 Warning");
-	}
-
-	[Fact]
-	public void StatusErrorSummary_Empty_WhenNone()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.StatusErrorSummary.Should().Be(string.Empty);
-	}
-
-	[Fact]
-	public void Clear_ResetsCountsAndEntries()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.AddError("e", "src");
-		Dispatcher.UIThread.RunJobs(null);
-		panel.RefreshReasons([new Warning("w")]);
-		Dispatcher.UIThread.RunJobs(null);
 		panel.Clear();
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ErrorCount.Should().Be(0);
 		panel.WarningCount.Should().Be(0);
+		panel.HasErrors.Should().BeFalse();
 		panel.Entries.Should().BeEmpty();
 	}
 
-	[Fact]
-	public void Clear_SetsHasErrorsFalse()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.AddError("e", "src");
-		Dispatcher.UIThread.RunJobs(null);
-		panel.Clear();
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.HasErrors.Should().BeFalse();
-	}
-
-	[Fact]
-	public void HasEntries_True_AfterAddError()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.AddError("e", "src");
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.HasEntries.Should().BeTrue();
-	}
-
-	[Fact]
-	public void HasEntries_False_Initially()
-	{
-		var panel = new MessagePanelViewModel();
-
-		panel.HasEntries.Should().BeFalse();
-	}
-
-	[Fact]
+	[AvaloniaFact]
 	public void ShowPanel_True_WhenHasEntriesAndVisible()
 	{
 		var panel = new MessagePanelViewModel();
 		panel.IsVisible = false;
 
 		panel.AddError("e", "src");
-		Dispatcher.UIThread.RunJobs(null);
 		panel.IsVisible = true;
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ShowPanel.Should().BeTrue();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void ShowPanel_False_WhenNotVisible()
 	{
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("e", "src");
-		Dispatcher.UIThread.RunJobs(null);
 		panel.IsVisible = false;
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.ShowPanel.Should().BeFalse();
 	}
 
-	[Fact]
-	public void RefreshReasons_AddsStructuralErrors()
+	[AvaloniaTheory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void RefreshReasons_AddsStructuralEntries_PreservingSeverity(bool isError)
 	{
 		var panel = new MessagePanelViewModel();
-		List<IReason> reasons = [new Error("some error")];
+		List<IReason> reasons = isError ? [new Error("some error")] : [new Warning("some warning")];
 
 		panel.RefreshReasons(reasons);
-		Dispatcher.UIThread.RunJobs(null);
 
-		panel.Entries.Should().ContainSingle(e => e.IsStructural && e.IsError);
+		panel.Entries.Should().ContainSingle(e => e.IsStructural && (isError ? e.IsError : e.IsWarning));
 	}
 
-	[Fact]
-	public void RefreshReasons_AddsStructuralWarnings()
-	{
-		var panel = new MessagePanelViewModel();
-		List<IReason> reasons = [new Warning("some warning")];
-
-		panel.RefreshReasons(reasons);
-		Dispatcher.UIThread.RunJobs(null);
-
-		panel.Entries.Should().ContainSingle(e => e.IsStructural && e.IsWarning);
-	}
-
-	[Fact]
+	[AvaloniaFact]
 	public void RefreshReasons_RemovesOldStructuralEntries_BeforeAddingNew()
 	{
 		var panel = new MessagePanelViewModel();
 
 		panel.RefreshReasons([new Error("old error")]);
-		Dispatcher.UIThread.RunJobs(null);
 		panel.RefreshReasons([]);
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().BeEmpty();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RefreshReasons_PreservesNonStructuralEntries()
 	{
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("non-structural", "custom source");
-		Dispatcher.UIThread.RunJobs(null);
 		panel.RefreshReasons([]);
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().ContainSingle(e => !e.IsStructural);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void ClearCommand_RemovesNonStructuralEntries()
 	{
 		var panel = new MessagePanelViewModel();
 
 		panel.AddError("e", "src");
-		Dispatcher.UIThread.RunJobs(null);
 		panel.ClearCommand.Execute().Subscribe();
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().BeEmpty();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void ClearCommand_PreservesStructuralEntries()
 	{
 		var panel = new MessagePanelViewModel();
 
 		panel.RefreshReasons([new Error("structural error")]);
-		Dispatcher.UIThread.RunJobs(null);
 		panel.ClearCommand.Execute().Subscribe();
-		Dispatcher.UIThread.RunJobs(null);
 
 		panel.Entries.Should().ContainSingle(e => e.IsStructural);
 	}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs
@@ -2,19 +2,10 @@
 
 using FluentAssertions;
 
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-
-using SemiStep.Core.Configuration;
-using SemiStep.Core.Plc;
-using SemiStep.Core.Recipes;
-using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Helpers;
-using SemiStep.Core.Recipes.Import;
 using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
 
-using SemiStep.UI.Coordinator;
-using SemiStep.UI.MessageService;
 using SemiStep.UI.RecipeGrid;
 
 using Xunit;
@@ -26,54 +17,26 @@ namespace SemiStep.Tests.UI;
 [Trait("Category", "Integration")]
 public sealed class RecipeGridViewModelTests : IAsyncLifetime
 {
-	private RecipeWorkspace _workspace = null!;
-	private RecipeEditor _editor = null!;
-	private PlcLifecycleManager _plc = null!;
-	private MessagePanelViewModel _panel = null!;
-	private RecipeMutationCoordinator _coordinator = null!;
+	private readonly UIFixture _fixture = new();
 	private RecipeGridViewModel _grid = null!;
-	private RecipeMetadataRegistry _recipeMetadataRegistry = null!;
 
 	public async ValueTask InitializeAsync()
 	{
-		var (services, workspace, editor, plc) = await CoreTestHelper.BuildAsync("WithGroups");
-		_workspace = workspace;
-		_editor = editor;
-		_plc = plc;
-		_recipeMetadataRegistry = services.GetRequiredService<RecipeMetadataRegistry>();
-		_panel = new MessagePanelViewModel();
-		var clipboardSerializer = services.GetRequiredService<ClipboardSerializer>();
-		var importedRecipeValidator = services.GetRequiredService<ImportedRecipeValidator>();
-		var queryService = new RecipeQueryService(_workspace, _plc, clipboardSerializer, importedRecipeValidator, _recipeMetadataRegistry);
-		var appConfiguration = services.GetRequiredService<AppConfiguration>();
-		var csvService = services.GetRequiredService<CsvService>();
-		_coordinator = new RecipeMutationCoordinator(
-			_workspace,
-			_editor,
-			_plc,
-			csvService,
-			importedRecipeValidator,
-			appConfiguration,
-			queryService,
-			_panel,
-			NullLogger<RecipeMutationCoordinator>.Instance);
-		_coordinator.Initialize();
-		_grid = new RecipeGridViewModel(_coordinator, _recipeMetadataRegistry, _panel);
+		await _fixture.InitializeAsync();
+		_grid = new RecipeGridViewModel(_fixture.Coordinator, _fixture.RecipeMetadataRegistry, _fixture.MessagePanel);
 		_grid.Initialize();
 	}
 
-	public ValueTask DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		_grid.Dispose();
-		_coordinator.Dispose();
-		_panel.Dispose();
-		return ValueTask.CompletedTask;
+		await _fixture.DisposeAsync();
 	}
 
 	[AvaloniaFact]
 	public void Initialize_EmptyRecipe_HasZeroRows()
 	{
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
 		_grid.RecipeRows.Should().BeEmpty();
 	}
@@ -81,9 +44,9 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void AppendStep_AddsOneRow()
 	{
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
@@ -91,9 +54,9 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void AppendStep_RowHasCorrectActionId()
 	{
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		_grid.RecipeRows[0].ActionId.Should().Be(RecipeTestDriver.WaitActionId);
 	}
@@ -101,9 +64,9 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void AppendStep_RowStepNumberIsOne_ForFirstRow()
 	{
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		_grid.RecipeRows[0].StepNumber.Should().Be(1);
 	}
@@ -111,11 +74,11 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void InsertStep_InsertsRowAtCorrectIndex()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.InsertStep(1, RecipeTestDriver.ForLoopActionId);
+		_fixture.Coordinator.InsertStep(1, RecipeTestDriver.ForLoopActionId);
 
 		_grid.RecipeRows[1].ActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
 	}
@@ -123,11 +86,11 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void InsertStep_RenumbersSubsequentRows()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.InsertStep(0, RecipeTestDriver.ForLoopActionId);
+		_fixture.Coordinator.InsertStep(0, RecipeTestDriver.ForLoopActionId);
 
 		_grid.RecipeRows[1].StepNumber.Should().Be(2);
 		_grid.RecipeRows[2].StepNumber.Should().Be(3);
@@ -136,11 +99,11 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void RemoveStep_ReducesRowCount()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.RemoveStep(0);
+		_fixture.Coordinator.RemoveStep(0);
 
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
@@ -148,12 +111,12 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void RemoveStep_RenumbersRemainingRows()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.RemoveStep(0);
+		_fixture.Coordinator.RemoveStep(0);
 
 		_grid.RecipeRows[0].StepNumber.Should().Be(1);
 		_grid.RecipeRows[1].StepNumber.Should().Be(2);
@@ -162,12 +125,12 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void RemoveSteps_RemovesMultipleRows()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.RemoveSteps(new[] { 0, 2 });
+		_fixture.Coordinator.RemoveSteps(new[] { 0, 2 });
 
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
@@ -175,12 +138,12 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void RemoveSteps_RenumbersRemainingRows()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.RemoveSteps(new[] { 0, 1 });
+		_fixture.Coordinator.RemoveSteps(new[] { 0, 1 });
 
 		_grid.RecipeRows[0].StepNumber.Should().Be(1);
 	}
@@ -188,10 +151,10 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void ChangeStepAction_RebuildsRow_WithNewActionId()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.ChangeStepAction(0, RecipeTestDriver.ForLoopActionId);
+		_fixture.Coordinator.ChangeStepAction(0, RecipeTestDriver.ForLoopActionId);
 
 		_grid.RecipeRows[0].ActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
 	}
@@ -199,11 +162,11 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void NewRecipe_ClearsAllRows()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
 		_grid.RecipeRows.Should().BeEmpty();
 	}
@@ -211,13 +174,13 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void FullRebuild_RowCountMatchesRecipeStepCount()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.Undo();
-		_coordinator.Undo();
+		_fixture.Coordinator.Undo();
+		_fixture.Coordinator.Undo();
 
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
@@ -225,9 +188,9 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void SelectedRowIndex_UpdatedAfterAppend()
 	{
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		_grid.SelectedRowIndex.Should().Be(0);
 	}
@@ -235,7 +198,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void CanDeleteStep_False_Initially()
 	{
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
 		_grid.CanDeleteStep.Should().BeFalse();
 	}
@@ -243,8 +206,8 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void CanDeleteStep_True_WhenRowSelected()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		_grid.SelectedRowIndices = new[] { 0 };
 
@@ -254,16 +217,16 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void CollectSelectedSteps_ReturnsStepsInIndexOrder()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_grid.SelectedRowIndices = new[] { 2, 0 };
 
 		var steps = _grid.CollectSelectedSteps();
 
 		steps.Should().HaveCount(2);
-		var recipe = _coordinator.CurrentRecipe;
+		var recipe = _fixture.Coordinator.CurrentRecipe;
 		steps[0].Should().Be(recipe.Steps[0]);
 		steps[1].Should().Be(recipe.Steps[2]);
 	}
@@ -271,10 +234,10 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void PropertyUpdated_UpdatesRowInPlace_WithoutChangingCount()
 	{
-		_coordinator.NewRecipe();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "15");
+		_fixture.Coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "15");
 
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
@@ -282,9 +245,9 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void StepStartTimes_RefreshedAfterMutation()
 	{
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		_grid.RecipeRows[0].StepStartTime.Should().NotBeNull();
 	}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -32,7 +34,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	private RecipeGridViewModel _grid = null!;
 	private RecipeMetadataRegistry _recipeMetadataRegistry = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		var (services, workspace, editor, plc) = await CoreTestHelper.BuildAsync("WithGroups");
 		_workspace = workspace;
@@ -60,15 +62,15 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.Initialize();
 	}
 
-	public Task DisposeAsync()
+	public ValueTask DisposeAsync()
 	{
 		_grid.Dispose();
 		_coordinator.Dispose();
 		_panel.Dispose();
-		return Task.CompletedTask;
+		return ValueTask.CompletedTask;
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void Initialize_EmptyRecipe_HasZeroRows()
 	{
 		_coordinator.NewRecipe();
@@ -76,7 +78,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows.Should().BeEmpty();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AppendStep_AddsOneRow()
 	{
 		_coordinator.NewRecipe();
@@ -86,7 +88,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AppendStep_RowHasCorrectActionId()
 	{
 		_coordinator.NewRecipe();
@@ -96,7 +98,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows[0].ActionId.Should().Be(RecipeTestDriver.WaitActionId);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AppendStep_RowStepNumberIsOne_ForFirstRow()
 	{
 		_coordinator.NewRecipe();
@@ -106,7 +108,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows[0].StepNumber.Should().Be(1);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void InsertStep_InsertsRowAtCorrectIndex()
 	{
 		_coordinator.NewRecipe();
@@ -118,7 +120,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows[1].ActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void InsertStep_RenumbersSubsequentRows()
 	{
 		_coordinator.NewRecipe();
@@ -131,7 +133,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows[2].StepNumber.Should().Be(3);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RemoveStep_ReducesRowCount()
 	{
 		_coordinator.NewRecipe();
@@ -143,7 +145,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RemoveStep_RenumbersRemainingRows()
 	{
 		_coordinator.NewRecipe();
@@ -157,7 +159,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows[1].StepNumber.Should().Be(2);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RemoveSteps_RemovesMultipleRows()
 	{
 		_coordinator.NewRecipe();
@@ -170,7 +172,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RemoveSteps_RenumbersRemainingRows()
 	{
 		_coordinator.NewRecipe();
@@ -183,7 +185,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows[0].StepNumber.Should().Be(1);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void ChangeStepAction_RebuildsRow_WithNewActionId()
 	{
 		_coordinator.NewRecipe();
@@ -194,7 +196,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows[0].ActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void NewRecipe_ClearsAllRows()
 	{
 		_coordinator.NewRecipe();
@@ -206,7 +208,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows.Should().BeEmpty();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void FullRebuild_RowCountMatchesRecipeStepCount()
 	{
 		_coordinator.NewRecipe();
@@ -220,7 +222,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void SelectedRowIndex_UpdatedAfterAppend()
 	{
 		_coordinator.NewRecipe();
@@ -230,7 +232,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.SelectedRowIndex.Should().Be(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void CanDeleteStep_False_Initially()
 	{
 		_coordinator.NewRecipe();
@@ -238,7 +240,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.CanDeleteStep.Should().BeFalse();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void CanDeleteStep_True_WhenRowSelected()
 	{
 		_coordinator.NewRecipe();
@@ -249,7 +251,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.CanDeleteStep.Should().BeTrue();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void CollectSelectedSteps_ReturnsStepsInIndexOrder()
 	{
 		_coordinator.NewRecipe();
@@ -266,7 +268,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		steps[1].Should().Be(recipe.Steps[2]);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void PropertyUpdated_UpdatesRowInPlace_WithoutChangingCount()
 	{
 		_coordinator.NewRecipe();
@@ -277,7 +279,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_grid.RecipeRows.Should().HaveCount(1);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void StepStartTimes_RefreshedAfterMutation()
 	{
 		_coordinator.NewRecipe();

--- a/SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Threading;
+﻿using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
@@ -29,7 +29,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 {
 	private const string TempFilePrefix = "SemiStep.CoordinatorTest";
 
-	[Fact]
+	[AvaloniaFact]
 	public async Task LoadRecipeAsync_Success_ClearsMessagePanelBeforeAddingNewReasons()
 	{
 		var (coordinator, panel, tempFilePath) = await BuildCoordinatorWithCsvAndSavedRecipeAsync();
@@ -37,10 +37,8 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		try
 		{
 			await coordinator.LoadRecipeAsync("nonexistent/path/recipe.csv");
-			Dispatcher.UIThread.RunJobs(null);
 
 			await coordinator.LoadRecipeAsync(tempFilePath);
-			Dispatcher.UIThread.RunJobs(null);
 
 			panel.Entries.Should().BeEmpty();
 		}
@@ -52,7 +50,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		}
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public async Task LoadRecipeAsync_Failure_LeavesPanelIntact()
 	{
 		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
@@ -60,10 +58,8 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		try
 		{
 			panel.AddError("pre-existing error", "Test");
-			Dispatcher.UIThread.RunJobs(null);
 
 			await coordinator.LoadRecipeAsync("nonexistent/path/recipe.csv");
-			Dispatcher.UIThread.RunJobs(null);
 
 			panel.Entries.Should().ContainSingle(e => e.Source == "Test");
 			panel.Entries.Should().Contain(e => e.IsStructural && e.IsError);
@@ -76,7 +72,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		}
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public async Task LoadRecipeAsync_Failure_DoesNotEmitSignal()
 	{
 		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
@@ -97,7 +93,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		}
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public async Task LoadRecipeAsync_Success_WithWarnings_ShowsWarningsInPanel()
 	{
 		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
@@ -110,7 +106,6 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 
 			// Load it back — an empty recipe triggers a "Recipe has no steps" warning from the analyzer.
 			var result = await coordinator.LoadRecipeAsync(tempFilePath);
-			Dispatcher.UIThread.RunJobs(null);
 
 			result.IsSuccess.Should().BeTrue("loading a valid CSV should succeed even when it has warnings");
 			panel.Entries.Should().Contain(e => e.IsWarning,
@@ -145,7 +140,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		return (coordinator, panel, tempFilePath);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public async Task SaveRecipeAsync_Failure_ReturnsFailed()
 	{
 		var (coordinator, panel) = await BuildCoordinatorWithThrowingCsvAsync();
@@ -153,7 +148,6 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		try
 		{
 			var result = await coordinator.SaveRecipeAsync("any/path.csv");
-			Dispatcher.UIThread.RunJobs(null);
 
 			result.IsFailed.Should().BeTrue();
 		}
@@ -164,7 +158,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		}
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public async Task SaveRecipeAsync_IoException_ConvertsToFailedResult()
 	{
 		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
@@ -179,7 +173,6 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		try
 		{
 			var result = await coordinator.SaveRecipeAsync(unwritablePath);
-			Dispatcher.UIThread.RunJobs(null);
 
 			result.IsFailed.Should().BeTrue(
 				"a real IOException from the underlying file system must be converted to Result.Fail by CsvService.SaveAsync");

--- a/SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorLoadRecipeTests.cs
@@ -32,7 +32,10 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 	[AvaloniaFact]
 	public async Task LoadRecipeAsync_Success_ClearsMessagePanelBeforeAddingNewReasons()
 	{
-		var (coordinator, panel, tempFilePath) = await BuildCoordinatorWithCsvAndSavedRecipeAsync();
+		var (coordinator, panel) = await BuildCoordinatorAsync(services => services.AddCsv());
+		coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		var tempFilePath = Path.Combine(Path.GetTempPath(), $"{TempFilePrefix}.{Guid.NewGuid():N}.csv");
+		await coordinator.SaveRecipeAsync(tempFilePath);
 
 		try
 		{
@@ -53,7 +56,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 	[AvaloniaFact]
 	public async Task LoadRecipeAsync_Failure_LeavesPanelIntact()
 	{
-		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
+		var (coordinator, panel) = await BuildCoordinatorAsync(services => services.AddCsv());
 
 		try
 		{
@@ -75,7 +78,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 	[AvaloniaFact]
 	public async Task LoadRecipeAsync_Failure_DoesNotEmitSignal()
 	{
-		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
+		var (coordinator, panel) = await BuildCoordinatorAsync(services => services.AddCsv());
 
 		try
 		{
@@ -96,7 +99,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 	[AvaloniaFact]
 	public async Task LoadRecipeAsync_Success_WithWarnings_ShowsWarningsInPanel()
 	{
-		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
+		var (coordinator, panel) = await BuildCoordinatorAsync(services => services.AddCsv());
 		var tempFilePath = Path.Combine(Path.GetTempPath(), $"{TempFilePrefix}.{Guid.NewGuid():N}.csv");
 
 		try
@@ -119,31 +122,15 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		}
 	}
 
-	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel)>
-		BuildCoordinatorWithCsvAsync()
-	{
-		return await BuildCoordinatorAsync(services => services.AddCsv());
-	}
-
-	private static async Task<(
-		RecipeMutationCoordinator Coordinator,
-		MessagePanelViewModel Panel,
-		string TempFilePath)> BuildCoordinatorWithCsvAndSavedRecipeAsync()
-	{
-		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
-
-		coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-
-		var tempFilePath = Path.Combine(Path.GetTempPath(), $"{TempFilePrefix}.{Guid.NewGuid():N}.csv");
-		await coordinator.SaveRecipeAsync(tempFilePath);
-
-		return (coordinator, panel, tempFilePath);
-	}
-
 	[AvaloniaFact]
 	public async Task SaveRecipeAsync_Failure_ReturnsFailed()
 	{
-		var (coordinator, panel) = await BuildCoordinatorWithThrowingCsvAsync();
+		var (coordinator, panel) = await BuildCoordinatorAsync(services =>
+		{
+			services.AddCsv();
+			services.AddSingleton<CsvService>(sp => new ThrowingCsvService(
+				sp.GetRequiredService<CsvFileSerializer>()));
+		});
 
 		try
 		{
@@ -161,7 +148,7 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 	[AvaloniaFact]
 	public async Task SaveRecipeAsync_IoException_ConvertsToFailedResult()
 	{
-		var (coordinator, panel) = await BuildCoordinatorWithCsvAsync();
+		var (coordinator, panel) = await BuildCoordinatorAsync(services => services.AddCsv());
 
 		// Use an existing file as the directory portion of the target path.
 		// File.Move into a "directory" that is actually a file throws an IOException
@@ -175,7 +162,8 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 			var result = await coordinator.SaveRecipeAsync(unwritablePath);
 
 			result.IsFailed.Should().BeTrue(
-				"a real IOException from the underlying file system must be converted to Result.Fail by CsvService.SaveAsync");
+				"a real IOException from the underlying file system must be converted to "
+				+ "Result.Fail by CsvService.SaveAsync");
 		}
 		finally
 		{
@@ -183,17 +171,6 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 			panel.Dispose();
 			File.Delete(blockingFile);
 		}
-	}
-
-	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel)>
-		BuildCoordinatorWithThrowingCsvAsync()
-	{
-		return await BuildCoordinatorAsync(services =>
-		{
-			services.AddCsv();
-			services.AddSingleton<CsvService>(sp => new ThrowingCsvService(
-				sp.GetRequiredService<CsvFileSerializer>()));
-		});
 	}
 
 	private static async Task<(RecipeMutationCoordinator Coordinator, MessagePanelViewModel Panel)>
@@ -228,7 +205,12 @@ public sealed class RecipeMutationCoordinatorLoadRecipeTests
 		var panel = new MessagePanelViewModel();
 		var clipboardSerializer = services.GetRequiredService<ClipboardSerializer>();
 		var importedRecipeValidator = services.GetRequiredService<ImportedRecipeValidator>();
-		var queryService = new RecipeQueryService(workspace, plc, clipboardSerializer, importedRecipeValidator, recipeMetadataRegistry);
+		var queryService = new RecipeQueryService(
+			workspace,
+			plc,
+			clipboardSerializer,
+			importedRecipeValidator,
+			recipeMetadataRegistry);
 		var appConfiguration = services.GetRequiredService<AppConfiguration>();
 		var csvService = services.GetRequiredService<CsvService>();
 		var coordinator = new RecipeMutationCoordinator(

--- a/SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorTests.cs
@@ -2,19 +2,11 @@
 
 using FluentAssertions;
 
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-
-using SemiStep.Core.Configuration;
-using SemiStep.Core.Plc;
-using SemiStep.Core.Recipes;
-using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Helpers;
-using SemiStep.Core.Recipes.Import;
 using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
 
 using SemiStep.UI.Coordinator;
-using SemiStep.UI.MessageService;
 
 using Xunit;
 
@@ -25,53 +17,26 @@ namespace SemiStep.Tests.UI;
 [Trait("Category", "Integration")]
 public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 {
-	private RecipeWorkspace _workspace = null!;
-	private RecipeEditor _editor = null!;
-	private PlcLifecycleManager _plc = null!;
-	private MessagePanelViewModel _messagePanel = null!;
-	private RecipeMutationCoordinator _coordinator = null!;
+	private readonly UIFixture _fixture = new();
 
-	public async ValueTask InitializeAsync()
+	public ValueTask InitializeAsync()
 	{
-		var (services, workspace, editor, plc) = await CoreTestHelper.BuildAsync("WithGroups");
-		_workspace = workspace;
-		_editor = editor;
-		_plc = plc;
-		var recipeMetadataRegistry = services.GetRequiredService<RecipeMetadataRegistry>();
-		_messagePanel = new MessagePanelViewModel();
-		var clipboardSerializer = services.GetRequiredService<ClipboardSerializer>();
-		var importedRecipeValidator = services.GetRequiredService<ImportedRecipeValidator>();
-		var queryService = new RecipeQueryService(_workspace, _plc, clipboardSerializer, importedRecipeValidator, recipeMetadataRegistry);
-		var appConfiguration = services.GetRequiredService<AppConfiguration>();
-		var csvService = services.GetRequiredService<CsvService>();
-		_coordinator = new RecipeMutationCoordinator(
-			_workspace,
-			_editor,
-			_plc,
-			csvService,
-			importedRecipeValidator,
-			appConfiguration,
-			queryService,
-			_messagePanel,
-			NullLogger<RecipeMutationCoordinator>.Instance);
-		_coordinator.Initialize();
+		return _fixture.InitializeAsync();
 	}
 
 	public ValueTask DisposeAsync()
 	{
-		_coordinator.Dispose();
-		_messagePanel.Dispose();
-		return ValueTask.CompletedTask;
+		return _fixture.DisposeAsync();
 	}
 
 	[AvaloniaFact]
 	public void AppendStep_EmitsStepAppendedSignal()
 	{
-		_workspace.Reset();
+		_fixture.Workspace.Reset();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.StepAppended>()
 			.Which.Index.Should().Be(0);
@@ -80,10 +45,10 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void AppendStep_SetsSuggestedSelection_ToLastIndex()
 	{
-		_workspace.Reset();
+		_fixture.Workspace.Reset();
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		var selection = _coordinator.ConsumeSuggestedSelection();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		var selection = _fixture.Coordinator.ConsumeSuggestedSelection();
 
 		selection.Should().Be(0);
 	}
@@ -91,12 +56,12 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void InsertStep_EmitsStepsInsertedSignal()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.InsertStep(0, RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.InsertStep(0, RecipeTestDriver.WaitActionId);
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.StepsInserted>()
 			.Which.Should().BeEquivalentTo(new MutationSignal.StepsInserted(0, 1));
@@ -105,12 +70,12 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void InsertStep_SetsSuggestedSelection_ToInsertedIndex()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.ConsumeSuggestedSelection();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.ConsumeSuggestedSelection();
 
-		_coordinator.InsertStep(0, RecipeTestDriver.WaitActionId);
-		var selection = _coordinator.ConsumeSuggestedSelection();
+		_fixture.Coordinator.InsertStep(0, RecipeTestDriver.WaitActionId);
+		var selection = _fixture.Coordinator.ConsumeSuggestedSelection();
 
 		selection.Should().Be(0);
 	}
@@ -118,13 +83,13 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void RemoveStep_EmitsStepRemovedSignal()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.ConsumeSuggestedSelection();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.RemoveStep(0);
+		_fixture.Coordinator.RemoveStep(0);
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.StepRemoved>()
 			.Which.RemovedIndex.Should().Be(0);
@@ -133,12 +98,12 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void RemoveStep_SuggestedSelection_IsNull_WhenRecipeBecomesEmpty()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.ConsumeSuggestedSelection();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.ConsumeSuggestedSelection();
 
-		_coordinator.RemoveStep(0);
-		var selection = _coordinator.ConsumeSuggestedSelection();
+		_fixture.Coordinator.RemoveStep(0);
+		var selection = _fixture.Coordinator.ConsumeSuggestedSelection();
 
 		selection.Should().BeNull();
 	}
@@ -146,14 +111,14 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void RemoveStep_SuggestedSelection_ClampedToLastIndex_WhenRemovingLast()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.ConsumeSuggestedSelection();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.ConsumeSuggestedSelection();
 
-		_coordinator.RemoveStep(2);
-		var selection = _coordinator.ConsumeSuggestedSelection();
+		_fixture.Coordinator.RemoveStep(2);
+		var selection = _fixture.Coordinator.ConsumeSuggestedSelection();
 
 		selection.Should().Be(1);
 	}
@@ -161,14 +126,14 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void RemoveSteps_EmitsStepsRemovedSignal()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.ConsumeSuggestedSelection();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.RemoveSteps(new[] { 0, 1 });
+		_fixture.Coordinator.RemoveSteps(new[] { 0, 1 });
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.StepsRemoved>();
 	}
@@ -176,13 +141,13 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void ChangeStepAction_EmitsStepActionChangedSignal()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.ConsumeSuggestedSelection();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.ChangeStepAction(0, RecipeTestDriver.ForLoopActionId);
+		_fixture.Coordinator.ChangeStepAction(0, RecipeTestDriver.ForLoopActionId);
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.StepActionChanged>()
 			.Which.StepIndex.Should().Be(0);
@@ -191,13 +156,13 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void UpdateStepProperty_EmitsPropertyUpdatedSignal_WithCorrectStepIndex()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.ConsumeSuggestedSelection();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "5");
+		_fixture.Coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "5");
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.PropertyUpdated>()
 			.Which.StepIndex.Should().Be(0);
@@ -206,13 +171,13 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void Undo_EmitsRecipeReplacedSignal()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.ConsumeSuggestedSelection();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.ConsumeSuggestedSelection();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.Undo();
+		_fixture.Coordinator.Undo();
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.RecipeReplaced>();
 	}
@@ -220,13 +185,13 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void Redo_EmitsRecipeReplacedSignal()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_coordinator.Undo();
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.Undo();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.Redo();
+		_fixture.Coordinator.Redo();
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.RecipeReplaced>();
 	}
@@ -234,11 +199,11 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void NewRecipe_EmitsRecipeReplacedSignal()
 	{
-		_workspace.Reset();
+		_fixture.Workspace.Reset();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.RecipeReplaced>();
 	}
@@ -246,22 +211,22 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void NewRecipe_ClearsPriorNonStructuralEntries()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(9999);
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(9999);
 
-		_coordinator.NewRecipe();
+		_fixture.Coordinator.NewRecipe();
 
-		_messagePanel.Entries.Should().NotContain(e => !e.IsStructural);
+		_fixture.MessagePanel.Entries.Should().NotContain(e => !e.IsStructural);
 	}
 
 	[AvaloniaFact]
 	public void ConsumeSuggestedSelection_ReturnsValueOnce_ThenNull()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var first = _coordinator.ConsumeSuggestedSelection();
-		var second = _coordinator.ConsumeSuggestedSelection();
+		var first = _fixture.Coordinator.ConsumeSuggestedSelection();
+		var second = _fixture.Coordinator.ConsumeSuggestedSelection();
 
 		first.Should().NotBeNull();
 		second.Should().BeNull();
@@ -270,11 +235,11 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void AppendStep_Failure_DoesNotEmitSignal()
 	{
-		_workspace.Reset();
+		_fixture.Workspace.Reset();
 		var signals = new List<MutationSignal>();
-		using var sub = _coordinator.StateChanged.Subscribe(signals.Add);
+		using var sub = _fixture.Coordinator.StateChanged.Subscribe(signals.Add);
 
-		_coordinator.AppendStep(9999);
+		_fixture.Coordinator.AppendStep(9999);
 
 		signals.Should().BeEmpty();
 	}
@@ -282,50 +247,50 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void AppendStep_Failure_AddsErrorToMessagePanel()
 	{
-		_workspace.Reset();
+		_fixture.Workspace.Reset();
 
-		_coordinator.AppendStep(9999);
+		_fixture.Coordinator.AppendStep(9999);
 
-		_messagePanel.ErrorCount.Should().BeGreaterThan(0);
+		_fixture.MessagePanel.ErrorCount.Should().BeGreaterThan(0);
 	}
 
 	[AvaloniaFact]
 	public void IsDirty_True_AfterMutation()
 	{
-		_workspace.Reset();
+		_fixture.Workspace.Reset();
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.IsDirty.Should().BeTrue();
+		_fixture.Coordinator.IsDirty.Should().BeTrue();
 	}
 
 	[AvaloniaFact]
 	public void CanUndo_True_AfterMutation()
 	{
-		_workspace.Reset();
+		_fixture.Workspace.Reset();
 
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.CanUndo.Should().BeTrue();
+		_fixture.Coordinator.CanUndo.Should().BeTrue();
 	}
 
 	[AvaloniaFact]
 	public void CanRedo_True_AfterUndoingMutation()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_coordinator.Undo();
+		_fixture.Coordinator.Undo();
 
-		_coordinator.CanRedo.Should().BeTrue();
+		_fixture.Coordinator.CanRedo.Should().BeTrue();
 	}
 
 	[AvaloniaFact]
 	public void AppendStep_Failure_ReturnsFailed()
 	{
-		_workspace.Reset();
+		_fixture.Workspace.Reset();
 
-		var result = _coordinator.AppendStep(9999);
+		var result = _fixture.Coordinator.AppendStep(9999);
 
 		result.IsFailed.Should().BeTrue();
 	}
@@ -333,10 +298,10 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void ChangeStepAction_Failure_ReturnsFailed()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var result = _coordinator.ChangeStepAction(0, 9999);
+		var result = _fixture.Coordinator.ChangeStepAction(0, 9999);
 
 		result.IsFailed.Should().BeTrue();
 	}
@@ -344,12 +309,11 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void UpdateStepProperty_Failure_ReturnsFailed()
 	{
-		_workspace.Reset();
-		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_fixture.Workspace.Reset();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var result = _coordinator.UpdateStepProperty(0, "NonExistentColumn", "value");
+		var result = _fixture.Coordinator.UpdateStepProperty(0, "NonExistentColumn", "value");
 
 		result.IsFailed.Should().BeTrue();
 	}
-
 }

--- a/SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeMutationCoordinatorTests.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Threading;
+﻿using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
@@ -31,7 +31,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 	private MessagePanelViewModel _messagePanel = null!;
 	private RecipeMutationCoordinator _coordinator = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		var (services, workspace, editor, plc) = await CoreTestHelper.BuildAsync("WithGroups");
 		_workspace = workspace;
@@ -57,14 +57,14 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		_coordinator.Initialize();
 	}
 
-	public Task DisposeAsync()
+	public ValueTask DisposeAsync()
 	{
 		_coordinator.Dispose();
 		_messagePanel.Dispose();
-		return Task.CompletedTask;
+		return ValueTask.CompletedTask;
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AppendStep_EmitsStepAppendedSignal()
 	{
 		_workspace.Reset();
@@ -77,7 +77,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 			.Which.Index.Should().Be(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AppendStep_SetsSuggestedSelection_ToLastIndex()
 	{
 		_workspace.Reset();
@@ -88,7 +88,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		selection.Should().Be(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void InsertStep_EmitsStepsInsertedSignal()
 	{
 		_workspace.Reset();
@@ -102,7 +102,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 			.Which.Should().BeEquivalentTo(new MutationSignal.StepsInserted(0, 1));
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void InsertStep_SetsSuggestedSelection_ToInsertedIndex()
 	{
 		_workspace.Reset();
@@ -115,7 +115,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		selection.Should().Be(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RemoveStep_EmitsStepRemovedSignal()
 	{
 		_workspace.Reset();
@@ -130,7 +130,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 			.Which.RemovedIndex.Should().Be(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RemoveStep_SuggestedSelection_IsNull_WhenRecipeBecomesEmpty()
 	{
 		_workspace.Reset();
@@ -143,7 +143,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		selection.Should().BeNull();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RemoveStep_SuggestedSelection_ClampedToLastIndex_WhenRemovingLast()
 	{
 		_workspace.Reset();
@@ -158,7 +158,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		selection.Should().Be(1);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void RemoveSteps_EmitsStepsRemovedSignal()
 	{
 		_workspace.Reset();
@@ -173,7 +173,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.StepsRemoved>();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void ChangeStepAction_EmitsStepActionChangedSignal()
 	{
 		_workspace.Reset();
@@ -188,7 +188,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 			.Which.StepIndex.Should().Be(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void UpdateStepProperty_EmitsPropertyUpdatedSignal_WithCorrectStepIndex()
 	{
 		_workspace.Reset();
@@ -203,7 +203,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 			.Which.StepIndex.Should().Be(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void Undo_EmitsRecipeReplacedSignal()
 	{
 		_workspace.Reset();
@@ -217,7 +217,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.RecipeReplaced>();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void Redo_EmitsRecipeReplacedSignal()
 	{
 		_workspace.Reset();
@@ -231,7 +231,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.RecipeReplaced>();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void NewRecipe_EmitsRecipeReplacedSignal()
 	{
 		_workspace.Reset();
@@ -243,20 +243,18 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		signals.Should().ContainSingle().Which.Should().BeOfType<MutationSignal.RecipeReplaced>();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void NewRecipe_ClearsPriorNonStructuralEntries()
 	{
 		_workspace.Reset();
 		_coordinator.AppendStep(9999);
-		Dispatcher.UIThread.RunJobs(null);
 
 		_coordinator.NewRecipe();
-		Dispatcher.UIThread.RunJobs(null);
 
 		_messagePanel.Entries.Should().NotContain(e => !e.IsStructural);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void ConsumeSuggestedSelection_ReturnsValueOnce_ThenNull()
 	{
 		_workspace.Reset();
@@ -269,7 +267,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		second.Should().BeNull();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AppendStep_Failure_DoesNotEmitSignal()
 	{
 		_workspace.Reset();
@@ -281,18 +279,17 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		signals.Should().BeEmpty();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AppendStep_Failure_AddsErrorToMessagePanel()
 	{
 		_workspace.Reset();
 
 		_coordinator.AppendStep(9999);
-		Dispatcher.UIThread.RunJobs(null);
 
 		_messagePanel.ErrorCount.Should().BeGreaterThan(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void IsDirty_True_AfterMutation()
 	{
 		_workspace.Reset();
@@ -302,7 +299,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		_coordinator.IsDirty.Should().BeTrue();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void CanUndo_True_AfterMutation()
 	{
 		_workspace.Reset();
@@ -312,7 +309,7 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		_coordinator.CanUndo.Should().BeTrue();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void CanRedo_True_AfterUndoingMutation()
 	{
 		_workspace.Reset();
@@ -323,20 +320,20 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		_coordinator.CanRedo.Should().BeTrue();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void AppendStep_Failure_ReturnsFailed()
 	{
-		_ = _workspace.Reset();
+		_workspace.Reset();
 
 		var result = _coordinator.AppendStep(9999);
 
 		result.IsFailed.Should().BeTrue();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void ChangeStepAction_Failure_ReturnsFailed()
 	{
-		_ = _workspace.Reset();
+		_workspace.Reset();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		var result = _coordinator.ChangeStepAction(0, 9999);
@@ -344,10 +341,10 @@ public sealed class RecipeMutationCoordinatorTests : IAsyncLifetime
 		result.IsFailed.Should().BeTrue();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void UpdateStepProperty_Failure_ReturnsFailed()
 	{
-		_ = _workspace.Reset();
+		_workspace.Reset();
 		_coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
 		var result = _coordinator.UpdateStepProperty(0, "NonExistentColumn", "value");

--- a/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,17 +23,18 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 	private RecipeEditor _editor = null!;
 	private RecipeMetadataRegistry _recipeMetadataRegistry = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		var (services, workspace, editor, _) = await CoreTestHelper.BuildAsync("WithGroups");
 		_workspace = workspace;
 		_editor = editor;
 		_recipeMetadataRegistry = services.GetRequiredService<RecipeMetadataRegistry>();
+		_workspace.Reset();
 	}
 
-	public Task DisposeAsync()
+	public ValueTask DisposeAsync()
 	{
-		return Task.CompletedTask;
+		return ValueTask.CompletedTask;
 	}
 
 	private RecipeRowViewModel CreateRow(int actionId = RecipeTestDriver.WaitActionId)
@@ -53,10 +56,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		return states;
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void GetPropertyValue_Action_ReturnsActionId()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		var value = row.GetPropertyValue("action");
@@ -64,10 +66,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		value.Should().Be(RecipeTestDriver.WaitActionId);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void GetPropertyValue_StepStartTime_ReturnsNull_Initially()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		var value = row.GetPropertyValue("step_start_time");
@@ -75,10 +76,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		value.Should().BeNull();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void GetPropertyValue_UnknownKey_ReturnsNull()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		var value = row.GetPropertyValue("nonexistent_column");
@@ -86,10 +86,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		value.Should().BeNull();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void GetPropertyValue_KnownColumn_ReturnsPropertyValue()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		var value = row.GetPropertyValue(RecipeTestDriver.StepDurationColumn);
@@ -97,22 +96,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		value.Should().NotBeNull();
 	}
 
-	[Fact]
-	public void Indexer_Get_DelegatesToGetPropertyValue()
-	{
-		_workspace.Reset();
-		var row = CreateRow();
-
-		var indexerValue = row["action"];
-		var getterValue = row.GetPropertyValue("action");
-
-		indexerValue.Should().Be(getterValue);
-	}
-
-	[Fact]
+	[AvaloniaFact]
 	public void SetPropertyValue_Action_FiresActionChangedEvent()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 		var receivedActionId = -1;
 		row.ActionChanged += id => receivedActionId = id;
@@ -122,10 +108,21 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		receivedActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
 	}
 
-	[Fact]
+	[AvaloniaFact]
+	public void Indexer_SetActionToIntId_FiresActionChangedEvent()
+	{
+		var row = CreateRow();
+		var receivedActionId = -1;
+		row.ActionChanged += id => receivedActionId = id;
+
+		row["action"] = RecipeTestDriver.ForLoopActionId;
+
+		receivedActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
+	}
+
+	[AvaloniaFact]
 	public void SetPropertyValue_Action_InvalidValue_DoesNotFireEvent()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 		var eventFired = false;
 		row.ActionChanged += _ => eventFired = true;
@@ -135,10 +132,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		eventFired.Should().BeFalse();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void SetPropertyValue_NonAction_FiresPropertyValueChangedEvent()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 		var receivedColumnKey = string.Empty;
 		row.PropertyValueChanged += (key, _) => receivedColumnKey = key;
@@ -148,10 +144,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		receivedColumnKey.Should().Be(RecipeTestDriver.StepDurationColumn);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void UpdateStep_RaisesItemArrayPropertyChanged()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 		var changedProperties = new List<string>();
 		row.PropertyChanged += (_, args) => changedProperties.Add(args.PropertyName ?? "");
@@ -162,10 +157,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		changedProperties.Should().Contain("Item[]");
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void UpdateStepNumber_ChangesStepNumber()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		row.UpdateStepNumber(3);
@@ -173,10 +167,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		row.StepNumber.Should().Be(3);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void UpdateStepStartTime_ChangesStepStartTime()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		row.UpdateStepStartTime("123.5");
@@ -184,28 +177,25 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		row.StepStartTime.Should().Be("123.5");
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void CellStates_NotEmpty()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		row.CellStates.Count.Should().BeGreaterThan(0);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void CellStates_ActionColumn_IsEnabled()
 	{
-		_workspace.Reset();
 		var row = CreateRow(RecipeTestDriver.PauseActionId);
 
 		row.CellStates["action"].Should().Be(CellState.Enabled);
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void GetGroupNameForColumn_ReturnsNull_ForNonGroupColumn()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		var groupName = row.GetGroupNameForColumn(RecipeTestDriver.StepDurationColumn);
@@ -213,10 +203,9 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		groupName.Should().BeNull();
 	}
 
-	[Fact]
+	[AvaloniaFact]
 	public void GetGroupItemsForColumn_ReturnsNull_ForNonGroupColumn()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 
 		var groupItems = row.GetGroupItemsForColumn(RecipeTestDriver.StepDurationColumn);
@@ -224,63 +213,37 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		groupItems.Should().BeNull();
 	}
 
-	[Fact]
-	public void ColumnUnits_ContainsStepStartTime_WithTimeUnits()
+	public static TheoryData<string, string> ColumnUnitsData => new()
 	{
-		_workspace.Reset();
-		var row = CreateRow();
+		{ "step_start_time", "с" },
+		{ RecipeTestDriver.StepDurationColumn, "s" },
+		{ RecipeTestDriver.CommentColumn, "" },
+	};
 
-		row.ColumnUnits.Should().ContainKey("step_start_time")
-			.WhoseValue.Should().Be("с");
-	}
-
-	[Fact]
-	public void ColumnFormatKinds_ContainsStepStartTime_WithTimeHmsFormat()
+	[AvaloniaTheory]
+	[MemberData(nameof(ColumnUnitsData))]
+	public void ColumnUnits_ExposesExpectedUnitsForKnownColumns(string columnKey, string expectedUnits)
 	{
-		_workspace.Reset();
-		var row = CreateRow();
-
-		row.ColumnFormatKinds.Should().ContainKey("step_start_time")
-			.WhoseValue.Should().Be("time_hms");
-	}
-
-	[Fact]
-	public void ColumnUnits_ContainsActionColumnUnits()
-	{
-		_workspace.Reset();
 		var row = CreateRow(RecipeTestDriver.WaitActionId);
 
-		// Wait action: step_duration -> time property -> units "s"
-		row.ColumnUnits.Should().ContainKey(RecipeTestDriver.StepDurationColumn)
-			.WhoseValue.Should().Be("s");
+		row.ColumnUnits.Should().ContainKey(columnKey)
+			.WhoseValue.Should().Be(expectedUnits);
 	}
 
-	[Fact]
-	public void ColumnFormatKinds_ContainsActionColumnFormatKind()
+	[AvaloniaTheory]
+	[InlineData("step_start_time", "time_hms")]
+	[InlineData(RecipeTestDriver.StepDurationColumn, "time_hms")]
+	public void ColumnFormatKinds_ExposesExpectedFormatKindForKnownColumns(string columnKey, string expectedFormatKind)
 	{
-		_workspace.Reset();
 		var row = CreateRow(RecipeTestDriver.WaitActionId);
 
-		// Wait action: step_duration -> time property -> formatKind "time_hms"
-		row.ColumnFormatKinds.Should().ContainKey(RecipeTestDriver.StepDurationColumn)
-			.WhoseValue.Should().Be("time_hms");
+		row.ColumnFormatKinds.Should().ContainKey(columnKey)
+			.WhoseValue.Should().Be(expectedFormatKind);
 	}
 
-	[Fact]
-	public void ColumnUnits_ColumnWithEmptyUnits_ReturnsEmptyString()
-	{
-		_workspace.Reset();
-		var row = CreateRow(RecipeTestDriver.WaitActionId);
-
-		// Wait action: comment -> string property -> units ""
-		row.ColumnUnits.Should().ContainKey(RecipeTestDriver.CommentColumn)
-			.WhoseValue.Should().Be("");
-	}
-
-	[Fact]
+	[AvaloniaFact]
 	public void Dispose_NullsEventDelegates()
 	{
-		_workspace.Reset();
 		var row = CreateRow();
 		var handlerCalled = false;
 		row.PropertyValueChanged += (_, _) => handlerCalled = true;

--- a/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Headless.XUnit;
+﻿using System.Collections.Immutable;
+
+using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
@@ -48,7 +50,7 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 
 	private IReadOnlyDictionary<string, CellState> BuildCellStates(ActionDefinition action)
 	{
-		var states = new Dictionary<string, CellState>();
+		var states = new Dictionary<string, CellState>(StringComparer.OrdinalIgnoreCase);
 		foreach (var col in _recipeMetadataRegistry.GetAllColumns())
 		{
 			states[col.Key] = CellStateResolver.GetCellState(col, action);
@@ -94,6 +96,28 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		var value = row.GetPropertyValue(RecipeTestDriver.StepDurationColumn);
 
 		value.Should().NotBeNull();
+	}
+
+	[AvaloniaFact]
+	public void Indexer_Get_DelegatesToGetPropertyValue()
+	{
+		var row = CreateRow();
+
+		var indexerValue = row["action"];
+		var directValue = row.GetPropertyValue("action");
+
+		indexerValue.Should().Be(directValue);
+		indexerValue.Should().Be(RecipeTestDriver.WaitActionId);
+	}
+
+	[AvaloniaFact]
+	public void Indexer_Get_UnknownKey_ReturnsNull()
+	{
+		var row = CreateRow();
+
+		var value = row["nonexistent_column"];
+
+		value.Should().BeNull();
 	}
 
 	[AvaloniaFact]
@@ -194,23 +218,62 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void GetGroupNameForColumn_ReturnsNull_ForNonGroupColumn()
+	public void GroupItemsByColumn_ExposesItems_ForGroupBoundColumn()
 	{
-		var row = CreateRow();
+		var row = CreateRow(RecipeTestDriver.WithGroupActionId);
 
-		var groupName = row.GetGroupNameForColumn(RecipeTestDriver.StepDurationColumn);
-
-		groupName.Should().BeNull();
+		row.GroupItemsByColumn.Should().ContainKey(RecipeTestDriver.TargetColumn);
+		var items = row.GroupItemsByColumn[RecipeTestDriver.TargetColumn];
+		items.Should().NotBeEmpty();
+		items.Select(item => item.Id).Should().BeInAscendingOrder();
 	}
 
 	[AvaloniaFact]
-	public void GetGroupItemsForColumn_ReturnsNull_ForNonGroupColumn()
+	public void GroupItemsByColumn_OmitsKey_ForNonGroupBoundColumn()
 	{
-		var row = CreateRow();
+		// Pre-population is intentionally scoped to ActionTargetComboBox columns so non-group
+		// columns (text/property/action) do not accumulate empty-list entries.
+		var row = CreateRow(RecipeTestDriver.WithGroupActionId);
 
-		var groupItems = row.GetGroupItemsForColumn(RecipeTestDriver.StepDurationColumn);
+		row.GroupItemsByColumn.Should().NotContainKey(RecipeTestDriver.StepDurationColumn);
+		row.GroupItemsByColumn.Should().NotContainKey(RecipeTestDriver.CommentColumn);
+	}
 
-		groupItems.Should().BeNull();
+	[AvaloniaFact]
+	public void GroupItemsByColumn_PrepopulatesEmptyList_ForGroupColumnAbsentFromActionProperties()
+	{
+		// Wait action has no `target` property, but `target` is a group-bound column in the registry.
+		// The dictionary pre-populates such keys so bindings for cross-action grids never hit
+		// a missing key (which would yield UnsetValue and bypass the converter contract).
+		var row = CreateRow(RecipeTestDriver.WaitActionId);
+
+		row.GroupItemsByColumn.Should().ContainKey(RecipeTestDriver.TargetColumn);
+		row.GroupItemsByColumn[RecipeTestDriver.TargetColumn].Should().BeEmpty();
+	}
+
+	[AvaloniaFact]
+	public void GroupItemsByColumn_OmitsKey_WhenActionGroupResolutionFails()
+	{
+		// When an action property references a group that does not exist in the metadata registry,
+		// the view-model skips it rather than surfacing the property key with an empty list. The
+		// property key is also not a registered group-bound column, so the pre-population loop
+		// does not insert it either — the key is fully absent from the dictionary.
+		var unresolvedGroupProperty = new ActionPropertyDefinition(
+			Key: "phantom_column",
+			GroupName: "nonexistent_group",
+			PropertyTypeId: "enum",
+			DefaultValue: null);
+		var actionWithUnresolvedGroup = new ActionDefinition(
+			Id: 999,
+			UiName: "Phantom",
+			DeployDuration: DeployDuration.Immediate,
+			Properties: new[] { unresolvedGroupProperty });
+		var step = new Step(999, ImmutableDictionary<PropertyId, PropertyValue>.Empty);
+		var cellStates = new Dictionary<string, CellState>();
+
+		var row = new RecipeRowViewModel(1, step, actionWithUnresolvedGroup, _recipeMetadataRegistry, cellStates);
+
+		row.GroupItemsByColumn.Should().NotContainKey("phantom_column");
 	}
 
 	public static TheoryData<string, string> ColumnUnitsData => new()

--- a/SemiStep/SemiStep.Tests/YamlConfigs/WithGroups/columns/columns.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/WithGroups/columns/columns.yaml
@@ -28,7 +28,7 @@ task:
     save_to_csv: true
 
 target:
-  column_type: enum_combo_box
+  column_type: action_target_combo_box
   ui:
     ui_name: "Target"
   business_logic:

--- a/SemiStep/SemiStep.UI/App.axaml.cs
+++ b/SemiStep/SemiStep.UI/App.axaml.cs
@@ -67,7 +67,7 @@ public class App : Application
 		BuildAvaloniaApp()
 			.AfterSetup(_ =>
 				// UseReactiveUI() above has already registered AvaloniaScheduler as
-				// RxApp.MainThreadScheduler. Initialize services here — after the
+				// RxSchedulers.MainThreadScheduler. Initialize services here — after the
 				// scheduler is set — so that ReactiveCommand singletons capture the
 				// correct scheduler at construction time.
 				InitializeServices(serviceProvider))

--- a/SemiStep/SemiStep.UI/App.axaml.cs
+++ b/SemiStep/SemiStep.UI/App.axaml.cs
@@ -1,9 +1,10 @@
 ﻿using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
-using Avalonia.ReactiveUI;
 
 using Microsoft.Extensions.DependencyInjection;
+
+using ReactiveUI.Avalonia;
 
 using SemiStep.Core.Recipes;
 using SemiStep.UI.Coordinator;
@@ -55,7 +56,8 @@ public class App : Application
 		return AppBuilder.Configure<App>()
 			.UseWin32()
 			.UseSkia()
-			.UseReactiveUI()
+			.UseHarfBuzz()
+			.UseReactiveUI(_ => { })
 			.LogToTrace();
 	}
 

--- a/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
+++ b/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
 using Avalonia.Input.Platform;
@@ -38,17 +39,17 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 		PasteStepCommand = ReactiveCommand.CreateFromTask(PasteStepsAsync);
 
 		CopyStepCommand.ThrownExceptions
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(ex => _messagePanel.AddError($"Copy failed: {ex.Message}", ClipboardSource))
 			.DisposeWith(_disposables);
 
 		CutStepCommand.ThrownExceptions
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(ex => _messagePanel.AddError($"Cut failed: {ex.Message}", ClipboardSource))
 			.DisposeWith(_disposables);
 
 		PasteStepCommand.ThrownExceptions
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(ex => _messagePanel.AddError($"Paste failed: {ex.Message}", ClipboardSource))
 			.DisposeWith(_disposables);
 	}
@@ -107,7 +108,7 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
-		var csvText = await _clipboard.GetTextAsync();
+		var csvText = await _clipboard.TryGetTextAsync();
 		if (string.IsNullOrWhiteSpace(csvText))
 		{
 			return;

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeMutationCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeMutationCoordinator.cs
@@ -106,7 +106,7 @@ public sealed class RecipeMutationCoordinator : IDisposable
 		_plc.Initialize();
 
 		_plcStateSubscription = _plc.PlcState
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(OnPlcStateChanged);
 
 		return this;

--- a/SemiStep/SemiStep.UI/Dialogs/ErrorWindow.axaml
+++ b/SemiStep/SemiStep.UI/Dialogs/ErrorWindow.axaml
@@ -7,7 +7,7 @@
         CanResize="False"
         ShowInTaskbar="True"
         WindowStartupLocation="CenterScreen"
-        SystemDecorations="BorderOnly">
+        WindowDecorations="BorderOnly">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/SemiStep/SemiStep.UI/Dialogs/MessageDialog.axaml
+++ b/SemiStep/SemiStep.UI/Dialogs/MessageDialog.axaml
@@ -10,7 +10,7 @@
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         ShowInTaskbar="False"
-        SystemDecorations="BorderOnly">
+        WindowDecorations="BorderOnly">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/SemiStep/SemiStep.UI/MainWindow/AppStatusBar.axaml
+++ b/SemiStep/SemiStep.UI/MainWindow/AppStatusBar.axaml
@@ -2,8 +2,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:SemiStep.UI.MainWindow"
              mc:Ignorable="d"
-             x:Class="SemiStep.UI.MainWindow.AppStatusBar">
+             x:Class="SemiStep.UI.MainWindow.AppStatusBar"
+             x:DataType="local:MainWindowViewModel">
 
     <UserControl.Styles>
         <!-- Connection indicator color via style class binding -->

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml
@@ -8,6 +8,7 @@
         d:DesignWidth="1600"
         d:DesignHeight="800"
         x:Class="SemiStep.UI.MainWindow.MainWindow"
+        x:DataType="local:MainWindowViewModel"
         Title="{Binding WindowTitle}"
         Width="1600"
         Height="800">

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
@@ -1,15 +1,15 @@
 ﻿using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Platform.Storage;
-using Avalonia.ReactiveUI;
 
 using ReactiveUI;
+using ReactiveUI.Avalonia;
 
 using SemiStep.Core.Recipes;
-
 using SemiStep.UI.RecipeGrid;
 using SemiStep.UI.ShutdownService;
 
@@ -20,6 +20,7 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 	private ColumnBuilder? _columnBuilder;
 	private bool _forceClose;
 	private bool _isEditing;
+	private bool _columnsBuilt;
 
 	public MainWindow()
 	{
@@ -223,11 +224,12 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
 	private void BuildGrid()
 	{
-		if (_columnBuilder is null || ViewModel is null)
+		if (_columnsBuilt || _columnBuilder is null || ViewModel is null)
 		{
 			return;
 		}
 
 		_columnBuilder.BuildColumns(RecipeGrid);
+		_columnsBuilt = true;
 	}
 }

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
 using Avalonia.Controls;
@@ -53,27 +54,27 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		ToggleSyncCommand = ReactiveCommand.CreateFromTask(ExecuteToggleSyncAsync);
 
 		ToggleSyncCommand.ThrownExceptions
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(ex => messagePanel.AddError($"Sync toggle failed: {ex.Message}", "PLC"))
 			.DisposeWith(_disposables);
 
 		_coordinator.StateChanged
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(_ => RaiseAllStateProperties())
 			.DisposeWith(_disposables);
 
 		_coordinator.PlcStateChanged
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(_ => RaiseConnectionStateProperties())
 			.DisposeWith(_disposables);
 
 		_coordinator.PlcRecipeConflictDetected
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(conflict => _ = HandleConflictAsync(conflict.Local, conflict.Plc))
 			.DisposeWith(_disposables);
 
 		Observable.Interval(TimeSpan.FromSeconds(1))
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(_ => this.RaisePropertyChanged(nameof(LastSyncTimeText)))
 			.DisposeWith(_disposables);
 	}

--- a/SemiStep/SemiStep.UI/MainWindow/RecipeMenuBar.axaml
+++ b/SemiStep/SemiStep.UI/MainWindow/RecipeMenuBar.axaml
@@ -2,8 +2,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:SemiStep.UI.MainWindow"
              mc:Ignorable="d"
-             x:Class="SemiStep.UI.MainWindow.RecipeMenuBar">
+             x:Class="SemiStep.UI.MainWindow.RecipeMenuBar"
+             x:DataType="local:MainWindowViewModel">
 
     <Menu>
         <MenuItem Header="_File">

--- a/SemiStep/SemiStep.UI/MessageService/MessagePanel.axaml
+++ b/SemiStep/SemiStep.UI/MessageService/MessagePanel.axaml
@@ -4,7 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:messageService="clr-namespace:SemiStep.UI.MessageService"
              mc:Ignorable="d"
-             x:Class="SemiStep.UI.MessageService.MessagePanel">
+             x:Class="SemiStep.UI.MessageService.MessagePanel"
+             x:DataType="messageService:MessagePanelViewModel">
 
     <UserControl.Styles>
         <!-- Severity dot colors via style class binding -->

--- a/SemiStep/SemiStep.UI/MessageService/MessagePanelViewModel.cs
+++ b/SemiStep/SemiStep.UI/MessageService/MessagePanelViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
 using Avalonia.Threading;

--- a/SemiStep/SemiStep.UI/Plc/PlcConflictDialog.axaml
+++ b/SemiStep/SemiStep.UI/Plc/PlcConflictDialog.axaml
@@ -10,7 +10,7 @@
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         ShowInTaskbar="False"
-        SystemDecorations="BorderOnly">
+        WindowDecorations="BorderOnly">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/SemiStep/SemiStep.UI/Plc/PlcMonitorViewModel.cs
+++ b/SemiStep/SemiStep.UI/Plc/PlcMonitorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
 using ReactiveUI;
@@ -24,7 +25,7 @@ public sealed class PlcMonitorViewModel : ReactiveObject, IDisposable
 	public PlcMonitorViewModel(RecipeMutationCoordinator coordinator)
 	{
 		coordinator.ExecutionState
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(OnExecutionStateChanged)
 			.DisposeWith(_disposables);
 	}

--- a/SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
 using ReactiveUI;
@@ -33,17 +34,17 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 		NewRecipeCommand = ReactiveCommand.Create(NewRecipe);
 
 		SaveRecipeCommand.ThrownExceptions
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(ex => _messagePanel.AddError($"Save failed: {ex.Message}", FileSource))
 			.DisposeWith(_disposables);
 
 		SaveAsRecipeCommand.ThrownExceptions
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(ex => _messagePanel.AddError($"Save As failed: {ex.Message}", FileSource))
 			.DisposeWith(_disposables);
 
 		LoadRecipeCommand.ThrownExceptions
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(ex => _messagePanel.AddError($"Load failed: {ex.Message}", FileSource))
 			.DisposeWith(_disposables);
 	}

--- a/SemiStep/SemiStep.UI/RecipeGrid/CellStateToBoolConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/CellStateToBoolConverter.cs
@@ -1,0 +1,26 @@
+﻿using System.Globalization;
+
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+using SemiStep.Core.Recipes;
+
+namespace SemiStep.UI.RecipeGrid;
+
+public sealed class CellStateToBoolConverter : IValueConverter
+{
+	public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+	{
+		if (value is CellState cellState)
+		{
+			return cellState == CellState.Enabled;
+		}
+
+		return false;
+	}
+
+	public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+	{
+		return BindingOperations.DoNothing;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
@@ -66,7 +66,7 @@ public sealed class ColumnBuilder(
 			return _comboBoxCellFactory.CreateActionColumn(columnDef, width);
 		}
 
-		if (IsGroupBasedComboBox(columnDef.ColumnType))
+		if (ColumnTypes.IsGroupBoundColumn(columnDef.ColumnType))
 		{
 			return _comboBoxCellFactory.CreateGroupComboBoxColumn(columnDef, width);
 		}
@@ -77,10 +77,5 @@ public sealed class ColumnBuilder(
 		}
 
 		return _textCellFactory.CreateEditableColumn(columnDef, width);
-	}
-
-	private static bool IsGroupBasedComboBox(string columnType)
-	{
-		return string.Equals(columnType, ColumnTypes.ActionTargetComboBox, StringComparison.OrdinalIgnoreCase);
 	}
 }

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
@@ -15,14 +15,6 @@ public sealed class ColumnBuilder(
 	private readonly TextCellFactory _textCellFactory = new();
 	private readonly ColumnWidthCalculator _widthCalculator = new(recipeMetadataRegistry, gridStyle);
 
-	public void BuildColumnsFromConfiguration(DataGrid grid, AppConfiguration config)
-	{
-		grid.Columns.Clear();
-		_comboBoxCellFactory.InvalidateCaches();
-		AddNumberingColumn(grid);
-		AddColumnsFromConfig(grid, config);
-	}
-
 	public void BuildColumns(DataGrid grid)
 	{
 		grid.Columns.Clear();
@@ -48,20 +40,11 @@ public sealed class ColumnBuilder(
 		});
 	}
 
-	private void AddColumnsFromConfig(DataGrid grid, AppConfiguration config)
-	{
-		foreach (var columnDef in config.Columns.Values)
-		{
-			var column = CreateColumn(columnDef);
-			grid.Columns.Add(column);
-		}
-	}
-
 	private DataGridColumn CreateColumn(GridColumnDefinition columnDef)
 	{
 		var width = _widthCalculator.CalculateColumnWidth(columnDef);
 
-		if (columnDef.Key == ColumnTypes.Action)
+		if (columnDef.ColumnType == ColumnTypes.ActionComboBox)
 		{
 			return _comboBoxCellFactory.CreateActionColumn(columnDef, width);
 		}

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnTypes.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnTypes.cs
@@ -3,6 +3,7 @@
 internal static class ColumnTypes
 {
 	public const string Action = "action";
+	public static readonly string ActionIndexerBindingPath = $"[{Action}]";
 	public const string ActionComboBox = "action_combo_box";
 	public const string ActionTargetComboBox = "action_target_combo_box";
 	public const string PropertyField = "property_field";

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnTypes.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnTypes.cs
@@ -3,7 +3,6 @@
 internal static class ColumnTypes
 {
 	public const string Action = "action";
-	public static readonly string ActionIndexerBindingPath = IndexerPath(Action);
 	public const string ActionComboBox = "action_combo_box";
 	public const string ActionTargetComboBox = "action_target_combo_box";
 	public const string PropertyField = "property_field";

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnTypes.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnTypes.cs
@@ -3,10 +3,30 @@
 internal static class ColumnTypes
 {
 	public const string Action = "action";
-	public static readonly string ActionIndexerBindingPath = $"[{Action}]";
+	public static readonly string ActionIndexerBindingPath = IndexerPath(Action);
 	public const string ActionComboBox = "action_combo_box";
 	public const string ActionTargetComboBox = "action_target_combo_box";
 	public const string PropertyField = "property_field";
 	public const string StepStartTimeField = "step_start_time_field";
 	public const string TextField = "text_field";
+
+	public static bool IsGroupBoundColumn(string columnType)
+	{
+		return string.Equals(columnType, ActionTargetComboBox, StringComparison.OrdinalIgnoreCase);
+	}
+
+	public static string IndexerPath(string columnKey)
+	{
+		return $"[{columnKey}]";
+	}
+
+	public static string CellStatePath(string columnKey)
+	{
+		return $"CellStates[{columnKey}]";
+	}
+
+	public static string GroupItemsPath(string columnKey)
+	{
+		return $"GroupItemsByColumn[{columnKey}]";
+	}
 }

--- a/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
@@ -75,35 +75,24 @@ public sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataReg
 	{
 		var items = GetOrCreateActionItems();
 		var cellStateConverter = new CellStateConverter(ColumnTypes.Action);
+		var selectionConverter = new ComboBoxItemSelectionConverter(items);
 
 		return new FuncDataTemplate<RecipeRowViewModel>((row, _) =>
 		{
-			var currentId = row?.ActionId ?? 0;
-			var selectedItem = items.FirstOrDefault(item => item.Id == currentId);
 			var isEnabled = !isColumnReadOnly;
 
 			var comboBox = new ComboBox
 			{
 				ItemsSource = items,
 				DisplayMemberBinding = new Binding("DisplayText"),
-				SelectedItem = selectedItem,
 				HorizontalAlignment = HorizontalAlignment.Stretch,
 				VerticalAlignment = VerticalAlignment.Center,
 				Background = Brushes.Transparent,
 				BorderThickness = new Thickness(0),
 				IsHitTestVisible = isEnabled,
 			};
-
-			if (isEnabled && row is not null)
-			{
-				comboBox.SelectionChanged += (_, _) =>
-				{
-					if (comboBox.SelectedItem is ComboBoxItemViewModel selected)
-					{
-						row.SetPropertyValue(ColumnTypes.Action, selected.Id.ToString());
-					}
-				};
-			}
+			comboBox.Bind(ComboBox.SelectedItemProperty,
+				new Binding(ColumnTypes.ActionIndexerBindingPath) { Mode = BindingMode.TwoWay, Converter = selectionConverter });
 
 			return CellPresenter.Wrap(comboBox, cellStateConverter);
 		}, supportsRecycling: false);

--- a/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 
@@ -12,13 +13,15 @@ namespace SemiStep.UI.RecipeGrid;
 
 public sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataRegistry)
 {
-	private readonly Dictionary<string, List<ComboBoxItemViewModel>> _groupItemsByGroupName = new();
+	private static readonly CellStateToBoolConverter _cellStateToBoolConverter = new();
+	private static readonly HitTestVisibleMultiConverter _hitTestVisibleMultiConverter = new();
+	private static readonly ComboBoxItemMultiSelectionConverter _groupSelectionConverter = new();
+
 	private List<ComboBoxItemViewModel>? _cachedActionItems;
 
 	public void InvalidateCaches()
 	{
 		_cachedActionItems = null;
-		_groupItemsByGroupName.Clear();
 	}
 
 	public DataGridColumn CreateActionColumn(GridColumnDefinition columnDef, DataGridLength width)
@@ -28,10 +31,9 @@ public sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataReg
 			Header = columnDef.UiName,
 			Tag = columnDef.Key,
 			Width = width,
-			IsReadOnly = false,
+			IsReadOnly = true,
 			CanUserSort = false,
-			CellTemplate = CreateActionDisplayTemplate(),
-			CellEditingTemplate = CreateActionEditingTemplate(columnDef.ReadOnly)
+			CellTemplate = CreateActionCellTemplate(columnDef.ReadOnly)
 		};
 	}
 
@@ -42,161 +44,116 @@ public sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataReg
 			Header = columnDef.UiName,
 			Tag = columnDef.Key,
 			Width = width,
-			IsReadOnly = false,
+			IsReadOnly = true,
 			CanUserSort = false,
-			CellTemplate = CreateGroupDisplayTemplate(columnDef.Key),
-			CellEditingTemplate = CreateGroupEditingTemplate(columnDef.Key, columnDef.ReadOnly)
+			CellTemplate = CreateGroupCellTemplate(columnDef.Key, columnDef.ReadOnly)
 		};
 	}
 
-	private FuncDataTemplate<RecipeRowViewModel> CreateActionDisplayTemplate()
-	{
-		var cellStateConverter = new CellStateConverter(ColumnTypes.Action);
-
-		return new FuncDataTemplate<RecipeRowViewModel>((row, _) =>
-		{
-			var textBlock = new TextBlock
-			{
-				VerticalAlignment = VerticalAlignment.Center,
-				Padding = new Thickness(4, 2),
-				TextAlignment = TextAlignment.Center,
-			};
-
-			if (row is not null)
-			{
-				textBlock.Text = row.ActionName;
-			}
-
-			return CellPresenter.Wrap(textBlock, cellStateConverter);
-		}, supportsRecycling: false);
-	}
-
-	private FuncDataTemplate<RecipeRowViewModel> CreateActionEditingTemplate(bool isColumnReadOnly)
+	private FuncDataTemplate<RecipeRowViewModel> CreateActionCellTemplate(bool isColumnReadOnly)
 	{
 		var items = GetOrCreateActionItems();
 		var cellStateConverter = new CellStateConverter(ColumnTypes.Action);
 		var selectionConverter = new ComboBoxItemSelectionConverter(items);
 
-		return new FuncDataTemplate<RecipeRowViewModel>((row, _) =>
+		return new FuncDataTemplate<RecipeRowViewModel>((_, _) =>
 		{
-			var isEnabled = !isColumnReadOnly;
+			var comboBox = CreateStyledComboBox();
+			comboBox.ItemsSource = items;
 
-			var comboBox = new ComboBox
-			{
-				ItemsSource = items,
-				DisplayMemberBinding = new Binding("DisplayText"),
-				HorizontalAlignment = HorizontalAlignment.Stretch,
-				VerticalAlignment = VerticalAlignment.Center,
-				Background = Brushes.Transparent,
-				BorderThickness = new Thickness(0),
-				IsHitTestVisible = isEnabled,
-			};
-			comboBox.Bind(ComboBox.SelectedItemProperty,
-				new Binding(ColumnTypes.ActionIndexerBindingPath) { Mode = BindingMode.TwoWay, Converter = selectionConverter });
+			comboBox.Bind(
+				ComboBox.SelectedItemProperty,
+				new Binding(ColumnTypes.ActionIndexerBindingPath)
+				{
+					Mode = BindingMode.TwoWay,
+					Converter = selectionConverter
+				});
+
+			comboBox.Bind(
+				InputElement.IsHitTestVisibleProperty,
+				BuildHitTestVisibleBinding(ColumnTypes.Action, isColumnReadOnly));
 
 			return CellPresenter.Wrap(comboBox, cellStateConverter);
-		}, supportsRecycling: false);
+		}, supportsRecycling: true);
 	}
 
-	private FuncDataTemplate<RecipeRowViewModel> CreateGroupDisplayTemplate(string columnKey)
+	private FuncDataTemplate<RecipeRowViewModel> CreateGroupCellTemplate(string columnKey, bool isColumnReadOnly)
 	{
 		var cellStateConverter = new CellStateConverter(columnKey);
+		var itemsSourcePath = ColumnTypes.GroupItemsPath(columnKey);
+		var valueIndexerPath = ColumnTypes.IndexerPath(columnKey);
 
-		return new FuncDataTemplate<RecipeRowViewModel>((row, _) =>
+		return new FuncDataTemplate<RecipeRowViewModel>((_, _) =>
 		{
-			var textBlock = new TextBlock
-			{
-				VerticalAlignment = VerticalAlignment.Center,
-				Padding = new Thickness(4, 2),
-				TextAlignment = TextAlignment.Center,
-			};
+			var comboBox = CreateStyledComboBox();
 
-			if (row is not null)
-			{
-				var displayText = ResolveGroupDisplayText(row, columnKey);
-				textBlock.Text = displayText;
-			}
+			comboBox.Bind(
+				ComboBox.ItemsSourceProperty,
+				new Binding(itemsSourcePath));
 
-			return CellPresenter.Wrap(textBlock, cellStateConverter);
-		}, supportsRecycling: false);
-	}
+			comboBox.Bind(
+				ComboBox.SelectedItemProperty,
+				new MultiBinding
+				{
+					Mode = BindingMode.TwoWay,
+					Converter = _groupSelectionConverter,
+					Bindings =
+					{
+						new Binding(valueIndexerPath) { Mode = BindingMode.TwoWay },
+						new Binding(itemsSourcePath)
+					}
+				});
 
-	private FuncDataTemplate<RecipeRowViewModel> CreateGroupEditingTemplate(string columnKey, bool isColumnReadOnly)
-	{
-		var cellStateConverter = new CellStateConverter(columnKey);
-
-		return new FuncDataTemplate<RecipeRowViewModel>((row, _) =>
-		{
-			if (row is null)
-			{
-				return CellPresenter.Wrap(new TextBlock { Text = string.Empty }, cellStateConverter);
-			}
-
-			var groupItems = GetOrCreateGroupItems(row, columnKey);
-			var selectionConverter = new ComboBoxItemSelectionConverter(groupItems);
-			var cellState = row.CellStates.TryGetValue(columnKey, out var state) ? state : CellState.Enabled;
-			var isEnabled = !isColumnReadOnly && cellState == CellState.Enabled;
-
-			var comboBox = new ComboBox
-			{
-				ItemsSource = groupItems,
-				DisplayMemberBinding = new Binding("DisplayText"),
-				HorizontalAlignment = HorizontalAlignment.Stretch,
-				VerticalAlignment = VerticalAlignment.Center,
-				Background = Brushes.Transparent,
-				BorderThickness = new Thickness(0),
-				IsHitTestVisible = isEnabled,
-			};
-			comboBox.Bind(ComboBox.SelectedItemProperty,
-				new Binding($"[{columnKey}]") { Mode = BindingMode.TwoWay, Converter = selectionConverter });
+			comboBox.Bind(
+				InputElement.IsHitTestVisibleProperty,
+				BuildHitTestVisibleBinding(columnKey, isColumnReadOnly));
 
 			return CellPresenter.Wrap(comboBox, cellStateConverter);
-		}, supportsRecycling: false);
+		}, supportsRecycling: true);
 	}
 
-	private string ResolveGroupDisplayText(RecipeRowViewModel row, string columnKey)
+	private static ComboBox CreateStyledComboBox()
 	{
-		if (row.GetPropertyValue(columnKey) is not int intValue)
+		return new ComboBox
 		{
-			return string.Empty;
-		}
-
-		var groupItems = row.GetGroupItemsForColumn(columnKey);
-		if (groupItems is null)
-		{
-			return string.Empty;
-		}
-
-		return groupItems.TryGetValue(intValue, out var displayText) ? displayText : string.Empty;
+			DisplayMemberBinding = new Binding("DisplayText"),
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			VerticalAlignment = VerticalAlignment.Center,
+			Background = Brushes.Transparent,
+			BorderThickness = new Thickness(0),
+		};
 	}
 
-	private List<ComboBoxItemViewModel> GetOrCreateGroupItems(RecipeRowViewModel row, string columnKey)
+	private static BindingBase BuildHitTestVisibleBinding(string columnKey, bool isColumnReadOnly)
 	{
-		var groupName = row.GetGroupNameForColumn(columnKey);
-		if (groupName is null)
+		if (isColumnReadOnly)
 		{
-			return [];
+			return new Binding
+			{
+				Source = false,
+				Mode = BindingMode.OneTime,
+			};
 		}
 
-		if (_groupItemsByGroupName.TryGetValue(groupName, out var cached))
+		return new MultiBinding
 		{
-			return cached;
-		}
-
-		var groupResult = recipeMetadataRegistry.GetGroup(groupName);
-		if (groupResult.IsFailed)
-		{
-			return [];
-		}
-
-		var items = groupResult.Value.Items
-			.Select(kvp => new ComboBoxItemViewModel(kvp.Key, kvp.Value))
-			.OrderBy(item => item.Id)
-			.ToList();
-
-		_groupItemsByGroupName[groupName] = items;
-
-		return items;
+			Converter = _hitTestVisibleMultiConverter,
+			Bindings =
+			{
+				new Binding(ColumnTypes.CellStatePath(columnKey))
+				{
+					Converter = _cellStateToBoolConverter,
+				},
+				new Binding(nameof(DataGrid.IsReadOnly))
+				{
+					RelativeSource = new RelativeSource
+					{
+						Mode = RelativeSourceMode.FindAncestor,
+						AncestorType = typeof(DataGrid),
+					},
+				},
+			},
+		};
 	}
 
 	private List<ComboBoxItemViewModel> GetOrCreateActionItems()

--- a/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
@@ -63,7 +63,7 @@ public sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataReg
 
 			comboBox.Bind(
 				ComboBox.SelectedItemProperty,
-				new Binding(ColumnTypes.ActionIndexerBindingPath)
+				new Binding(ColumnTypes.IndexerPath(ColumnTypes.Action))
 				{
 					Mode = BindingMode.TwoWay,
 					Converter = selectionConverter

--- a/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxItemMultiSelectionConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxItemMultiSelectionConverter.cs
@@ -1,0 +1,51 @@
+﻿using System.Globalization;
+
+using Avalonia;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace SemiStep.UI.RecipeGrid;
+
+public sealed class ComboBoxItemMultiSelectionConverter : IMultiValueConverter
+{
+	private static readonly object?[] _noOpConvertBack =
+		new object?[] { BindingOperations.DoNothing, BindingOperations.DoNothing };
+
+	public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+	{
+		if (values.Count < 2)
+		{
+			return null;
+		}
+
+		var idValue = values[0];
+		var itemsValue = values[1];
+
+		if (idValue == AvaloniaProperty.UnsetValue || itemsValue == AvaloniaProperty.UnsetValue)
+		{
+			return null;
+		}
+
+		if (idValue is not int id)
+		{
+			return null;
+		}
+
+		if (itemsValue is not IReadOnlyList<ComboBoxItemViewModel> items)
+		{
+			return null;
+		}
+
+		return items.FirstOrDefault(item => item.Id == id);
+	}
+
+	public object?[] ConvertBack(object? value, IList<Type> targetTypes, object? parameter, CultureInfo culture)
+	{
+		if (value is ComboBoxItemViewModel selectedItem)
+		{
+			return new object?[] { selectedItem.Id, BindingOperations.DoNothing };
+		}
+
+		return _noOpConvertBack;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/HitTestVisibleMultiConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/HitTestVisibleMultiConverter.cs
@@ -1,0 +1,23 @@
+﻿using System.Globalization;
+
+using Avalonia.Data.Converters;
+
+namespace SemiStep.UI.RecipeGrid;
+
+public sealed class HitTestVisibleMultiConverter : IMultiValueConverter
+{
+	public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+	{
+		if (values.Count < 2)
+		{
+			return false;
+		}
+
+		if (values[0] is not bool cellEnabled || values[1] is not bool gridReadOnly)
+		{
+			return false;
+		}
+
+		return cellEnabled && !gridReadOnly;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeMultiConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeMultiConverter.cs
@@ -14,9 +14,12 @@ internal sealed class PropertyTimeMultiConverter : IMultiValueConverter
 			return string.Empty;
 		}
 
-		if (values.Any(v => v == AvaloniaProperty.UnsetValue))
+		for (var i = 0; i < values.Count; i++)
 		{
-			return string.Empty;
+			if (values[i] == AvaloniaProperty.UnsetValue)
+			{
+				return string.Empty;
+			}
 		}
 
 		var cellValue = values[0];
@@ -28,7 +31,7 @@ internal sealed class PropertyTimeMultiConverter : IMultiValueConverter
 			return string.Empty;
 		}
 
-		var rawString = cellValue.ToString();
+		var rawString = cellValue as string ?? cellValue.ToString();
 		if (string.IsNullOrEmpty(rawString))
 		{
 			return string.Empty;

--- a/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeMultiConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeMultiConverter.cs
@@ -7,7 +7,7 @@ namespace SemiStep.UI.RecipeGrid;
 
 internal sealed class PropertyTimeMultiConverter : IMultiValueConverter
 {
-	public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+	public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
 	{
 		if (values.Count < 3)
 		{

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
 using ReactiveUI;
@@ -22,12 +23,12 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 		_recipeGrid = recipeGrid;
 
 		var canUndo = _coordinator.StateChanged
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Select(_ => _coordinator.CanUndo)
 			.StartWith(false);
 
 		var canRedo = _coordinator.StateChanged
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Select(_ => _coordinator.CanRedo)
 			.StartWith(false);
 

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
 using ReactiveUI;
@@ -47,18 +48,18 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 			.DisposeWith(_disposables);
 
 		_isReadOnly = coordinator.ExecutionState
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Select(info => info.RecipeActive)
 			.ToProperty(this, x => x.IsReadOnly)
 			.DisposeWith(_disposables);
 
 		coordinator.ExecutionState
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(OnExecutionStateChanged)
 			.DisposeWith(_disposables);
 
 		coordinator.StateChanged
-			.ObserveOn(RxApp.MainThreadScheduler)
+			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(OnStateChange)
 			.DisposeWith(_disposables);
 	}

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
@@ -346,10 +346,21 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 		var stepStartTimes = _coordinator.Snapshot.StepStartTimes;
 		for (var i = 0; i < RecipeRows.Count; i++)
 		{
-			var rawSeconds = stepStartTimes.TryGetValue(i, out var time)
-				? time.TotalSeconds.ToString(CultureInfo.InvariantCulture)
-				: string.Empty;
-			RecipeRows[i].UpdateStepStartTime(rawSeconds);
+			string formattedTime;
+			if (stepStartTimes.TryGetValue(i, out var time))
+			{
+				var rawSeconds = time.TotalSeconds.ToString(CultureInfo.InvariantCulture);
+				formattedTime = TimeFormatHelper.FormatValue(
+					rawSeconds,
+					TimeFormatHelper.TimeHmsFormat,
+					TimeFormatHelper.TimeUnits);
+			}
+			else
+			{
+				formattedTime = string.Empty;
+			}
+
+			RecipeRows[i].UpdateStepStartTime(formattedTime);
 		}
 	}
 
@@ -368,7 +379,7 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 		ActionDefinition action,
 		int stepNumber)
 	{
-		var cellStates = new Dictionary<string, CellState>();
+		var cellStates = new Dictionary<string, CellState>(StringComparer.OrdinalIgnoreCase);
 		foreach (var col in RecipeMetadataRegistry.GetAllColumns())
 		{
 			cellStates[col.Key] = _coordinator.QueryService.GetCellState(col, action);

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
@@ -5,7 +5,7 @@ using SemiStep.Core.Recipes;
 
 namespace SemiStep.UI.RecipeGrid;
 
-public class RecipeRowViewModel(
+public sealed class RecipeRowViewModel(
 	int stepNumber,
 	Step step,
 	ActionDefinition action,

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
@@ -18,6 +18,9 @@ public class RecipeRowViewModel(
 	private readonly (IReadOnlyDictionary<string, string?> Units, IReadOnlyDictionary<string, string> FormatKinds) _columnMetadata
 		= BuildColumnMetadata(action, recipeMetadataRegistry);
 
+	private readonly IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> _groupItemsByColumn
+		= BuildGroupItemsByColumn(action, recipeMetadataRegistry);
+
 	public int StepNumber
 	{
 		get;
@@ -31,8 +34,6 @@ public class RecipeRowViewModel(
 	}
 
 	public int ActionId => _step.ActionKey;
-
-	public string ActionName => action.UiName;
 
 	public bool IsCurrentStep
 	{
@@ -52,11 +53,16 @@ public class RecipeRowViewModel(
 
 	public IReadOnlyDictionary<string, string> ColumnFormatKinds => _columnMetadata.FormatKinds;
 
+	public IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupItemsByColumn => _groupItemsByColumn;
+
 	public object? this[string columnKey]
 	{
 		get => GetPropertyValue(columnKey);
 		set => SetPropertyValue(columnKey, value?.ToString());
 	}
+
+	public event Action<string, string?>? PropertyValueChanged;
+	public event Action<int>? ActionChanged;
 
 	public void Dispose()
 	{
@@ -64,9 +70,6 @@ public class RecipeRowViewModel(
 		ActionChanged = null;
 		GC.SuppressFinalize(this);
 	}
-
-	public event Action<string, string?>? PropertyValueChanged;
-	public event Action<int>? ActionChanged;
 
 	public void UpdateStep(Step newStep)
 	{
@@ -120,30 +123,6 @@ public class RecipeRowViewModel(
 		PropertyValueChanged?.Invoke(columnKey, value);
 	}
 
-	public string? GetGroupNameForColumn(string columnKey)
-	{
-		var actionColumn = action.Properties.FirstOrDefault(c => c.Key == columnKey);
-
-		return actionColumn?.GroupName;
-	}
-
-	public IReadOnlyDictionary<int, string>? GetGroupItemsForColumn(string columnKey)
-	{
-		var groupName = GetGroupNameForColumn(columnKey);
-		if (groupName is null)
-		{
-			return null;
-		}
-
-		var groupResult = recipeMetadataRegistry.GetGroup(groupName);
-		if (groupResult.IsFailed)
-		{
-			return null;
-		}
-
-		return groupResult.Value.Items;
-	}
-
 	private static PropertyTypeDefinition? ResolvePropertyType(
 		ActionPropertyDefinition actionProperty,
 		RecipeMetadataRegistry recipeMetadataRegistry)
@@ -152,12 +131,50 @@ public class RecipeRowViewModel(
 		return propertyResult.IsSuccess ? propertyResult.Value : null;
 	}
 
+	private static IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> BuildGroupItemsByColumn(
+		ActionDefinition actionDefinition,
+		RecipeMetadataRegistry recipeMetadataRegistry)
+	{
+		var groupItemsByColumn = new Dictionary<string, IReadOnlyList<ComboBoxItemViewModel>>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var columnDefinition in recipeMetadataRegistry.GetAllColumns())
+		{
+			if (!ColumnTypes.IsGroupBoundColumn(columnDefinition.ColumnType))
+			{
+				continue;
+			}
+
+			groupItemsByColumn[columnDefinition.Key] = Array.Empty<ComboBoxItemViewModel>();
+		}
+
+		foreach (var actionProperty in actionDefinition.Properties)
+		{
+			if (actionProperty.GroupName is null)
+			{
+				continue;
+			}
+
+			var groupResult = recipeMetadataRegistry.GetGroup(actionProperty.GroupName);
+			if (groupResult.IsFailed)
+			{
+				continue;
+			}
+
+			groupItemsByColumn[actionProperty.Key] = groupResult.Value.Items
+				.Select(kvp => new ComboBoxItemViewModel(kvp.Key, kvp.Value))
+				.OrderBy(item => item.Id)
+				.ToList();
+		}
+
+		return groupItemsByColumn;
+	}
+
 	private static (IReadOnlyDictionary<string, string?> Units, IReadOnlyDictionary<string, string> FormatKinds) BuildColumnMetadata(
 		ActionDefinition actionDefinition,
 		RecipeMetadataRegistry recipeMetadataRegistry)
 	{
-		var units = new Dictionary<string, string?>(StringComparer.Ordinal);
-		var formatKinds = new Dictionary<string, string>(StringComparer.Ordinal);
+		var units = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+		var formatKinds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
 		foreach (var actionProperty in actionDefinition.Properties)
 		{

--- a/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
@@ -40,6 +40,35 @@ internal sealed class TextCellFactory
 
 	private FuncDataTemplate<RecipeRowViewModel> CreateDisplayTemplate(string columnKey)
 	{
+		return columnKey == TimeFormatHelper.StepStartTimeColumnKey
+			? CreateStepStartTimeTemplate(columnKey)
+			: CreateMultiBindingTemplate(columnKey);
+	}
+
+	private FuncDataTemplate<RecipeRowViewModel> CreateStepStartTimeTemplate(string columnKey)
+	{
+		var cellStateConverter = new CellStateConverter(columnKey);
+
+		return new FuncDataTemplate<RecipeRowViewModel>((_, _) =>
+		{
+			var textBlock = new TextBlock
+			{
+				VerticalAlignment = VerticalAlignment.Center,
+				Padding = new Thickness(4, 2),
+				TextAlignment = TextAlignment.Center,
+			};
+
+			textBlock.Bind(TextBlock.TextProperty, new Binding(nameof(RecipeRowViewModel.StepStartTime))
+			{
+				Mode = BindingMode.OneWay
+			});
+
+			return CellPresenter.Wrap(textBlock, cellStateConverter);
+		}, supportsRecycling: true);
+	}
+
+	private FuncDataTemplate<RecipeRowViewModel> CreateMultiBindingTemplate(string columnKey)
+	{
 		var cellStateConverter = new CellStateConverter(columnKey);
 		var bindingPath = ResolveBindingPath(columnKey);
 		var unitsConverter = new DictionaryEntryConverter<string?>(columnKey, null);

--- a/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
@@ -20,7 +20,9 @@ internal sealed class TextCellFactory
 			Width = width,
 			IsReadOnly = true,
 			CanUserSort = false,
-			CellTemplate = CreateDisplayTemplate(columnDef.Key)
+			CellTemplate = columnDef.ColumnType == ColumnTypes.StepStartTimeField
+				? CreateStepStartTimeTemplate(columnDef.Key)
+				: CreateMultiBindingTemplate(columnDef.Key)
 		};
 	}
 
@@ -33,16 +35,11 @@ internal sealed class TextCellFactory
 			Width = width,
 			IsReadOnly = false,
 			CanUserSort = false,
-			CellTemplate = CreateDisplayTemplate(columnDef.Key),
+			CellTemplate = columnDef.ColumnType == ColumnTypes.StepStartTimeField
+				? CreateStepStartTimeTemplate(columnDef.Key)
+				: CreateMultiBindingTemplate(columnDef.Key),
 			CellEditingTemplate = CreateEditingTemplate(columnDef.Key)
 		};
-	}
-
-	private FuncDataTemplate<RecipeRowViewModel> CreateDisplayTemplate(string columnKey)
-	{
-		return columnKey == TimeFormatHelper.StepStartTimeColumnKey
-			? CreateStepStartTimeTemplate(columnKey)
-			: CreateMultiBindingTemplate(columnKey);
 	}
 
 	private FuncDataTemplate<RecipeRowViewModel> CreateStepStartTimeTemplate(string columnKey)
@@ -144,6 +141,6 @@ internal sealed class TextCellFactory
 	{
 		return columnKey == TimeFormatHelper.StepStartTimeColumnKey
 			? nameof(RecipeRowViewModel.StepStartTime)
-			: $"[{columnKey}]";
+			: ColumnTypes.IndexerPath(columnKey);
 	}
 }

--- a/SemiStep/SemiStep.UI/SemiStep.UI.csproj
+++ b/SemiStep/SemiStep.UI/SemiStep.UI.csproj
@@ -12,19 +12,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.13"/>
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.13"/>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13"/>
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8"/>
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13"/>
-    <PackageReference Include="Avalonia.Win32" Version="11.3.13"/>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.13"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5"/>
-    <PackageReference Include="Serilog" Version="4.3.1"/>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2"/>
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1"/>
-    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
+    <PackageReference Include="Avalonia"/>
+    <PackageReference Include="Avalonia.HarfBuzz"/>
+    <PackageReference Include="Avalonia.Desktop"/>
+    <PackageReference Include="Avalonia.Themes.Fluent"/>
+    <PackageReference Include="ReactiveUI.Avalonia"/>
+    <PackageReference Include="Avalonia.Controls.DataGrid"/>
+    <PackageReference Include="Avalonia.Win32"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
+    <PackageReference Include="Serilog"/>
+    <PackageReference Include="Serilog.Extensions.Logging"/>
+    <PackageReference Include="Serilog.Sinks.Console"/>
+    <PackageReference Include="Serilog.Sinks.File"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/SemiStep/SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml
+++ b/SemiStep/SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml
@@ -10,7 +10,7 @@
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         ShowInTaskbar="False"
-        SystemDecorations="BorderOnly">
+        WindowDecorations="BorderOnly">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary

- **Stack modernization**: brings the project to .NET 10 / C# 14 with Avalonia 12.0.3, xUnit v3, ReactiveUI.Avalonia 12.0.1, and Central Package Management via `Directory.Packages.props`. Includes DataGrid scroll-perf fixes discovered during the migration.
- **ComboBox CellTemplate migration**: replaces the broken `CellEditingTemplate + ComboBox` pattern (Avalonia 12 regression — `AvaloniaUI/Avalonia.Controls.DataGrid#236`) with the canonical `CellTemplate + IsReadOnly=true` workaround. Action column and group-bound columns now build via `FuncDataTemplate<RecipeRowViewModel>` without `row`-closures — group items live as an immutable `IReadOnlyDictionary` on the row VM, action items live as a global cache on the factory.
- **Group ComboBox binding refactor**: introduces `ComboBoxItemMultiSelectionConverter` (`IMultiValueConverter`) so `SelectedItem` resolves through bindings against `(id, items-list)` rather than a captured items list.

## Test plan

- [ ] CI: build + xUnit v3 tests + format check (`dotnet format --verify-no-changes`)
- [ ] Manual smoke (7 scenarios, headless cannot validate hit-testing):
  - [ ] Click action ComboBox cell → popup opens on first click
  - [ ] Pick a different action → row rebuilds correctly
  - [ ] Click group ComboBox cell → popup opens, shows group items
  - [ ] Disabled cells stay non-interactive (`IsHitTestVisible=false`)
  - [ ] RecipeActive read-only mode blocks edits
  - [ ] Scroll recipe ≥100 steps for 30s — no GC spikes or visual glitches
  - [ ] Open / save existing recipe round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)