### PR TITLE
docs: trim CLAUDE.md to an entry document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,6 @@ SemiStep is a recipe table editor/runtime for PLC integration (S7 protocol).
 Platform: .NET 10, Windows, C# 14. UI: Avalonia 12.0.3 + ReactiveUI (MVVM).
 Solution: `SemiStep/SemiStep.slnx`. All commands run from repository root.
 
-Inline-formula recalculation (per-action `formula:` blocks) is evaluated via the
-`NCalcSync` package (`SemiStep.Core/Recipes/Formulas`). See `Docs/03-data-model.md` §3.4.
-
 ## Build
 
 ```powershell
@@ -53,14 +50,14 @@ directory and overlay only the differing files from `SemiStep.Tests/YamlConfigs/
 
 ### Naming
 
-| Element                           | Convention                     | Example                            |
-| --------------------------------- | ------------------------------ | ---------------------------------- |
-| Public types, methods, properties | PascalCase                     | `RecipeEditor`, `LoadAsync()`      |
-| Interfaces                        | I-prefix                       | `IRecipeRepository`                |
-| Private fields                    | `_camelCase`                   | `_recipeService`                   |
+| Element                           | Convention                     | Example                                 |
+| --------------------------------- | ------------------------------ | --------------------------------------- |
+| Public types, methods, properties | PascalCase                     | `RecipeEditor`, `LoadAsync()`           |
+| Interfaces                        | I-prefix                       | `IRecipeRepository`                     |
+| Private fields                    | `_camelCase`                   | `_recipeService`                        |
 | Class instance fields             | `_className` (no abbreviation) | `_recipeEditor`, `_plcLifecycleManager` |
-| Constants                         | PascalCase                     | `MaxStepCount`                     |
-| Local variables                   | camelCase                      | `stepIndex`                        |
+| Constants                         | PascalCase                     | `MaxStepCount`                          |
+| Local variables                   | camelCase                      | `stepIndex`                             |
 
 No abbreviations in names.
 
@@ -97,18 +94,6 @@ No abbreviations in names.
 
 - Only for genuinely non-obvious business logic. No process notes (`// TODO`, `// in new version`). No transitional comments.
 - English only.
-
-## Conventions
-
-**Inline formulas on actions:** when an action declares a `formula:` block (see `Docs/03-data-model.md` §3.4), cell edits route through `RecipeSession.UpdateStepProperty` → `FormulaEvaluator.Recalculate` and update one coupled cell in the same mutation (single undo unit). CSV import (§3.5) is verbatim — formulas are not re-evaluated on load.
-
-**Cell palettes in `ui/grid_style.yaml`:** the file must contain three sibling palette sections under `colors.cells` — `readonly`, `disabled`, and `execution` — each driving a distinct cell-painting concern. `GridStyleValidator` rejects the config if any section or key is missing or is not a valid hex color, and `GridStyleLoader` fails loudly when the file or directory is absent.
-
-- **`colors.cells.readonly`** (ten hex keys): paints cells in columns marked `ReadOnly=true` (column-level structural read-only — e.g. the step-number column). Eight per-depth × past background keys (`depth_0..3`, `depth_0..3_past`) plus two shared keys (`selected`, `foreground`).
-- **`colors.cells.disabled`** (ten hex keys, same layout): paints cells where `InapplicableCellTheme.IsInapplicable=True` (row-action × column intersection — i.e. this property does not apply to this action). The two signals (read-only column class and inapplicable attached property) are disjoint by design (`CellStateResolver` returns `false` for read-only columns), so the two palettes never compete for the same cell.
-- **`colors.cells.execution`** (nine hex keys): row-tinting palette for loop-depth × past-state plus the `current_step_marker` brush for the current-step indicator on the step-number column. This block was relocated from the top-level `colors.execution` to `colors.cells.execution` so all cell-painting palettes nest under `cells:`.
-
-At startup, `CellPaletteInstaller` publishes all three palettes (plus `colors.grid_line`) as Avalonia resources consumed by `DataGridStyles.axaml`. See `SemiStep/SemiStep.UI/Styles/CellPaletteInstaller.cs` for the authoritative list of brush-resource keys — do not enumerate them here, the list evolves as the palette is extracted further.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Keeps CLAUDE.md as a high-level entry document and moves feature-specific detail out:

- Removes the inline-formula intro note and the "## Conventions" section (cell-palette keys) — these specifics live in their `Docs/` chapters.
- Reformats the Naming table padding.

What remains is general orientation: project intro, Build, Test, Code Style, Troubleshooting.

## Test plan

- [ ] Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)