### PR TITLE
feat: drive recipe edit-lock from execution state

### DIFF
--- a/Docs/plans/completed/20260529-execution-driven-edit-lock.md
+++ b/Docs/plans/completed/20260529-execution-driven-edit-lock.md
@@ -1,0 +1,217 @@
+# Execution-Driven Edit Lock
+
+## Overview
+
+Switch the recipe edit-lock from being driven by **sync mode** (`IsSyncEnabled`) to being
+driven by **execution state** (`recipe_active`). This makes the three operating states behave
+as intended:
+
+- **Not connected (sync off):** full editing, no PLC interaction. Editing is available because
+  no connection implies no execution (`recipe_active=false`).
+- **Connected, recipe not executing (`recipe_active=false`):** full editing; every change
+  auto-syncs to the PLC through the existing 1 s debounce.
+- **Connected, recipe executing (`recipe_active=true`):** editing is fully locked; PLC writes are
+  already blocked by `PlcSyncExecutor.CheckCanSyncAsync`.
+
+This reverts the core decision of the completed plan
+`Docs/plans/completed/20260520-per-window-edit-connect-mode.md`, which tied the edit-lock to the
+window's Connect/Edit mode. That decision neutralized the already-implemented online-sync feature:
+`RecipeSession.NotifySyncIfEnabled` only pushes edits when sync is enabled, yet the UI forbade
+edits while sync was enabled, so user-edit-driven sync could never fire in Connect mode.
+
+The problem it solves: enables online editing of a connected (but idle) recipe with auto-push to
+the PLC, while still protecting a running recipe from edits.
+
+## Context (from discovery)
+
+Files/components involved:
+- `SemiStep.UI/Coordinator/RecipeCoordinator.cs` — the **single** production change point. Builds
+  the `CanEditRecipe` observable (lines 81-87) from `_plcStateChangedShared` (`IsSyncEnabled`).
+- `SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs:62-64` — `IsReadOnly = !CanEditRecipe`.
+- `SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs:36`, `Clipboard/ClipboardViewModel.cs:48`,
+  `RecipeFile/RecipeFileViewModel.cs:30` — all gate mutating commands on the same
+  `coordinator.CanEditRecipe`. No changes required in these consumers.
+- `SemiStep.Core/Plc/State/PlcExecutionInfo.cs` — carries `RecipeActive`; `Empty` has it `false`.
+- `SemiStep.Core/Plc/Sync/PlcExecutionMonitor.cs` — on every disconnect path publishes
+  `PlcExecutionInfo.Empty` (`RecipeActive=false`) on the execution stream.
+
+Wiring verification (the user's explicit concern — "no connection must set executing=false"):
+- `S7Service.ExecutionState => executionMonitor.State`, `IsRecipeActive => executionMonitor.LastKnown.RecipeActive`.
+- `DisconnectAsync()` -> `executionMonitor.StopAsync()` -> `PublishAndTrack(Empty)`.
+- `OnConnectionLost()` (keep-alive failure / drop) -> `executionMonitor.Stop()` -> `PublishAndTrack(Empty)`.
+- Poll loop on `NotConnectedError` -> `onConnectionLost()` -> same path.
+- Conclusion: driving the lock from `ExecutionState.RecipeActive` automatically yields
+  "editable when disconnected".
+
+Related patterns found:
+- `RecipeCoordinator` already exposes `_executionState` as `ObserveOn(MainThreadScheduler).Publish().RefCount()`
+  (lines 68-71) and uses the `Replay(1) + Connect()` pattern for `CanEditRecipe`.
+- `StubS7Service.PushExecutionState(PlcExecutionInfo)` already exists and feeds the execution stream;
+  `UIFixture.S7Service` is reachable from tests.
+- Tests currently drive the lock via `UIFixture.SetSyncEnabled`; we add a parallel `SetRecipeActive`.
+
+Dependencies identified:
+- `IsSyncEnabled` keeps its current role: it controls whether edits push to the PLC
+  (`RecipeSession.NotifySyncIfEnabled`). The two signals become orthogonal; no change there.
+- PLC write-block during execution already exists (`PlcSyncExecutor.cs:233-238`). No change there.
+
+## Development Approach
+
+- **Testing approach: Regular** (change production signal first, then update tests to the new behavior).
+- Complete each task fully before moving to the next; small, focused changes.
+- Every task includes new/updated tests for the code it touches; all tests pass before the next task.
+- `dotnet format SemiStep/SemiStep.slnx` before any commit (pre-commit hook enforces it).
+- Backward compatibility: not a public API; internal behavior change is the point of the task.
+
+## Testing Strategy
+
+- **Unit/integration tests:** required per task. UI behavior is covered by Avalonia headless tests
+  (`[AvaloniaFact]`) in `SemiStep.Tests`.
+- **No e2e harness** exists in this project; manual verification is listed in Post-Completion.
+- Test commands:
+  - Full: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`
+  - Coordinator: `--filter "Area=Coordinator"`
+  - UI: `--filter "Component=UI"`
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with the ➕ prefix; blockers with the ⚠️ prefix.
+- Keep this plan in sync with actual work.
+
+## Solution Overview
+
+Change the **source** of one observable. In `RecipeCoordinator`, replace
+
+```csharp
+var canEditConnectable = _plcStateChangedShared
+    .Select(plcState => plcState.IsSuccess ? !plcState.Value.IsSyncEnabled : !IsSyncEnabled)
+    .StartWith(!IsSyncEnabled)
+    .DistinctUntilChanged()
+    .Replay(1);
+```
+
+with
+
+```csharp
+var canEditConnectable = _executionState
+    .Select(info => !info.RecipeActive)
+    .StartWith(!IsRecipeActive)
+    .DistinctUntilChanged()
+    .Replay(1);
+```
+
+All consumers (`RecipeGridViewModel.IsReadOnly`, the three command view-models) already read
+`coordinator.CanEditRecipe`, so they follow automatically — no consumer code changes. The
+`EditorMustClose` mechanism (forces an open cell editor closed when `IsReadOnly` flips true) is
+reused as-is: it now fires when `recipe_active` flips true mid-edit.
+
+Key design decisions:
+- The lock signal is exactly `!RecipeActive` — no `IsConnected` term is needed, because disconnect
+  forces `RecipeActive=false` (verified above).
+- `_plcStateChanged` / `_plcStateChangedShared` / `PlcStateChanged` are kept: they still feed
+  connection/sync status to other consumers (e.g. status bar, conflict handling).
+- `IsSyncEnabled` keeps controlling auto-push; orthogonality is the goal.
+
+## Technical Details
+
+- `_executionState` is already on the UI scheduler and shared via `Publish().RefCount()`.
+  `canEditConnectable.Connect()` adds one long-lived subscriber (disposed by the existing
+  `_canEditRecipeConnection.Dispose()` in `Dispose()`), so RefCount stays alive for the
+  coordinator's lifetime — same lifecycle as today.
+- Initial value: at construction no execution has been observed, so `IsRecipeActive` is `false`
+  and `StartWith(!IsRecipeActive)` emits `true` (editable). Matches the disconnected default.
+- Under `[AvaloniaFact]`, the headless dispatcher runs scheduler jobs, so pushing execution state
+  then asserting synchronously works the same way `SetSyncEnabled` does today.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]`): production change + test rewrites in this repo.
+- **Post-Completion** (no checkboxes): spec-doc edits (owned by the user) and manual verification.
+
+## Implementation Steps
+
+### Task 1: Drive `CanEditRecipe` from execution state (+ fixture helper + coordinator tests)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/Coordinator/RecipeCoordinatorCanEditRecipeTests.cs`
+
+- [x] In `RecipeCoordinator`, change `canEditConnectable` to derive from `_executionState`:
+      `.Select(info => !info.RecipeActive).StartWith(!IsRecipeActive).DistinctUntilChanged().Replay(1)`.
+- [x] Leave `_plcStateChanged`, `_plcStateChangedShared`, and the `PlcStateChanged` property intact.
+- [x] Add `UIFixture.SetRecipeActive(bool active)` that calls
+      `S7Service.PushExecutionState(PlcExecutionInfo.Empty with { RecipeActive = active, ActualLine = ... })`
+      (a minimal `PlcExecutionInfo`).
+- [x] Rewrite `RecipeCoordinatorCanEditRecipeTests`: emits `true` on subscribe (no execution);
+      flips to `false` when `recipe_active` becomes true; flips back to `true` when it becomes false.
+- [x] Add cases: late subscriber receives current value; `DistinctUntilChanged` suppresses duplicate
+      `recipe_active=true` emissions.
+- [x] Run tests `--filter "Area=Coordinator"` — must pass before next task.
+
+### Task 2: Invert grid read-only tests
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridViewModelReadOnlyTests.cs`
+
+- [x] `IsReadOnly` false initially (no execution); true when `recipe_active=true`; back to false when
+      execution stops — driven via `SetRecipeActive`.
+- [x] Replace the `IsReadOnly_StaysFalse_WhenExecutionActive_AndSyncDisabled` §2.7 regression test
+      with its inverse: `IsReadOnly` is **true** when execution is active.
+- [x] Add `IsReadOnly_StaysFalse_WhenSyncEnabled_ButNotExecuting` — the new core behavior
+      (connected-idle is editable): call `SetSyncEnabled(true)` with no execution, assert false.
+- [x] Update `CellValueChanged_WhenReadOnly_DoesNotMutateSession` to enter read-only via
+      `SetRecipeActive(true)`.
+- [x] Update `EditorMustClose` tests to fire on `recipe_active` flipping true (not on sync enable).
+- [x] Run tests `--filter "Area=RecipeGrid"` — must pass before next task.
+
+### Task 3: Update command CanExecute tests
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/Clipboard/ClipboardViewModelCanExecuteTests.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeFile/RecipeFileViewModelCanExecuteTests.cs`
+
+- [x] In each file, change the "gated-false" cases from `SetSyncEnabled(true)` to
+      `SetRecipeActive(true)`; rename tests (Connect-mode -> executing).
+- [x] Add one test per view-model: gated commands (Add/Delete/Undo/Redo, Cut/Paste, Load/New) remain
+      **enabled** when `SetSyncEnabled(true)` but not executing (connected-idle).
+- [x] Keep unconditional-command tests (Copy, Save, SaveAs) unchanged.
+- [x] Run tests `--filter "Component=UI"` — must pass before next task.
+
+### Task 4: Verify acceptance criteria
+
+- [x] Verify the three states: offline edit (no PLC), connected-idle edit (+ `NotifyRecipeChanged`
+      fires), executing locked.
+- [x] Confirm `RecipeSessionSyncIsValidTests` and other `SetSyncEnabled`-using tests still pass
+      (sync-push path is unchanged).
+- [x] Run full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`.
+- [x] Run `dotnet format SemiStep/SemiStep.slnx`.
+
+### Task 5: Finalize
+
+- [x] Confirm no `CLAUDE.md` / `README.md` change is needed (no new build/test pattern introduced).
+- [x] Move this plan to `Docs/plans/completed/`.
+
+## Post-Completion
+
+*Items requiring manual intervention or owned externally — informational only.*
+
+**Spec documentation (owned by the user, per their instruction):**
+- `Docs/02-ui-requirements.md` §2.5 / §2.7 — currently state blocking is owned by window mode and
+  there is "no separate blocked-because-executing state". This must be rewritten to: editing is
+  locked by execution (`recipe_active`), not by Connect/Edit mode.
+- `Docs/04-plc.md` §4.5 — `recipe_active` rows already describe execution-based locking; verify they
+  match the implemented model.
+- `Docs/05-plc-protocol.md` — the `recipe_active` field description ("редактирование таблицы
+  блокируется") is now accurate for editing; keep the "PLC writes forbidden" clause as-is.
+
+**Manual verification:**
+- With a real/simulated PLC: connect to an idle recipe, edit a cell, confirm the debounced write
+  reaches the PLC; start execution, confirm the grid and commands lock; stop execution, confirm
+  editing unlocks; drop the connection mid-execution, confirm editing unlocks.
+
+**Out of scope:**
+- Conflict-on-connect dialog behavior, execution overlay/loop tinting, keyboard-shortcut gaps —
+  unchanged by this task.

--- a/SemiStep/SemiStep.Tests/UI/Clipboard/ClipboardViewModelCanExecuteTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Clipboard/ClipboardViewModelCanExecuteTests.cs
@@ -82,10 +82,10 @@ public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void Cut_CanExecuteFalse_WhenSyncEnabled_EvenWithSelection()
+	public void Cut_CanExecuteFalse_WhenRecipeExecuting_EvenWithSelection()
 	{
 		AppendStepAndSelect();
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		((ICommand)_clipboard.CutStepCommand).CanExecute(null).Should().BeFalse();
 	}
@@ -101,11 +101,11 @@ public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void Cut_CanExecuteBackToTrue_AfterSyncDisabledAgain()
+	public void Cut_CanExecuteBackToTrue_AfterExecutionStops()
 	{
 		AppendStepAndSelect();
-		_fixture.SetSyncEnabled(true);
-		_fixture.SetSyncEnabled(false);
+		_fixture.SetRecipeActive(true);
+		_fixture.SetRecipeActive(false);
 
 		((ICommand)_clipboard.CutStepCommand).CanExecute(null).Should().BeTrue();
 	}
@@ -119,30 +119,38 @@ public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void Paste_CanExecuteFalse_WhenSyncEnabled()
+	public void Paste_CanExecuteFalse_WhenRecipeExecuting()
 	{
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		((ICommand)_clipboard.PasteStepCommand).CanExecute(null).Should().BeFalse();
 	}
 
 	[AvaloniaFact]
-	public void Paste_CanExecuteBackToTrue_AfterSyncDisabledAgain()
+	public void Paste_CanExecuteTrue_WhenSyncEnabledButNotExecuting()
 	{
 		_fixture.SetSyncEnabled(true);
-		_fixture.SetSyncEnabled(false);
 
 		((ICommand)_clipboard.PasteStepCommand).CanExecute(null).Should().BeTrue();
 	}
 
 	[AvaloniaFact]
-	public void Cut_GatedInvocation_InConnectMode_DoesNotRemoveStep()
+	public void Paste_CanExecuteBackToTrue_AfterExecutionStops()
+	{
+		_fixture.SetRecipeActive(true);
+		_fixture.SetRecipeActive(false);
+
+		((ICommand)_clipboard.PasteStepCommand).CanExecute(null).Should().BeTrue();
+	}
+
+	[AvaloniaFact]
+	public void Cut_GatedInvocation_WhileExecuting_DoesNotRemoveStep()
 	{
 		// UI buttons honor CanExecute and never call Execute when gated. Simulate that
-		// pattern and assert recipe state is untouched in Connect mode.
+		// pattern and assert recipe state is untouched while executing.
 		AppendStepAndSelect();
 		var stepCountBefore = _fixture.Coordinator.CurrentRecipe.StepCount;
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		var command = (ICommand)_clipboard.CutStepCommand;
 		if (command.CanExecute(null))
@@ -155,11 +163,11 @@ public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void Paste_GatedInvocation_InConnectMode_DoesNotInsertSteps()
+	public void Paste_GatedInvocation_WhileExecuting_DoesNotInsertSteps()
 	{
 		_fixture.Coordinator.NewRecipe();
 		var stepCountBefore = _fixture.Coordinator.CurrentRecipe.StepCount;
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		var command = (ICommand)_clipboard.PasteStepCommand;
 		if (command.CanExecute(null))

--- a/SemiStep/SemiStep.Tests/UI/Coordinator/RecipeCoordinatorCanEditRecipeTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Coordinator/RecipeCoordinatorCanEditRecipeTests.cs
@@ -26,7 +26,7 @@ public sealed class RecipeCoordinatorCanEditRecipeTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void CanEditRecipe_EmitsTrueOnSubscribe_WhenSyncDisabled()
+	public void CanEditRecipe_EmitsTrueOnSubscribe_WhenNoExecution()
 	{
 		var values = CollectValues(_fixture.Coordinator.CanEditRecipe, out var subscription);
 		try
@@ -40,12 +40,12 @@ public sealed class RecipeCoordinatorCanEditRecipeTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void CanEditRecipe_FlipsToFalse_WhenSyncEnabled()
+	public void CanEditRecipe_FlipsToFalse_WhenRecipeBecomesActive()
 	{
 		var values = CollectValues(_fixture.Coordinator.CanEditRecipe, out var subscription);
 		try
 		{
-			_fixture.SetSyncEnabled(true);
+			_fixture.SetRecipeActive(true);
 
 			values.Should().Equal(true, false);
 		}
@@ -56,13 +56,13 @@ public sealed class RecipeCoordinatorCanEditRecipeTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void CanEditRecipe_FlipsBackToTrue_WhenSyncDisabledAfterEnabled()
+	public void CanEditRecipe_FlipsBackToTrue_WhenRecipeStops()
 	{
 		var values = CollectValues(_fixture.Coordinator.CanEditRecipe, out var subscription);
 		try
 		{
-			_fixture.SetSyncEnabled(true);
-			_fixture.SetSyncEnabled(false);
+			_fixture.SetRecipeActive(true);
+			_fixture.SetRecipeActive(false);
 
 			values.Should().Equal(true, false, true);
 		}
@@ -75,7 +75,7 @@ public sealed class RecipeCoordinatorCanEditRecipeTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void CanEditRecipe_LateSubscriber_ReceivesCurrentValue()
 	{
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		var values = CollectValues(_fixture.Coordinator.CanEditRecipe, out var subscription);
 		try
@@ -89,13 +89,13 @@ public sealed class RecipeCoordinatorCanEditRecipeTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void CanEditRecipe_DistinctUntilChanged_SuppressesDuplicateEmissions()
+	public void CanEditRecipe_DistinctUntilChanged_SuppressesDuplicateActiveEmissions()
 	{
 		var values = CollectValues(_fixture.Coordinator.CanEditRecipe, out var subscription);
 		try
 		{
-			_fixture.SetSyncEnabled(true);
-			_fixture.SetSyncEnabled(true);
+			_fixture.SetRecipeActive(true);
+			_fixture.SetRecipeActive(true);
 
 			values.Should().Equal(true, false);
 		}

--- a/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
@@ -69,4 +69,9 @@ public sealed class UIFixture : IAsyncLifetime
 		PlcSyncService.PushPlcState(Result.Ok(
 			new PlcSessionSnapshot(PlcConnectionState.Disconnected, PlcSyncStatus.Idle, isSyncEnabled)));
 	}
+
+	public void SetRecipeActive(bool active)
+	{
+		S7Service.PushExecutionState(PlcExecutionInfo.Empty with { RecipeActive = active });
+	}
 }

--- a/SemiStep/SemiStep.Tests/UI/RecipeFile/RecipeFileViewModelCanExecuteTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeFile/RecipeFileViewModelCanExecuteTests.cs
@@ -43,18 +43,26 @@ public sealed class RecipeFileViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void LoadRecipe_CanExecuteFalse_WhenSyncEnabled()
+	public void LoadRecipe_CanExecuteFalse_WhenRecipeExecuting()
 	{
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		((ICommand)_recipeFile.LoadRecipeCommand).CanExecute(null).Should().BeFalse();
 	}
 
 	[AvaloniaFact]
-	public void LoadRecipe_CanExecuteBackToTrue_AfterSyncDisabledAgain()
+	public void LoadRecipe_CanExecuteTrue_WhenSyncEnabledButNotExecuting()
 	{
 		_fixture.SetSyncEnabled(true);
-		_fixture.SetSyncEnabled(false);
+
+		((ICommand)_recipeFile.LoadRecipeCommand).CanExecute(null).Should().BeTrue();
+	}
+
+	[AvaloniaFact]
+	public void LoadRecipe_CanExecuteBackToTrue_AfterExecutionStops()
+	{
+		_fixture.SetRecipeActive(true);
+		_fixture.SetRecipeActive(false);
 
 		((ICommand)_recipeFile.LoadRecipeCommand).CanExecute(null).Should().BeTrue();
 	}
@@ -66,18 +74,18 @@ public sealed class RecipeFileViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void NewRecipe_CanExecuteFalse_WhenSyncEnabled()
+	public void NewRecipe_CanExecuteFalse_WhenRecipeExecuting()
 	{
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		((ICommand)_recipeFile.NewRecipeCommand).CanExecute(null).Should().BeFalse();
 	}
 
 	[AvaloniaFact]
-	public void NewRecipe_CanExecuteBackToTrue_AfterSyncDisabledAgain()
+	public void NewRecipe_CanExecuteBackToTrue_AfterExecutionStops()
 	{
-		_fixture.SetSyncEnabled(true);
-		_fixture.SetSyncEnabled(false);
+		_fixture.SetRecipeActive(true);
+		_fixture.SetRecipeActive(false);
 
 		((ICommand)_recipeFile.NewRecipeCommand).CanExecute(null).Should().BeTrue();
 	}
@@ -103,15 +111,15 @@ public sealed class RecipeFileViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void NewRecipe_GatedInvocation_InConnectMode_DoesNotMutateRecipe()
+	public void NewRecipe_GatedInvocation_WhileExecuting_DoesNotMutateRecipe()
 	{
 		// End-to-end: simulate the binding-time invocation pattern used by the UI
-		// (button click respects CanExecute). In Connect mode the gate refuses
+		// (button click respects CanExecute). While executing the gate refuses
 		// invocation, so no mutation occurs.
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		var stepCountBefore = _fixture.Coordinator.CurrentRecipe.StepCount;
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		var command = (ICommand)_recipeFile.NewRecipeCommand;
 		if (command.CanExecute(null))
@@ -124,17 +132,17 @@ public sealed class RecipeFileViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void LoadRecipe_GatedInvocation_InConnectMode_DoesNotOpenDialog()
+	public void LoadRecipe_GatedInvocation_WhileExecuting_DoesNotOpenDialog()
 	{
 		// End-to-end: the dialog handler must not be invoked because CanExecute is
-		// false in Connect mode (UI buttons honor CanExecute and never call Execute).
+		// false while executing (UI buttons honor CanExecute and never call Execute).
 		var interactionInvoked = false;
 		_recipeFile.OpenFileInteraction.RegisterHandler((IInteractionContext<Unit, string?> ctx) =>
 		{
 			interactionInvoked = true;
 			ctx.SetOutput(null);
 		});
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		var command = (ICommand)_recipeFile.LoadRecipeCommand;
 		if (command.CanExecute(null))

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs
@@ -51,18 +51,26 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void AddStep_CanExecuteFalse_WhenSyncEnabled()
+	public void AddStep_CanExecuteFalse_WhenRecipeExecuting()
 	{
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		((ICommand)_commands.AddStepCommand).CanExecute(null).Should().BeFalse();
 	}
 
 	[AvaloniaFact]
-	public void AddStep_CanExecuteBackToTrue_AfterSyncDisabledAgain()
+	public void AddStep_CanExecuteTrue_WhenSyncEnabledButNotExecuting()
 	{
 		_fixture.SetSyncEnabled(true);
-		_fixture.SetSyncEnabled(false);
+
+		((ICommand)_commands.AddStepCommand).CanExecute(null).Should().BeTrue();
+	}
+
+	[AvaloniaFact]
+	public void AddStep_CanExecuteBackToTrue_AfterExecutionStops()
+	{
+		_fixture.SetRecipeActive(true);
+		_fixture.SetRecipeActive(false);
 
 		((ICommand)_commands.AddStepCommand).CanExecute(null).Should().BeTrue();
 	}
@@ -78,12 +86,12 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void DeleteStep_CanExecuteFalse_WhenSyncEnabled_EvenWithSelection()
+	public void DeleteStep_CanExecuteFalse_WhenRecipeExecuting_EvenWithSelection()
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_grid.SelectedRowIndices = new[] { 0 };
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		((ICommand)_commands.DeleteStepCommand).CanExecute(null).Should().BeFalse();
 	}
@@ -108,11 +116,11 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void Undo_CanExecuteFalse_WhenSyncEnabled_EvenWithUndoAvailable()
+	public void Undo_CanExecuteFalse_WhenRecipeExecuting_EvenWithUndoAvailable()
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		((ICommand)_commands.UndoCommand).CanExecute(null).Should().BeFalse();
 	}
@@ -128,24 +136,24 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void Redo_CanExecuteFalse_WhenSyncEnabled_EvenWithRedoAvailable()
+	public void Redo_CanExecuteFalse_WhenRecipeExecuting_EvenWithRedoAvailable()
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_fixture.Coordinator.Undo();
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		((ICommand)_commands.RedoCommand).CanExecute(null).Should().BeFalse();
 	}
 
 	[AvaloniaFact]
-	public void AddStep_GatedInvocation_InConnectMode_DoesNotInsertStep()
+	public void AddStep_GatedInvocation_WhileExecuting_DoesNotInsertStep()
 	{
 		// UI buttons honor CanExecute and never call Execute when gated. Simulate that
 		// pattern and assert no mutation reaches the session.
 		_fixture.Coordinator.NewRecipe();
 		var stepCountBefore = _fixture.Coordinator.CurrentRecipe.StepCount;
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		var command = (ICommand)_commands.AddStepCommand;
 		if (command.CanExecute(null))
@@ -158,13 +166,13 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void DeleteStep_GatedInvocation_InConnectMode_DoesNotRemoveStep()
+	public void DeleteStep_GatedInvocation_WhileExecuting_DoesNotRemoveStep()
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_grid.SelectedRowIndices = new[] { 0 };
 		var stepCountBefore = _fixture.Coordinator.CurrentRecipe.StepCount;
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		var command = (ICommand)_commands.DeleteStepCommand;
 		if (command.CanExecute(null))

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridViewModelReadOnlyTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridViewModelReadOnlyTests.cs
@@ -4,7 +4,6 @@ using FluentAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 
-using SemiStep.Core.Plc.State;
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
@@ -41,40 +40,34 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void IsReadOnly_False_Initially_WhenSyncDisabled()
+	public void IsReadOnly_False_Initially_WhenNoExecution()
 	{
 		_grid.IsReadOnly.Should().BeFalse();
 	}
 
 	[AvaloniaFact]
-	public void IsReadOnly_True_WhenSyncEnabled()
+	public void IsReadOnly_True_WhenExecutionActive()
 	{
-		_fixture.SetSyncEnabled(true);
+		// §2.7: execution being active locks editing.
+		_fixture.SetRecipeActive(true);
 
 		_grid.IsReadOnly.Should().BeTrue();
 	}
 
 	[AvaloniaFact]
-	public void IsReadOnly_BackToFalse_AfterSyncDisabledAgain()
+	public void IsReadOnly_BackToFalse_AfterExecutionStops()
 	{
-		_fixture.SetSyncEnabled(true);
-		_fixture.SetSyncEnabled(false);
+		_fixture.SetRecipeActive(true);
+		_fixture.SetRecipeActive(false);
 
 		_grid.IsReadOnly.Should().BeFalse();
 	}
 
 	[AvaloniaFact]
-	public void IsReadOnly_StaysFalse_WhenExecutionActive_AndSyncDisabled()
+	public void IsReadOnly_StaysFalse_WhenSyncEnabled_ButNotExecuting()
 	{
-		// §2.7 regression: execution being active does not lock editing on its own.
-		_fixture.S7Service.PushExecutionState(
-			new PlcExecutionInfo(
-				RecipeActive: true,
-				ActualLine: 1,
-				StepCurrentTime: 0f,
-				ForLoopCount1: 0,
-				ForLoopCount2: 0,
-				ForLoopCount3: 0));
+		// Connected-but-idle is editable: sync enabled without execution does not lock editing.
+		_fixture.SetSyncEnabled(true);
 
 		_grid.IsReadOnly.Should().BeFalse();
 	}
@@ -87,7 +80,7 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 		// the property update.
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 		_grid.IsReadOnly.Should().BeTrue();
 
 		var row = _grid.RecipeRows[0];
@@ -101,23 +94,23 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void EditorMustClose_Emits_WhenSyncFlipsToEnabled()
+	public void EditorMustClose_Emits_WhenRecipeBecomesActive()
 	{
 		var emissionCount = 0;
 		using var subscription = _grid.EditorMustClose.Subscribe(_ => emissionCount++);
 
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		emissionCount.Should().Be(1);
 	}
 
 	[AvaloniaFact]
-	public void EditorMustClose_DoesNotEmit_WhenSyncStaysDisabled()
+	public void EditorMustClose_DoesNotEmit_WhenNoExecution()
 	{
 		var emissionCount = 0;
 		using var subscription = _grid.EditorMustClose.Subscribe(_ => emissionCount++);
 
-		_fixture.SetSyncEnabled(false);
+		_fixture.SetRecipeActive(false);
 
 		emissionCount.Should().Be(0);
 	}
@@ -125,7 +118,7 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 	[AvaloniaFact]
 	public void EditorMustClose_LateSubscriber_DoesNotReceiveInitialReadOnlyState()
 	{
-		_fixture.SetSyncEnabled(true);
+		_fixture.SetRecipeActive(true);
 
 		var emissionCount = 0;
 		using var subscription = _grid.EditorMustClose.Subscribe(_ => emissionCount++);

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -78,9 +78,9 @@ public sealed class RecipeCoordinator : IDisposable
 			.Publish()
 			.RefCount();
 
-		var canEditConnectable = _plcStateChangedShared
-			.Select(plcState => plcState.IsSuccess ? !plcState.Value.IsSyncEnabled : !IsSyncEnabled)
-			.StartWith(!IsSyncEnabled)
+		var canEditConnectable = _executionState
+			.Select(info => !info.RecipeActive)
+			.StartWith(!IsRecipeActive)
 			.DistinctUntilChanged()
 			.Replay(1);
 		_canEditRecipeConnection = canEditConnectable.Connect();


### PR DESCRIPTION
## What

Gate the recipe edit-lock on **execution state** (`recipe_active`) instead of **sync mode** (`IsSyncEnabled`).

Behavior by state:
- **Not connected** — editable (disconnect drives `recipe_active=false` on every path).
- **Connected, not executing** — editable; changes auto-sync to the PLC via the existing 1 s debounce.
- **Executing** — fully locked.

## Why

The previously merged per-window-edit-connect-mode change tied the edit-lock to Connect/Edit mode, so the table became read-only whenever sync was on — even with no recipe running — and left the auto-sync-on-edit path (`RecipeSession.NotifySyncIfEnabled`) unreachable. This PR reverts that core decision so connected-but-idle editing works as intended, while still protecting a running recipe.

## How

Single production change: `RecipeCoordinator.CanEditRecipe` now derives from the execution stream (`!RecipeActive`) instead of `IsSyncEnabled`. All consumers (grid `IsReadOnly` + the command view-models) read the same observable, so they follow automatically. `IsSyncEnabled` keeps its orthogonal role of gating push-to-PLC.

## Testing

- Full suite: 689 passing, 0 failing.
- Read-only / CanExecute tests inverted and extended to cover all three states; `dotnet format` clean.

## Follow-up (not in this PR)

Spec docs `Docs/02-ui-requirements.md` (§2.5/§2.7), `04-plc.md`, `05-plc-protocol.md` are owner-managed and updated separately. Manual verification on a real/simulated PLC pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
