### PR TITLE
fix(ui): reconcile row selection after mutations to prevent stale paste index

### DIFF
--- a/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
+++ b/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
@@ -145,9 +145,10 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
+		var rowCount = _recipeGrid.RecipeRows.Count;
 		var insertIndex = _recipeGrid.SelectedRowIndices.Count > 0
-			? _recipeGrid.SelectedRowIndices.Max() + 1
-			: _recipeGrid.RecipeRows.Count;
+			? Math.Min(_recipeGrid.SelectedRowIndices.Max() + 1, rowCount)
+			: rowCount;
 
 		var insertResult = _coordinator.InsertSteps(insertIndex, recipeResult.Value.Steps);
 		if (insertResult.IsFailed)

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
@@ -151,8 +152,26 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 				return;
 		}
 
+		ReconcileSelectionWithRows();
 		RefreshStepStartTimes();
 		RefreshRowLoopDepths();
+	}
+
+	private void ReconcileSelectionWithRows()
+	{
+		var currentSelection = SelectedRowIndices;
+		if (currentSelection.Count == 0)
+		{
+			return;
+		}
+
+		var rowCount = RecipeRows.Count;
+		if (currentSelection.All(index => index < rowCount))
+		{
+			return;
+		}
+
+		SelectedRowIndices = currentSelection.Where(index => index < rowCount).ToList();
 	}
 
 	public void RequestSelection(int? suggestedIndex)


### PR DESCRIPTION
## Problem

Intermittent error during heavy copy/paste/undo/redo: `Insert index N is out of range for recipe with 0 steps`. The log showed a `Mutation entry: InsertSteps StartIndex=7` against a 0-step recipe with no following dispatch — a failed mutation surfacing as an error in the message panel.

## Root cause

`SelectedRowIndices` (RecipeGridViewModel) is a cache written **only** from the DataGrid `SelectionChanged` event. `FullRebuild` — triggered by `RecipeReplaced` (undo/redo/load) — clears and recreates row objects without going through `SelectionChanged`, so the cache keeps stale indices while nothing is visually selected. Delete/cut/paste then operate on phantom indices; paste computes `Max()+1` against a shrunk or empty grid → out-of-range insert index → `ValidateInsertIndex` fails.

Delete/Cut alone don't reproduce it because they remove rows via `RemoveAt`, which does raise `SelectionChanged` and heals the cache — hence the floating nature.

## Fix

- `RecipeGridViewModel`: `ReconcileSelectionWithRows()` after every mutation signal drops cached indices `>= RecipeRows.Count`. Fixes paste, cut, copy and commands centrally.
- `ClipboardViewModel.PasteStepsAsync`: clamp insert index to `RecipeRows.Count` as defense in depth.

## Testing

Build clean; 99 clipboard/grid/mutation tests pass. Manually verified the repro path (select last row → undo to fewer steps → Ctrl+V) no longer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)