### PR TITLE
fix: use Avalonia indexer name 'Item' so coupled cells refresh

### DIFF
--- a/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
@@ -231,8 +231,11 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void UpdateStep_RaisesItemArrayPropertyChanged()
+	public void UpdateStep_RaisesIndexerPropertyChanged()
 	{
+		// Avalonia's IndexerNode invalidates indexer bindings only when PropertyChanged carries
+		// the declared CLR indexer name ("Item" by default). The WPF "Item[]" convention is not
+		// recognized — see Avalonia.Data.Core.ExpressionNodes.Reflection.ReflectionIndexerNode.
 		var row = CreateRow();
 		var changedProperties = new List<string>();
 		row.PropertyChanged += (_, args) => changedProperties.Add(args.PropertyName ?? "");
@@ -240,7 +243,7 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		var updatedStep = _session.Current.Steps[0];
 		row.UpdateStep(updatedStep);
 
-		changedProperties.Should().Contain("Item[]");
+		changedProperties.Should().Contain("Item");
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
@@ -15,7 +15,7 @@ public sealed class RecipeRowViewModel(
 	IReadOnlySet<string> inapplicableColumns)
 	: ReactiveObject, IDisposable
 {
-	private const string IndexerName = "Item[]";
+	private const string IndexerName = "Item";
 
 	private readonly (IReadOnlyDictionary<string, string?> Units, IReadOnlyDictionary<string, string> FormatKinds) _columnMetadata
 		= BuildColumnMetadata(action, recipeMetadataRegistry);


### PR DESCRIPTION
Salvaged from PR #26 rebase. Standalone change: corrects the indexer name passed to PropertyChanged from `Item[]` to `Item`, which is what Avalonia's binding layer listens for. Without it, coupled-cell mutations did not refresh dependent cells.