### PR TITLE
fix(ci): drop separate restore step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,8 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: restore
-        run: dotnet restore SemiStep/SemiStep.slnx
-
       - name: publish
-        run: dotnet publish SemiStep/SemiStep.UI/SemiStep.UI.csproj -c Release --no-restore -p:Version=${{ steps.version.outputs.version }}
+        run: dotnet publish SemiStep/SemiStep.UI/SemiStep.UI.csproj -c Release -p:Version=${{ steps.version.outputs.version }}
 
       - name: install Inno Setup
         shell: powershell


### PR DESCRIPTION
In PR #36 I dropped the explicit \`dotnet build\` step and added \`--no-restore\` to publish. The v0.2.0 tag push surfaced the bug: \`dotnet restore SemiStep/SemiStep.slnx\` restores \`TargetFramework=net10.0\` only — but \`publish\` needs \`net10.0/win-x64\`. The RID is conditioned on \`_IsPublishing=true\` in \`Directory.Build.props\`, which only flips during the publish target itself, so a precomputed restore never sees it.

Fix: drop the standalone restore step. \`dotnet publish\` does its own restore with the correct RID.

CI error from the failed v0.2.0 run:
\`\`\`
Assets file 'project.assets.json' doesn't have a target for 'net10.0/win-x64'.
\`\`\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>