### PR TITLE
chore: drop unused usings, test constants, and discard

### DIFF
--- a/SemiStep/SemiStep.Core/Configuration/AppConfiguration.cs
+++ b/SemiStep/SemiStep.Core/Configuration/AppConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using SemiStep.Core.Plc.Configuration;
-using SemiStep.Core.Plc.State;
 using SemiStep.Core.Recipes;
 
 namespace SemiStep.Core.Configuration;

--- a/SemiStep/SemiStep.Core/Configuration/Loaders/ConnectionLoader.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Loaders/ConnectionLoader.cs
@@ -1,7 +1,6 @@
 ﻿using FluentResults;
 
 using SemiStep.Core.Configuration.Dto;
-using SemiStep.Core.Shared;
 
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;

--- a/SemiStep/SemiStep.Core/Configuration/Mapping/ConnectionMapper.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Mapping/ConnectionMapper.cs
@@ -1,7 +1,6 @@
 ﻿using SemiStep.Core.Configuration.Dto;
 using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.Configuration.Memory;
-using SemiStep.Core.Plc.State;
 
 namespace SemiStep.Core.Configuration.Mapping;
 

--- a/SemiStep/SemiStep.Core/Configuration/Mapping/GridStyleMapper.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Mapping/GridStyleMapper.cs
@@ -1,5 +1,4 @@
-﻿using SemiStep.Core.Configuration;
-using SemiStep.Core.Configuration.Dto;
+﻿using SemiStep.Core.Configuration.Dto;
 
 namespace SemiStep.Core.Configuration.Mapping;
 

--- a/SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs
+++ b/SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs
@@ -1,6 +1,5 @@
 ﻿using FluentResults;
 
-using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Recipes;
 

--- a/SemiStep/SemiStep.Core/Plc/S7/IS7Driver.cs
+++ b/SemiStep/SemiStep.Core/Plc/S7/IS7Driver.cs
@@ -1,5 +1,4 @@
 ﻿using SemiStep.Core.Plc.Configuration;
-using SemiStep.Core.Plc.State;
 
 namespace SemiStep.Core.Plc.S7;
 

--- a/SemiStep/SemiStep.Core/Plc/S7/S7Driver.cs
+++ b/SemiStep/SemiStep.Core/Plc/S7/S7Driver.cs
@@ -1,5 +1,4 @@
 ﻿using SemiStep.Core.Plc.Configuration;
-using SemiStep.Core.Plc.State;
 
 using S7NetCpuType = global::S7.Net.CpuType;
 using S7NetDataType = global::S7.Net.DataType;

--- a/SemiStep/SemiStep.Core/Plc/S7/Serialization/RecipeConverter.cs
+++ b/SemiStep/SemiStep.Core/Plc/S7/Serialization/RecipeConverter.cs
@@ -2,8 +2,6 @@
 
 using FluentResults;
 
-using SemiStep.Core.Configuration;
-using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Recipes;
 

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcExecutionMonitor.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcExecutionMonitor.cs
@@ -1,7 +1,4 @@
-﻿using System.Linq;
-using System.Reactive.Subjects;
-
-using FluentResults;
+﻿using System.Reactive.Subjects;
 
 using Microsoft.Extensions.Logging;
 

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcRecipeDataComparer.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcRecipeDataComparer.cs
@@ -1,5 +1,4 @@
-﻿using SemiStep.Core.Plc.Configuration;
-using SemiStep.Core.Plc.State;
+﻿using SemiStep.Core.Plc.State;
 
 namespace SemiStep.Core.Plc.Sync;
 

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
@@ -4,8 +4,6 @@ using FluentResults;
 
 using Microsoft.Extensions.Logging;
 
-using SemiStep.Core.Plc.Configuration;
-using SemiStep.Core.Plc.S7.Protocol;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Recipes;
 

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncExecutor.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncExecutor.cs
@@ -1,10 +1,7 @@
-﻿using System.Linq;
-
-using FluentResults;
+﻿using FluentResults;
 
 using Microsoft.Extensions.Logging;
 
-using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.S7.Protocol;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Recipes;

--- a/SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs
@@ -1,7 +1,5 @@
 ﻿using FluentResults;
 
-using SemiStep.Core.Shared;
-
 namespace SemiStep.Core.Recipes.Analysis;
 
 public sealed class RecipeAnalyzer(RecipeMetadataRegistry registry)

--- a/SemiStep/SemiStep.Core/Recipes/Clipboard/ClipboardSerializer.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Clipboard/ClipboardSerializer.cs
@@ -6,8 +6,6 @@ using CsvHelper.Configuration;
 
 using FluentResults;
 
-using SemiStep.Core.Configuration;
-
 namespace SemiStep.Core.Recipes.Clipboard;
 
 public sealed class ClipboardSerializer(RecipeMetadataRegistry recipeMetadataRegistry)

--- a/SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs
@@ -1,7 +1,5 @@
 ﻿using FluentResults;
 
