### PR TITLE
feat: block save and PLC push when recipe has warnings

### DIFF
--- a/Docs/plans/completed/20260520-warning-blocks-save.md
+++ b/Docs/plans/completed/20260520-warning-blocks-save.md
@@ -1,0 +1,194 @@
+# Block Save and PLC Push When Recipe Has Warnings
+
+**Prerequisite for:** `Docs/plans/20260520-execution-overlay-and-loop-tinting.md` — overlay/tinting behaviour over malformed recipes is safer once such recipes can no longer be saved or pushed to the PLC.
+
+## Overview
+
+A recipe whose structure is broken — currently the only known case being an unclosed `For` loop — is today persisted to CSV without complaint and silently pushed to the PLC. `RecipeSession.IsValid` is `true` because `LoopParser` emits a `Warning`, not an `Error`, and FluentResults' `IsSuccess` ignores warnings. The user sees a yellow message in the panel but nothing in the persistence or sync path consults it.
+
+**Decision (after discussion):** any warning attached to the current recipe snapshot is treated as a blocking defect for Save and PLC push. To make this rule clean, the existing advisory warning "Recipe has no steps" is removed — an empty recipe is a normal initial state that does not warrant a warning. The remaining analyzer warnings (`LoopParser` unclosed-For and unmatched-EndFor) all represent real structural defects, so promoting "any warning blocks Save" causes no false positives.
+
+Goal:
+
+- An empty recipe is valid (no warnings, `IsValid=true`).
+- A recipe whose snapshot carries any warning cannot be saved to CSV and cannot be pushed to the PLC.
+- Editing of a defective recipe continues to work (so the user can add the missing `EndFor`); `RecipeSession.Apply` continues to gate only on `Result.IsFailed`, not on warnings.
+- Loading a defective recipe from disk is still allowed — the user must be able to open a file to fix it.
+
+## Context (from discovery)
+
+**Warning emission sites that land in the recipe snapshot:**
+
+- `SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs:16` — `Result.Ok(RecipeSnapshot.Empty).WithWarning("Recipe has no steps")`. Emitted when `recipe.Steps.Count == 0`. **To be removed.**
+- `SemiStep/SemiStep.Core/Recipes/Analysis/LoopParser.cs:45` — `new Warning($"Unmatched EndFor at step {i}")`.
+- `SemiStep/SemiStep.Core/Recipes/Analysis/LoopParser.cs:67` — `new Warning($"Unclosed For loop starting at step {frame.StartIndex}")`.
+
+Other `WithWarning(...)` and `new Warning(...)` calls in the codebase (CSV import in `CsvService.cs:55`, config loaders in `SemiStep.Core/Configuration/Loaders/*`, etc.) do **not** flow into `RecipeSession._latestSnapshot`. They surface through other `Result` objects that hit the message panel directly. The "warning blocks Save" rule applies strictly to warnings inside `RecipeSession._latestSnapshot.Reasons`.
+
+**`IsValid` definition and consumers:**
+
+- `SemiStep/SemiStep.Core/Recipes/RecipeSession.cs:56` — `IsValid => _latestSnapshot.IsSuccess`. FluentResults: `IsSuccess` is `true` when there are no `Error` reasons; warnings do not flip it. New definition: `IsSuccess && no warning reasons present`.
+- `SemiStep/SemiStep.Core/Recipes/RecipeSession.cs:529` — `NotifySyncIfEnabled` already passes `IsValid` to `IPlcSyncService.NotifyRecipeChanged`. Becomes correct automatically.
+- `SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs:176,324` — both call sites already pass `_session.IsValid`. Become correct automatically.
+- `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs:99-114` — `NotifyRecipeChanged(recipe, isValid)` on `isValid=false` clears pending snapshot and sets `Status = OutOfSync`. Already correct.
+- `SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs:350-379` — `SaveRecipeAsync` does **not** consult `IsValid`. New gate goes here.
+
+**Why `Apply` must keep gating only on `IsFailed`:**
+
+`RecipeSession.Apply` (`RecipeSession.cs:66-79`) rejects any mutation whose snapshot `IsFailed`. If `IsValid=false` were used to gate `Apply`, adding a single `For` step to an empty recipe (which produces a warning until the matching `EndFor` is added) would be rejected, leaving the user unable to construct any loop. So `Apply` stays as it is; warnings only block Save and PLC push via the new `IsValid` definition.
+
+**Tests affected:**
+
+- `SemiStep/SemiStep.Tests/Core/Integration/Validity/CoreValidityTests.cs:14-23` — `EmptyRecipe_IsValid_ButHasWarning`: rewrite to `EmptyRecipe_IsValid_NoWarnings` — `IsValid=true`, `Warnings` empty.
+- `SemiStep/SemiStep.Tests/Core/Integration/Validity/CoreValidityTests.cs:48-56` — `UnclosedLoop_ProducesWarning`: rename to `UnclosedLoop_BlocksValidity` — assert `IsValid=false` and the warning message present.
+- `SemiStep/SemiStep.Tests/Core/Integration/Validity/CoreValidityTests.cs:96-103` — `WarningsDoNotAffectValidity`: delete (the asserted invariant is no longer true).
+- `SemiStep/SemiStep.Tests/Core/Integration/Loops/CoreLoopTests.cs:43-51` — `UnclosedLoop_ProducesWarning`: add `driver.IsValid.Should().BeFalse()`.
+- `SemiStep/SemiStep.Tests/Core/Integration/Loops/CoreLoopTests.cs:53-61` — `UnmatchedEndFor_ProducesWarning`: same treatment.
+- `SemiStep/SemiStep.Tests/Core/Integration/Snapshot/CoreSnapshotStateTests.cs:14-34` — `RejectedMutation_LeavesRecipeAndValidStateUnchanged`: the existing state in this test contains an unclosed-For chain; `IsValid` flips to `false`. Update the assertion message and value.
+- `SemiStep/SemiStep.Tests/Core/Integration/Snapshot/CoreSnapshotStateTests.cs:36-49` — `LastValidRecipe_UpdatesAfterFix`: after `AddFor(3).AddWait(1f)`, `IsValid=false`; after `AddEndFor()`, `IsValid=true`; `LastValidRecipe.StepCount=3`.
+- `SemiStep/SemiStep.Tests/UI/RecipeCoordinatorLoadRecipeTests.cs:104-118` — the test that loads a previously-saved empty recipe and asserts the message panel shows "Recipe has no steps". Update: panel is empty after loading an empty recipe (no warnings expected).
+- `SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs:77-130` — already covers `isValid=false` paths; no change needed.
+
+## Development Approach
+
+- Testing approach: Regular — implement, then write/update tests in the same task.
+- Each task ends with tests written/updated and passing.
+- `dotnet format SemiStep/SemiStep.slnx` before any commit (pre-commit hook).
+- Backward compatibility: `IsValid` semantics change. Consumers that should observe the new behaviour (Save, PLC sync) already use `IsValid`. No public API is removed.
+
+## Testing Strategy
+
+- **Core unit/integration tests (Component=Core):**
+  - Update the existing tests listed above.
+  - Add `Save_BlockedWhenWarningPresent_FromRecipeSession`: not needed — the Save gate is a UI-side concern; covered by the UI integration test below.
+  - Add `Apply_AcceptsDefectiveSnapshot_KeepsIsValidFalse`: build an unclosed-For via the driver; assert `Apply` returned success, `IsValid=false`, warning present.
+- **UI integration test (Component=UI, Category=Integration):** `Save_OnDefectiveRecipe_FailsAndWritesNoFile` — drive a recipe with unclosed `For` through `RecipeCoordinator.SaveRecipeAsync(tempPath)`, assert `Result.IsFailed`, `File.Exists(tempPath) == false`, and the message panel still shows the warning.
+- **PLC sync (Component=S7):** add `Apply_OnDefectiveRecipe_NotifiesSyncWithIsValidFalse` — spy on `IPlcSyncService`; drive `AddFor(3).AddWait(1)`; assert the spy received `NotifyRecipeChanged(_, isValid: false)`.
+
+## Solution Overview
+
+1. Remove the "Recipe has no steps" warning from `RecipeAnalyzer.Analyze`. Empty recipe → `Result.Ok(RecipeSnapshot.Empty)` with no reasons.
+2. Redefine `RecipeSession.IsValid` to combine `IsSuccess` with absence of any `Warning` in `_latestSnapshot.Reasons`. Leave `Apply` gating untouched.
+3. Add an `IsValid` check at the top of `RecipeCoordinator.SaveRecipeAsync`; on `false`, return a failed `Result` without writing the file and refresh the message panel.
+4. Update or delete the named tests; add the new tests per Testing Strategy.
+
+## Technical Details
+
+### `RecipeAnalyzer` change
+
+`SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs:14-17` — drop the early-return warning entirely. Empty recipes pass through normally; `LoopParser.Parse` on a zero-step recipe returns `Result.Ok([])` with no reasons (verified by reading the loop body — no warnings emitted on empty input).
+
+```
+public Result<RecipeSnapshot> Analyze(Recipe recipe)
+{
+    var loopParseResult = LoopParser.Parse(recipe);
+    if (loopParseResult.IsFailed)
+    {
+        return Result.Fail(loopParseResult.Errors);
+    }
+    // ... existing tail unchanged ...
+}
+```
+
+### `RecipeSession.IsValid` redefinition
+
+`SemiStep/SemiStep.Core/Recipes/RecipeSession.cs:56`:
+
+```
+public bool IsValid =>
+    _latestSnapshot.IsSuccess && _latestSnapshot.Reasons.OfType<Warning>().Any() == false;
+```
+
+`Apply` (line 66) keeps its current `if (snapshot.IsFailed) return ...` gate — defective edits still produce accepted snapshots, so the user can keep typing.
+
+### Save gate
+
+`SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs:350-379`, inserted before `_csvService.SaveAsync`:
+
+```
+if (_session.IsValid == false)
+{
+    var message = "Cannot save recipe with structural defects (see warnings in the message panel).";
+    _logger.LogWarning("Save rejected: recipe is not valid. StepCount={StepCount}", _session.Current.StepCount);
+    _lastRecipeResult = Result.Fail(message);
+    RebuildMessagePanel();
+    return _lastRecipeResult;
+}
+```
+
+### PLC sync
+
+No new code. `RecipeSession.NotifySyncIfEnabled` and `PlcLifecycleManager` already pass `IsValid`; `PlcSyncCoordinator.NotifyRecipeChanged` already short-circuits on `isValid=false`.
+
+## Implementation Steps
+
+### Task 1: Remove "Recipe has no steps" warning
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs:14-17`
+
+- [ ] Delete the early-return branch for `recipe.Steps.Count == 0`.
+- [ ] Verify `LoopParser.Parse` on an empty recipe returns `Result.Ok([])` with no reasons (the loop body in `LoopParser.cs:18-62` is skipped when `Steps.Count == 0` and the post-loop drain at line 64 is a no-op on an empty stack).
+- [ ] Build: `dotnet build SemiStep/SemiStep.slnx`.
+
+### Task 2: Redefine `IsValid`
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/RecipeSession.cs:56`
+
+- [ ] Replace the `IsValid` property body to combine `IsSuccess` with the absence of any `Warning` reason on `_latestSnapshot.Reasons`.
+- [ ] Confirm `Apply` (`RecipeSession.cs:66-79`) still gates only on `snapshot.IsFailed`.
+- [ ] Build.
+
+### Task 3: Gate `RecipeCoordinator.SaveRecipeAsync`
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs:350-379`
+
+- [ ] First, read `RebuildMessagePanel()` to see how `_lastRecipeResult` is merged with other panel sources. If overwriting `_lastRecipeResult` with the Save-rejection `Result.Fail` would hide the underlying analyzer warning, adjust the gate so both surface — e.g. attach the snapshot warnings to the failure `Result.Fail(message).WithReasons(_session.Snapshot.Reasons)`, or call `RebuildMessagePanel()` with an explicit list that includes both.
+- [ ] Insert the early-return guard before `_csvService.SaveAsync`.
+- [ ] Set `_lastRecipeResult` to the failure result; call `RebuildMessagePanel()`.
+- [ ] Build.
+
+### Task 4: Update / delete existing tests
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/Core/Integration/Validity/CoreValidityTests.cs` (`EmptyRecipe_IsValid_ButHasWarning` at line 14, `UnclosedLoop_ProducesWarning` at line 48, **delete** `WarningsDoNotAffectValidity` at line 96)
+- Modify: `SemiStep/SemiStep.Tests/Core/Integration/Loops/CoreLoopTests.cs` (`UnclosedLoop_ProducesWarning` at line 43, `UnmatchedEndFor_ProducesWarning` at line 53)
+- Modify: `SemiStep/SemiStep.Tests/Core/Integration/Snapshot/CoreSnapshotStateTests.cs` (`RejectedMutation_LeavesRecipeAndValidStateUnchanged` at line 14, `LastValidRecipe_UpdatesAfterFix` at line 36)
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeCoordinatorLoadRecipeTests.cs:104-118` (the load-empty-recipe test that asserts the "Recipe has no steps" panel state)
+
+- [ ] Rewrite `EmptyRecipe_IsValid_ButHasWarning` → `EmptyRecipe_IsValid_NoWarnings`: `IsValid=true`, `Warnings` empty.
+- [ ] Delete `WarningsDoNotAffectValidity`.
+- [ ] In `CoreLoopTests` and `CoreValidityTests`, add `driver.IsValid.Should().BeFalse()` next to the existing warning assertions; the warning message assertions remain.
+- [ ] In `CoreSnapshotStateTests`, flip `IsValid` expectations on the defective intermediate states. Before writing the new `LastValidRecipe.StepCount=3` assertion in `LastValidRecipe_UpdatesAfterFix`, read `RecipeSession.UpdateSnapshot` and confirm `_lastValidRecipe` is assigned on every accepted snapshot regardless of warnings — the assertion only holds if it is. Adjust the expected value if not.
+- [ ] Audit `CoreValidityTests.MultipleWarnings_AllCaptured` (line 106). No behavioural change is expected — the test should continue to pass with the two unclosed-For warnings — but verify the assertions still read coherently after the "no steps" warning removal.
+- [ ] In `RecipeCoordinatorLoadRecipeTests`, update the post-load assertion: panel has no warnings after loading an empty recipe.
+- [ ] Run: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Component=Core"` and `--filter "Component=UI"`.
+
+### Task 5: Add new tests
+
+**Files:**
+- Modify (or create new file under): `SemiStep/SemiStep.Tests/Core/Integration/Validity/` — add `Apply_AcceptsDefectiveSnapshot_KeepsIsValidFalse`.
+- Create: `SemiStep/SemiStep.Tests/UI/Coordinator/RecipeCoordinatorSaveGateTests.cs` — `Save_OnDefectiveRecipe_FailsAndWritesNoFile`.
+- Modify (or create new file under): `SemiStep/SemiStep.Tests/S7/` — add `Apply_OnDefectiveRecipe_NotifiesSyncWithIsValidFalse`.
+
+- [ ] `Apply_AcceptsDefectiveSnapshot_KeepsIsValidFalse`: build an unclosed-For via `RecipeTestDriver`; assert the `Apply` call returned a successful `Result`, `session.IsValid=false`, at least one warning present in `Warnings`.
+- [ ] `Save_OnDefectiveRecipe_FailsAndWritesNoFile`: drive an unclosed-For recipe through a real `RecipeCoordinator`, call `SaveRecipeAsync(tempFilePath)`, assert `Result.IsFailed`, `File.Exists(tempFilePath) == false`, and the message panel still surfaces the underlying warning.
+- [ ] `Apply_OnDefectiveRecipe_NotifiesSyncWithIsValidFalse`: spy on `IPlcSyncService`; drive `AddFor(3).AddWait(1)`; assert the spy received `NotifyRecipeChanged(_, isValid: false)` for the final state.
+- [ ] Run: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`.
+
+### Task 6: Verify acceptance criteria and close out
+
+- [ ] `dotnet build SemiStep/SemiStep.slnx` succeeds.
+- [ ] `dotnet format SemiStep/SemiStep.slnx` — no diff.
+- [ ] Full test suite green.
+- [ ] Manual smoke (optional but recommended): launch the UI, add `For 3 / Wait 10`, attempt Save — observe failure message; add `EndFor`, Save succeeds. Start the app with an empty recipe — no warning panel, Save succeeds (and produces an empty CSV).
+- [ ] Move this plan to `Docs/plans/completed/`.
+
+## Out of Scope
+
+- The existing `Result.Fail` path in `RecipeAnalyzer.cs:33-36` for `MaxLoopDepth > 3` continues to reject the mutation via `Apply` (so the user cannot add a fourth nested `For`). This is intentional and orthogonal to the warning-blocks-save change.
+- Warnings emitted outside the recipe snapshot (CSV import warnings, config loader warnings, etc.) are unaffected and do not block Save.
+- Localisation of the Save-rejection user-facing message. English-only for now, consistent with other coordinator messages.
+- Any change to the message-panel rendering. The existing yellow warning is sufficient; failed Save additionally surfaces the coordinator's `Result.Fail` message through the existing `_lastRecipeResult` path.

--- a/SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs
@@ -10,12 +10,6 @@ public sealed class RecipeAnalyzer(RecipeMetadataRegistry registry)
 
 	public Result<RecipeSnapshot> Analyze(Recipe recipe)
 	{
-
-		if (recipe.Steps.Count == 0)
-		{
-			return Result.Ok(RecipeSnapshot.Empty).WithWarning("Recipe has no steps");
-		}
-
 		var loopParseResult = LoopParser.Parse(recipe);
 		if (loopParseResult.IsFailed)
 		{

--- a/SemiStep/SemiStep.Core/Recipes/RecipeSession.cs
+++ b/SemiStep/SemiStep.Core/Recipes/RecipeSession.cs
@@ -6,6 +6,7 @@ using SemiStep.Core.Plc;
 using SemiStep.Core.Recipes.Analysis;
 using SemiStep.Core.Recipes.Formulas;
 using SemiStep.Core.Recipes.Helpers;
+using SemiStep.Core.Shared;
 
 namespace SemiStep.Core.Recipes;
 
@@ -53,7 +54,8 @@ public sealed class RecipeSession
 
 	public bool IsDirty => _isDirty;
 
-	public bool IsValid => _latestSnapshot.IsSuccess;
+	public bool IsValid =>
+		_latestSnapshot.IsSuccess && !_latestSnapshot.Reasons.OfType<Warning>().Any();
 
 	public Result<RecipeSnapshot> Snapshot => _latestSnapshot;
 

--- a/SemiStep/SemiStep.Tests/Core/Integration/Loops/CoreLoopTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Loops/CoreLoopTests.cs
@@ -48,6 +48,7 @@ public sealed class CoreLoopTests(CoreFixture fixture) : IClassFixture<CoreFixtu
 		driver.AddFor(2).AddWait(5f);
 
 		driver.Warnings.Should().NotBeEmpty();
+		driver.IsValid.Should().BeFalse();
 	}
 
 	[Fact]
@@ -58,6 +59,7 @@ public sealed class CoreLoopTests(CoreFixture fixture) : IClassFixture<CoreFixtu
 		driver.AddWait(5f).AddEndFor();
 
 		driver.Warnings.Should().NotBeEmpty();
+		driver.IsValid.Should().BeFalse();
 	}
 
 	[Fact]
@@ -119,8 +121,7 @@ public sealed class CoreLoopTests(CoreFixture fixture) : IClassFixture<CoreFixtu
 
 		result.IsFailed.Should().BeTrue();
 		result.Errors.Should().ContainSingle(e => e.Message.Contains("nesting depth", StringComparison.OrdinalIgnoreCase));
-		driver.IsValid.Should().BeTrue("the mutation was rejected, recipe is unchanged");
-		driver.StepCount.Should().Be(stepCountBeforeRejection);
+		driver.StepCount.Should().Be(stepCountBeforeRejection, "the mutation was rejected, recipe is unchanged");
 	}
 
 	[Fact]

--- a/SemiStep/SemiStep.Tests/Core/Integration/Snapshot/CoreSnapshotStateTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Snapshot/CoreSnapshotStateTests.cs
@@ -20,7 +20,7 @@ public sealed class CoreSnapshotStateTests(CoreFixture fixture) : IClassFixture<
 		driver.AddWait(5f).AddWait(10f);
 		driver.AddFor(1).AddFor(1).AddFor(1).AddFor(1).AddWait(1f);
 
-		driver.IsValid.Should().BeTrue("unclosed For loops produce warnings, not errors");
+		driver.IsValid.Should().BeFalse("unclosed For loops block validity");
 
 		var stepCountBeforeRejection = fixture.Session.Current.StepCount;
 		var lastValidStepCountBeforeRejection = fixture.Session.LastValidRecipe.StepCount;
@@ -28,7 +28,7 @@ public sealed class CoreSnapshotStateTests(CoreFixture fixture) : IClassFixture<
 		var result = fixture.Session.AppendStep(RecipeTestDriver.EndForLoopActionId);
 
 		result.IsFailed.Should().BeTrue("closing a 4th nested loop exceeds the maximum nesting depth");
-		driver.IsValid.Should().BeTrue("mutation was rejected, state is unchanged");
+		driver.IsValid.Should().BeFalse("mutation was rejected, state still has unclosed For loops");
 		fixture.Session.Current.StepCount.Should().Be(stepCountBeforeRejection, "rejected mutation must not change the recipe");
 		fixture.Session.LastValidRecipe.StepCount.Should().Be(lastValidStepCountBeforeRejection, "last valid recipe must not change when mutation is rejected");
 	}
@@ -40,7 +40,7 @@ public sealed class CoreSnapshotStateTests(CoreFixture fixture) : IClassFixture<
 		var driver = new RecipeTestDriver(fixture.Session);
 
 		driver.AddFor(3).AddWait(1f);
-		driver.IsValid.Should().BeTrue("unclosed For produces a warning, not an error");
+		driver.IsValid.Should().BeFalse("unclosed For blocks validity");
 
 		driver.AddEndFor();
 		driver.IsValid.Should().BeTrue("adding EndFor closes the loop");

--- a/SemiStep/SemiStep.Tests/Core/Integration/Validity/CoreValidityTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Validity/CoreValidityTests.cs
@@ -12,14 +12,13 @@ namespace SemiStep.Tests.Core.Integration.Validity;
 public sealed class CoreValidityTests(CoreFixture fixture) : IClassFixture<CoreFixture>
 {
 	[Fact]
-	public void EmptyRecipe_IsValid_ButHasWarning()
+	public void EmptyRecipe_IsValid_NoWarnings()
 	{
 		fixture.Session.Reset();
 		var driver = new RecipeTestDriver(fixture.Session);
 
 		driver.IsValid.Should().BeTrue();
-		driver.Warnings.Should().NotBeEmpty();
-		driver.Warnings.Should().ContainSingle(w => w.Contains("no steps", StringComparison.OrdinalIgnoreCase));
+		driver.Warnings.Should().BeEmpty();
 	}
 
 	[Fact]
@@ -45,13 +44,13 @@ public sealed class CoreValidityTests(CoreFixture fixture) : IClassFixture<CoreF
 	}
 
 	[Fact]
-	public void UnclosedLoop_ProducesWarning()
+	public void UnclosedLoop_BlocksValidity()
 	{
 		fixture.Session.Reset();
 		var driver = new RecipeTestDriver(fixture.Session);
 		driver.AddFor(3).AddWait(10f);
 
-		driver.IsValid.Should().BeTrue("unclosed loops are warnings, not errors");
+		driver.IsValid.Should().BeFalse("unclosed loops are structural defects that block validity");
 		driver.Warnings.Should().ContainSingle(w => w.Contains("Unclosed For loop", StringComparison.OrdinalIgnoreCase));
 	}
 
@@ -68,8 +67,7 @@ public sealed class CoreValidityTests(CoreFixture fixture) : IClassFixture<CoreF
 
 		result.IsFailed.Should().BeTrue();
 		result.Errors.Should().ContainSingle(e => e.Message.Contains("nesting depth", StringComparison.OrdinalIgnoreCase));
-		driver.IsValid.Should().BeTrue("the mutation was rejected, recipe is unchanged");
-		driver.StepCount.Should().Be(stepCountBeforeRejection);
+		driver.StepCount.Should().Be(stepCountBeforeRejection, "the mutation was rejected, recipe is unchanged");
 	}
 
 	[Fact]
@@ -88,18 +86,20 @@ public sealed class CoreValidityTests(CoreFixture fixture) : IClassFixture<CoreF
 		var result = fixture.Session.AppendStep(RecipeTestDriver.EndForLoopActionId);
 
 		result.IsFailed.Should().BeTrue("exceeding max loop depth produces an error");
-		driver.IsValid.Should().BeTrue("the mutation was rejected, recipe is unchanged");
-		driver.StepCount.Should().Be(stepCountBeforeRejection);
+		driver.StepCount.Should().Be(stepCountBeforeRejection, "the mutation was rejected, recipe is unchanged");
 	}
 
 	[Fact]
-	public void WarningsDoNotAffectValidity()
+	public void Apply_AcceptsDefectiveSnapshot_KeepsIsValidFalse()
 	{
 		fixture.Session.Reset();
 		var driver = new RecipeTestDriver(fixture.Session);
 
+		var applyResult = fixture.Session.AppendStep(RecipeTestDriver.ForLoopActionId);
+
+		applyResult.IsSuccess.Should().BeTrue("a defective snapshot (unclosed For) is still accepted to let the user keep editing");
+		driver.IsValid.Should().BeFalse("an unclosed For loop is a structural defect");
 		driver.Warnings.Should().NotBeEmpty();
-		driver.IsValid.Should().BeTrue("warnings alone should not invalidate the recipe");
 	}
 
 	[Fact]

--- a/SemiStep/SemiStep.Tests/Helpers/StubPlcSyncService.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/StubPlcSyncService.cs
@@ -27,6 +27,9 @@ public sealed class StubPlcSyncService : IPlcSyncService
 	/// <summary>Number of times <see cref="NotifyRecipeChanged"/> was called.</summary>
 	public int NotifyRecipeChangedCallCount { get; private set; }
 
+	/// <summary>Calls recorded by <see cref="NotifyRecipeChanged"/>, in order.</summary>
+	public List<(Recipe Recipe, bool IsValid)> NotifyRecipeChangedCalls { get; } = new();
+
 	/// <summary>Pushes a new PLC state snapshot to subscribers of <see cref="PlcState"/>.</summary>
 	public void PushPlcState(Result<PlcSessionSnapshot> state)
 	{
@@ -36,6 +39,7 @@ public sealed class StubPlcSyncService : IPlcSyncService
 	public void NotifyRecipeChanged(Recipe recipe, bool isValid)
 	{
 		NotifyRecipeChangedCallCount++;
+		NotifyRecipeChangedCalls.Add((recipe, isValid));
 	}
 
 	public void Reset()

--- a/SemiStep/SemiStep.Tests/S7/RecipeSessionSyncIsValidTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/RecipeSessionSyncIsValidTests.cs
@@ -1,0 +1,32 @@
+﻿using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using SemiStep.Core.Plc;
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.S7;
+
+[Trait("Component", "S7")]
+[Trait("Area", "RecipeSessionSync")]
+[Trait("Category", "Integration")]
+public sealed class RecipeSessionSyncIsValidTests
+{
+	[Fact]
+	public async Task Apply_OnDefectiveRecipe_NotifiesSyncWithIsValidFalse()
+	{
+		var (services, session, _) = await CoreTestHelper.BuildAsync();
+		var syncService = (StubPlcSyncService)services.GetRequiredService<IPlcSyncService>();
+		syncService.SetSyncEnabled(true);
+
+		var driver = new RecipeTestDriver(session);
+		driver.AddFor(3).AddWait(1f);
+
+		syncService.NotifyRecipeChangedCalls.Should().NotBeEmpty();
+		syncService.NotifyRecipeChangedCalls[^1].IsValid.Should()
+			.BeFalse("the final state has an unclosed For loop so the PLC must observe isValid=false");
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorLoadRecipeTests.cs
@@ -98,7 +98,7 @@ public sealed class RecipeCoordinatorLoadRecipeTests
 	}
 
 	[AvaloniaFact]
-	public async Task LoadRecipeAsync_Success_WithWarnings_ShowsWarningsInPanel()
+	public async Task LoadRecipeAsync_EmptyRecipe_PanelHasNoWarnings()
 	{
 		var (coordinator, panel) = await BuildCoordinatorAsync(services => services.AddCsv());
 		var tempFilePath = Path.Combine(Path.GetTempPath(), $"{TempFilePrefix}.{Guid.NewGuid():N}.csv");
@@ -108,12 +108,11 @@ public sealed class RecipeCoordinatorLoadRecipeTests
 			// Save the default empty recipe so we have a valid CSV file with no steps.
 			await coordinator.SaveRecipeAsync(tempFilePath);
 
-			// Load it back — an empty recipe triggers a "Recipe has no steps" warning from the analyzer.
 			var result = await coordinator.LoadRecipeAsync(tempFilePath);
 
-			result.IsSuccess.Should().BeTrue("loading a valid CSV should succeed even when it has warnings");
-			panel.Entries.Should().Contain(e => e.IsWarning,
-				"the message panel must show the 'Recipe has no steps' warning after loading an empty recipe");
+			result.IsSuccess.Should().BeTrue("loading a valid empty CSV must succeed");
+			panel.Entries.Should().NotContain(e => e.IsWarning,
+				"an empty recipe is a normal initial state and must not produce warnings");
 		}
 		finally
 		{

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorSaveGateTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorSaveGateTests.cs
@@ -1,0 +1,108 @@
+﻿using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using SemiStep.Core.Configuration;
+using SemiStep.Core.Configuration.Facade;
+using SemiStep.Core.Plc;
+using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Clipboard;
+using SemiStep.Core.Recipes.Helpers;
+using SemiStep.Core.Recipes.Import;
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.Coordinator;
+using SemiStep.UI.MessageService;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Coordinator")]
+[Trait("Category", "Integration")]
+public sealed class RecipeCoordinatorSaveGateTests
+{
+	private const string TempFilePrefix = "SemiStep.CoordinatorSaveGate";
+
+	[AvaloniaFact]
+	public async Task Save_OnDefectiveRecipe_FailsAndWritesNoFile()
+	{
+		var (coordinator, panel, session) = await BuildCoordinatorAsync();
+		var tempFilePath = Path.Combine(Path.GetTempPath(), $"{TempFilePrefix}.{Guid.NewGuid():N}.csv");
+
+		try
+		{
+			var driver = new RecipeTestDriver(session);
+			driver.AddFor(3).AddWait(1f);
+
+			session.IsValid.Should().BeFalse("the recipe has an unclosed For loop");
+
+			var result = await coordinator.SaveRecipeAsync(tempFilePath);
+
+			result.IsFailed.Should().BeTrue("Save must reject a recipe with structural defects");
+			File.Exists(tempFilePath).Should().BeFalse("the file must not be written when Save is rejected");
+			panel.Entries.Should().Contain(
+				e => e.IsWarning && e.Message.Contains("Unclosed For loop", StringComparison.OrdinalIgnoreCase),
+				"the underlying analyzer warning must still surface in the message panel after the rejected Save");
+		}
+		finally
+		{
+			coordinator.Dispose();
+			panel.Dispose();
+			if (File.Exists(tempFilePath))
+			{
+				File.Delete(tempFilePath);
+			}
+		}
+	}
+
+	private static async Task<(RecipeCoordinator Coordinator, MessagePanelViewModel Panel, RecipeSession Session)>
+		BuildCoordinatorAsync()
+	{
+		var configDir = TestConfigLocator.GetConfigDirectory("WithGroups");
+		var configLoadResult = await ConfigFacade.LoadAndValidateAsync(configDir);
+		var configuration = configLoadResult.EnsureSuccess("Test config load");
+
+		var services = new ServiceCollection()
+			.AddLogging()
+			.AddSingleton(configuration)
+			.AddRecipe()
+			.AddClipboard()
+			.AddCsv()
+			.AddSingleton<StubS7Service>()
+			.AddSingleton<IS7Connection>(sp => sp.GetRequiredService<StubS7Service>())
+			.AddSingleton<IS7Reader>(sp => sp.GetRequiredService<StubS7Service>())
+			.AddSingleton<IS7ExecutionStream>(sp => sp.GetRequiredService<StubS7Service>())
+			.AddSingleton<IPlcSyncService, StubPlcSyncService>()
+			.BuildServiceProvider();
+
+		var session = services.GetRequiredService<RecipeSession>();
+		var plc = services.GetRequiredService<PlcLifecycleManager>();
+		plc.Initialize();
+		session.Reset().EnsureSuccess("Session reset");
+
+		var recipeMetadataRegistry = services.GetRequiredService<RecipeMetadataRegistry>();
+		var panel = new MessagePanelViewModel();
+		var importedRecipeValidator = services.GetRequiredService<ImportedRecipeValidator>();
+		var appConfiguration = services.GetRequiredService<AppConfiguration>();
+		var csvService = services.GetRequiredService<CsvService>();
+		var coordinator = new RecipeCoordinator(
+			session,
+			plc,
+			csvService,
+			importedRecipeValidator,
+			appConfiguration,
+			recipeMetadataRegistry,
+			panel,
+			NullLogger<RecipeCoordinator>.Instance);
+		coordinator.Initialize();
+
+		return (coordinator, panel, session);
+	}
+}

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -366,6 +366,17 @@ public sealed class RecipeCoordinator : IDisposable
 			filePath,
 			_session.Current.StepCount);
 
+		if (_session.IsValid == false)
+		{
+			const string SaveRejectionMessage = "Cannot save recipe with structural defects (see warnings in the message panel).";
+			_logger.LogWarning(
+				"Save rejected: recipe is not valid. StepCount={StepCount}",
+				_session.Current.StepCount);
+			_lastRecipeResult = Result.Fail(SaveRejectionMessage).WithReasons(_session.Snapshot.Reasons);
+			RebuildMessagePanel();
+			return _lastRecipeResult;
+		}
+
 		var result = await _csvService.SaveAsync(_session.Current, filePath);
 
 		if (result.IsFailed)


### PR DESCRIPTION
Salvaged from PR #26 rebase. `301bc0e` — `RecipeSession.IsValid` now also considers warning-level diagnostics; `RecipeCoordinator` gains a save-gate that rejects saves / PLC pushes when the snapshot has warnings. New tests: `RecipeSessionSyncIsValidTests`, `RecipeCoordinatorSaveGateTests`. Existing core integration / loop / snapshot / validity tests updated. Plan: `Docs/plans/completed/20260520-warning-blocks-save.md`.