### PR TITLE
ci: drop formatter from CI, drop tests from release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,3 @@ jobs:
 
       - name: test
         run: dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
-
-      - name: verify formatting
-        run: dotnet format SemiStep/SemiStep.slnx --verify-no-changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
-    name: Build, Test & Release
+  build-and-release:
+    name: Build & Release
     runs-on: windows-latest
     permissions:
       contents: write
@@ -58,9 +58,6 @@ jobs:
 
       - name: build
         run: dotnet build SemiStep/SemiStep.slnx -c Release --no-restore
-
-      - name: test
-        run: dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
 
       - name: publish
         run: dotnet publish SemiStep/SemiStep.UI/SemiStep.UI.csproj -c Release -p:Version=${{ steps.version.outputs.version }}


### PR DESCRIPTION
Aligns with NtoLib's workflow split: tests run once in CI, release skips them.

**`ci.yml`** — removed `verify formatting`. The local `.git/hooks/pre-commit` already runs `dotnet format --verify-no-changes` and auto-fixes, so the CI-side check is redundant. `build` + `test` stay.

**`release.yml`** — removed the `test` step. The tagged commit has already passed CI on its way to master, so re-running tests in release duplicates the same work. `build` + `publish` + installer + GitHub Release stay. Job renamed from `build-and-test` to `build-and-release` to reflect actual scope.