-using SemiStep.Core.Configuration;
-
 namespace SemiStep.Core.Recipes.Helpers;
 
 public sealed class ImportedRecipeValidator(

--- a/SemiStep/SemiStep.Core/Recipes/Import/CsvFileSerializer.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Import/CsvFileSerializer.cs
@@ -6,8 +6,6 @@ using CsvHelper.Configuration;
 
 using FluentResults;
 
-using SemiStep.Core.Configuration;
-
 namespace SemiStep.Core.Recipes.Import;
 
 public sealed class CsvFileSerializer(

--- a/SemiStep/SemiStep.Core/Recipes/Import/CsvStepWriter.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Import/CsvStepWriter.cs
@@ -1,7 +1,5 @@
 ﻿using CsvHelper;
 
-using SemiStep.Core.Configuration;
-
 namespace SemiStep.Core.Recipes.Import;
 
 internal static class CsvStepWriter

--- a/SemiStep/SemiStep.Tests/Core/Integration/Mutation/CoreMutationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Mutation/CoreMutationTests.cs
@@ -14,8 +14,6 @@ namespace SemiStep.Tests.Core.Integration.Mutation;
 [Trait("Area", "Mutation")]
 public sealed class CoreMutationTests(CoreFixture fixture) : IClassFixture<CoreFixture>
 {
-	private const float DefaultWaitDurationSeconds = 10f;
-
 	[Fact]
 	public void AppendStep_CreatesStepWithDefaults()
 	{

--- a/SemiStep/SemiStep.Tests/Core/RecipeSessionBehaviourCharacterizationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/RecipeSessionBehaviourCharacterizationTests.cs
@@ -27,7 +27,6 @@ public sealed class RecipeSessionBehaviourCharacterizationTests
 	private const int UnknownActionId = 9999;
 	private const string DurationColumn = RecipeTestDriver.StepDurationColumn;
 	private const string CommentColumn = RecipeTestDriver.CommentColumn;
-	private const string TaskColumn = RecipeTestDriver.TaskColumn;
 
 	#region Session.Apply
 

--- a/SemiStep/SemiStep.Tests/Core/Unit/Properties/RecipeMetadataRegistryStringMaxLengthTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Properties/RecipeMetadataRegistryStringMaxLengthTests.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 
-using SemiStep.Core.Recipes;
 using SemiStep.Tests.Helpers;
 
 using Xunit;

--- a/SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs
@@ -2,7 +2,6 @@
 
 using FluentAssertions;
 
-using SemiStep.Core.Configuration;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Tests.Helpers;

--- a/SemiStep/SemiStep.Tests/Helpers/StubS7Service.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/StubS7Service.cs
@@ -1,5 +1,4 @@
-﻿using System.Reactive.Linq;
-using System.Reactive.Subjects;
+﻿using System.Reactive.Subjects;
 
 using FluentResults;
 

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -216,7 +216,7 @@ public sealed class PlcSyncCoordinatorTests
 	[Fact]
 	public void Dispose_PreventsSubsequentNotifications()
 	{
-		var (coordinator, transport, _) = Build(connected: false);
+		var (coordinator, _, _) = Build(connected: false);
 		coordinator.Dispose();
 
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: false);

--- a/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
@@ -14,7 +14,6 @@ using SemiStep.Tests.Helpers;
 
 using SemiStep.UI.Coordinator;
 using SemiStep.UI.MessageService;
-using SemiStep.UI.RecipeGrid;
 
 using Xunit;
 

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorSaveGateTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorSaveGateTests.cs
@@ -14,7 +14,6 @@ using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Core.Recipes.Import;
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.Helpers;
-using SemiStep.Tests.UI.Helpers;
 
 using SemiStep.UI.Coordinator;
 using SemiStep.UI.MessageService;

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorTests.cs
@@ -2,7 +2,6 @@
 
 using FluentAssertions;
 
-using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RowExecutionClassesStampingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RowExecutionClassesStampingTests.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
-using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Avalonia.VisualTree;

--- a/SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGridViewModelTests.cs
@@ -6,7 +6,6 @@ using FluentAssertions;
 
 using Microsoft.Extensions.Logging;
 
-using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -11,7 +11,6 @@ using ReactiveUI;
 
 using SemiStep.Core.Configuration;
 using SemiStep.Core.Plc;
-using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Helpers;

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
@@ -2,7 +2,6 @@
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Platform.Storage;

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 
 using ReactiveUI;
 
-using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Recipes;
 

--- a/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
@@ -6,7 +6,6 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
 
-using SemiStep.Core.Configuration;
 using SemiStep.Core.Recipes;
 
 namespace SemiStep.UI.RecipeGrid;

--- a/SemiStep/SemiStep.UI/RecipeGrid/InapplicableCellTheme.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/InapplicableCellTheme.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Data;
 using Avalonia.Styling;
 
 namespace SemiStep.UI.RecipeGrid;

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
@@ -11,8 +11,6 @@ using Microsoft.Extensions.Logging;
 
 using ReactiveUI;
 
-using SemiStep.Core.Configuration;
-using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Helpers;
 

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
@@ -2,7 +2,6 @@
 
 using ReactiveUI;
 
-using SemiStep.Core.Configuration;
 using SemiStep.Core.Recipes;
 
 namespace SemiStep.UI.RecipeGrid;


### PR DESCRIPTION
## Summary
Pure cleanup PR identified by an earlier code-cleanliness audit. No behavioural change.

- Removed ~30 unused `using` directives across `SemiStep.Core`, `SemiStep.UI`, and `SemiStep.Tests`. Surfaced via Roslyn IDE0005, applied via `dotnet format style --diagnostics IDE0005`.
- Dropped two unused private constants:
  - `CoreMutationTests.DefaultWaitDurationSeconds`
  - `RecipeSessionBehaviourCharacterizationTests.TaskColumn`
- Replaced unused `transport` local with discard in `PlcSyncCoordinatorTests.Dispose_PreventsSubsequentNotifications` (line 219).

## Test plan
- [x] `dotnet build SemiStep/SemiStep.slnx` — 0 errors, 0 warnings
- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 656/656 pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>