### PR TITLE
fix(installer): rename exe to Semistep, fix paths, add RIE preset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,8 @@ jobs:
       - name: restore
         run: dotnet restore SemiStep/SemiStep.slnx
 
-      - name: build
-        run: dotnet build SemiStep/SemiStep.slnx -c Release --no-restore
-
       - name: publish
-        run: dotnet publish SemiStep/SemiStep.UI/SemiStep.UI.csproj -c Release -p:Version=${{ steps.version.outputs.version }}
+        run: dotnet publish SemiStep/SemiStep.UI/SemiStep.UI.csproj -c Release --no-restore -p:Version=${{ steps.version.outputs.version }}
 
       - name: install Inno Setup
         shell: powershell

--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,9 @@ AutoTest.Net/
 # Installshield output folder
 [Ee]xpress/
 
+# Inno Setup compiled installer output
+Installer/Output/
+
 # DocProject is a documentation generator add-in
 DocProject/buildhelp/
 DocProject/Help/*.HxT

--- a/Installer/SemiStep.iss
+++ b/Installer/SemiStep.iss
@@ -8,14 +8,14 @@
 
 #define AppName      "SemiStep"
 #define AppPublisher "Inc Semiteq"
-#define AppExeName   "UI.exe"
+#define AppExeName   "Semistep.exe"
 #define AppId        "{{8B3F2C1A-4D7E-4F9B-A2C6-1E5D8F3B7A4C}"
 
 ; Paths relative to the location of this .iss file (Installer/)
 #define SrcBinDir    "..\SemiStep\Artifacts\publish\SemiStep.UI\release_win-x64"
 
 #define SrcCfgDir    "..\ConfigFiles"
-#define AppIconFile       "..\SemiStep\UI\logo.ico"
+#define AppIconFile       "..\SemiStep\SemiStep.UI\logo.ico"
 #define LicenseFile       ".\LICENSE.txt"
 #define WizardImageLarge  ".\WizardImageFile.bmp"
 #define WizardImageSmall  ".\WizardSmallImageFile.bmp"
@@ -65,6 +65,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Tasks]
 Name: "preset_mbe";   Description: "MBE";   GroupDescription: "Configuration preset:"; Flags: exclusive
 Name: "preset_mocvd"; Description: "MOCVD"; GroupDescription: "Configuration preset:"; Flags: exclusive
+Name: "preset_rie";   Description: "RIE";   GroupDescription: "Configuration preset:"; Flags: exclusive
 Name: "desktopicon";  Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [InstallDelete]
@@ -86,6 +87,7 @@ Source: "{#SrcBinDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs 
 ; controls only which preset the created shortcuts target.
 Source: "..\ConfigFiles\MBE\*";   DestDir: "C:\DISTR\Config\Semistep\MBE";   Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\ConfigFiles\MOCVD\*"; DestDir: "C:\DISTR\Config\Semistep\MOCVD"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\ConfigFiles\RIE\*";   DestDir: "C:\DISTR\Config\Semistep\RIE";   Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Dirs]
 ; Ensure the logs directory exists before the app first runs
@@ -95,10 +97,13 @@ Name: "C:\DISTR\Logs"
 [Icons]
 Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"; IconFilename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\MBE"""; Tasks: preset_mbe
 Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"; IconFilename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\MOCVD"""; Tasks: preset_mocvd
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"; IconFilename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\RIE"""; Tasks: preset_rie
 Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; IconFilename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\MBE"""; Tasks: desktopicon and preset_mbe
 Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; IconFilename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\MOCVD"""; Tasks: desktopicon and preset_mocvd
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; IconFilename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\RIE"""; Tasks: desktopicon and preset_rie
 
 [Run]
 Filename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\MBE"""; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent; Tasks: preset_mbe
 Filename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\MOCVD"""; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent; Tasks: preset_mocvd
+Filename: "{app}\{#AppExeName}"; Parameters: "--config-dir ""C:\DISTR\Config\Semistep\RIE"""; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent; Tasks: preset_rie

--- a/SemiStep/SemiStep.UI/App.axaml
+++ b/SemiStep/SemiStep.UI/App.axaml
@@ -5,13 +5,13 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceInclude Source="avares://SemiStep.UI/Styles/ColorPalette.axaml" />
+                <ResourceInclude Source="avares://Semistep/Styles/ColorPalette.axaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>
     <Application.Styles>
         <FluentTheme />
         <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
-        <StyleInclude Source="avares://SemiStep.UI/Styles/DataGridStyles.axaml" />
+        <StyleInclude Source="avares://Semistep/Styles/DataGridStyles.axaml" />
     </Application.Styles>
 </Application>

--- a/SemiStep/SemiStep.UI/SemiStep.UI.csproj
+++ b/SemiStep/SemiStep.UI/SemiStep.UI.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <AssemblyName>Semistep</AssemblyName>
     <ApplicationIcon>logo.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
+++ b/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
@@ -1,6 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:rg="clr-namespace:SemiStep.UI.RecipeGrid;assembly=SemiStep.UI">
+        xmlns:rg="clr-namespace:SemiStep.UI.RecipeGrid;assembly=Semistep">
 
     <!-- Base DataGrid styles -->
     <Style Selector="DataGrid">


### PR DESCRIPTION
## Summary

The release workflow has not run since the project reorg that renamed the UI project to \`SemiStep.UI\`, leaving the installer broken on several fronts. Discovered while attempting to build the installer locally.

- **\`SemiStep.UI.csproj\`**: \`<AssemblyName>Semistep</AssemblyName>\` so publish produces \`Semistep.exe\`.
- **\`App.axaml\`** and **\`Styles/DataGridStyles.axaml\`**: updated \`avares://SemiStep.UI/…\` and \`clr-namespace ;assembly=SemiStep.UI\` references to \`Semistep\` (required because the resource URIs are keyed by assembly name, not project name).
- **\`Installer/SemiStep.iss\`**:
  - \`AppExeName\` \`UI.exe\` → \`Semistep.exe\`
  - \`AppIconFile\` path corrected after the reorg (\`..\SemiStep\UI\logo.ico\` → \`..\SemiStep\SemiStep.UI\logo.ico\`)
  - Added the \`RIE\` configuration preset, symmetric to MBE/MOCVD, in \`[Tasks]\`, \`[Files]\`, \`[Icons]\`, \`[Run]\`. (RIE was added to \`ConfigFiles/\` in 89c9fa9 but never bundled.)
- **\`.github/workflows/release.yml\`**: dropped the redundant explicit \`dotnet build\` step (publish builds anyway); added \`--no-restore\` to publish.
- **\`.gitignore\`**: ignore \`Installer/Output/\`; untracked the stale \`SemiStep-Setup.exe\` artifact from the v0.1.0 release.

## Test plan

- [x] \`dotnet test\` — 656/656 pass (verified \`InternalsVisibleTo\` to \`SemiStep.Tests\` survives the assembly-name change).
- [x] \`dotnet publish\` — produces \`Semistep.exe\` at \`SemiStep/Artifacts/publish/SemiStep.UI/release_win-x64/\`.
- [x] \`iscc /DAppVersion=0.1.1 Installer/SemiStep.iss\` — produces \`Installer/Output/SemiStep-Setup.exe\` (~58 MB), all three presets bundled.
- [ ] End-to-end install/run check on a clean machine — to be done before the next tag.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>