### PR TITLE
chore: enforce feature-branch workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"if": "Bash(git commit*)",
+						"command": "branch=$(git symbolic-ref --short HEAD 2>/dev/null); if [ \"$branch\" = \"master\" ] || [ \"$branch\" = \"main\" ]; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Direct commit to %s is forbidden. Create a feature branch: git switch -c <name> origin/master\"}}' \"$branch\"; fi"
+					}
+				]
+			}
+		]
+	}
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ "$branch" = "master" ] || [ "$branch" = "main" ]; then
+	echo ""
+	echo "BLOCKED: direct commit to '$branch' is forbidden."
+	echo "Create a feature branch first:"
+	echo "  git switch -c <feature-name> origin/master"
+	echo ""
+	exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,19 @@ No abbreviations in names.
 
 **Inline formulas on actions:** when an action declares a `formula:` block (see `Docs/03-data-model.md` §3.4), cell edits route through `RecipeSession.UpdateStepProperty` → `FormulaEvaluator.Recalculate` and update one coupled cell in the same mutation (single undo unit). CSV import (§3.5) is verbatim — formulas are not re-evaluated on load.
 
+## Git Workflow
+
+- `master` is a mirror of `origin/master`. Never commit directly to it — the local pre-commit hook (`.githooks/pre-commit`) and the Claude Code PreToolUse hook both enforce this; do not bypass with `--no-verify`.
+- Start every new task with a feature branch off the freshest remote tip: `git fetch origin && git switch -c <feature-name> origin/master`.
+- Before any push, run `git log origin/master..HEAD --oneline` and verify every commit belongs to the stated PR scope. If anything unrelated appears, stop and split.
+- One PR = one logical change. If the PR description needs the word "and", split into two PRs.
+- Keep feature branches rebased on `origin/master`. Do not let them drift.
+- After a PR merges: `git switch master && git pull --ff-only`, then delete the local branch.
+
+### Worktree branches
+
+When the user asks to create a worktree branch for a feature, name the branch with the feature name **only** — no `worktree-` prefix, no `wt-` prefix, no suffix. Example: feature `execution-status-timing` → branch `execution-status-timing`, worktree path `.claude/worktrees/execution-status-timing`.
+
 ## Troubleshooting
 
 **Deleting Windows reserved-name files (`nul`, `con`, `aux`, etc.):** Use Git Bash: `rm -f nul`


### PR DESCRIPTION
## Summary

Two-layer defence against the failure mode that polluted PR #26 (direct commits to local master leaking into feature branches):

- `.githooks/pre-commit` blocks `git commit` when HEAD is `master`/`main`. Wired via `git config core.hooksPath .githooks` (per-checkout setting; new clones run that once).
- `.claude/settings.json` PreToolUse hook denies any `git commit*` from the Claude Code Bash tool while on `master`/`main`.
- `CLAUDE.md` gains a **Git Workflow** section: branch off `origin/master`, scope-verify before push, one logical change per PR, worktree branch naming without the `worktree-` prefix.

GitHub branch protection on `master` will be enabled separately (require PR before merging, block direct pushes, block force-push and deletions).

## Test plan

- [x] Local pre-commit hook: tested on master, returns exit 1 with explanation.
- [x] Claude Code PreToolUse hook: pipe-tested, returns the correct `permissionDecision: deny` JSON payload on master.
- [x] Commit of this PR happened on the feature branch — hooks correctly did not fire.