### PR TITLE
Fix Recipe/Step structural equality so reconnect matches identical content

### DIFF
--- a/Docs/plans/20260601-fix-recipe-step-structural-equality.md
+++ b/Docs/plans/20260601-fix-recipe-step-structural-equality.md
@@ -77,11 +77,11 @@
 - Modify: `SemiStep/SemiStep.Core/Recipes/Recipe.cs`
 - Modify: `SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs`
 
-- [ ] Add `public bool Equals(Recipe? other)` to `Recipe`: `other is not null && Steps.SequenceEqual(other.Steps)` (order-sensitive), relying on `Step`'s content equality.
-- [ ] Add `public override int GetHashCode()` folding step hashes in order via `HashCode`.
-- [ ] Keep `Empty`, `StepCount`, and all mutation helpers (`AppendStep`, `InsertStep`, etc.) intact.
-- [ ] Write unit tests: two recipes with identical steps in distinct list instances are equal; `Recipe.Empty` equals `new Recipe([])`; recipes differing in step order are not equal; differing step count not equal; a recipe with one content-equal step but a fresh inner `Step`/`Properties` instance is equal (the reconnect scenario at the unit level); equal recipes produce equal `GetHashCode`; `Equals(null)` is `false` and `Equals(self)` is `true`.
-- [ ] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=RecipeEquality"` — must pass before Task 3.
+- [x] Add `public bool Equals(Recipe? other)` to `Recipe`: `other is not null && Steps.SequenceEqual(other.Steps)` (order-sensitive), relying on `Step`'s content equality.
+- [x] Add `public override int GetHashCode()` folding step hashes in order via `HashCode`.
+- [x] Keep `Empty`, `StepCount`, and all mutation helpers (`AppendStep`, `InsertStep`, etc.) intact.
+- [x] Write unit tests: two recipes with identical steps in distinct list instances are equal; `Recipe.Empty` equals `new Recipe([])`; recipes differing in step order are not equal; differing step count not equal; a recipe with one content-equal step but a fresh inner `Step`/`Properties` instance is equal (the reconnect scenario at the unit level); equal recipes produce equal `GetHashCode`; `Equals(null)` is `false` and `Equals(self)` is `true`.
+- [x] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=RecipeEquality"` — must pass before Task 3.
 
 ### Task 3: Reconnect identical-content -> no conflict regression test
 

--- a/Docs/plans/20260601-fix-recipe-step-structural-equality.md
+++ b/Docs/plans/20260601-fix-recipe-step-structural-equality.md
@@ -1,0 +1,115 @@
+# Fix Recipe/Step structural equality so reconnect reconciliation matches identical content (issue #49)
+
+## Overview
+- Reconnect reconciliation decides "PLC recipe == PC recipe" via `localRecipe.Equals(plcRecipe)` (`PlcLifecycleManager.cs:320`), but `Recipe` and `Step` record equality degrades to **reference** equality because their members are `ImmutableList<Step>` / `ImmutableDictionary<PropertyId, PropertyValue>`, neither of which implements structural equality.
+- Effect: a recipe freshly read from the PLC (new list/dict instances) never compares equal to the local one even when the content is byte-identical, so `!localRecipe.Equals(plcRecipe)` is effectively always true. The intended "committed=true, PLC = PC -> no action" branch is unreachable; the conflict dialog fires on every reconnect where both recipes are non-empty.
+- Fix: give `Recipe` and `Step` content-based `Equals`/`GetHashCode`. `Recipe` compares `Steps` order-sensitively (`SequenceEqual`); `Step` compares `ActionKey` plus `Properties` by content (count + per-key value), order-independent. `PropertyValue` already has correct value equality and is **not** changed.
+
+## Context (from discovery)
+- Files/components involved:
+  - `SemiStep/SemiStep.Core/Recipes/Recipe.cs:5` — `sealed record Recipe(ImmutableList<Step> Steps)`.
+  - `SemiStep/SemiStep.Core/Recipes/Step.cs:5-7` — `sealed record Step(int ActionKey, ImmutableDictionary<PropertyId, PropertyValue> Properties)`.
+  - `SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs:320` — the only consumer of `Recipe.Equals`.
+  - `SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs` — reconnect integration tests.
+- Related patterns found:
+  - `PropertyValue` (`PropertyValue.cs`) is a `sealed record` over `object Value` + `PropertyType Type`. Synthesized equality routes `Value` through `EqualityComparer<object>.Default` -> `object.Equals`; boxed `int`/`float` and `string` compare by value. **Value equality already correct; leave unchanged.** (Resolves the issue's open "Confirm PropertyValue has value equality" point.)
+  - `PropertyId` (`PropertyId.cs`) is a `readonly record struct` with proper value equality; safe as a dictionary key.
+  - Core unit tests live under `SemiStep/SemiStep.Tests/Core/Unit/Recipes/` with traits `[Trait("Category","Unit")] [Trait("Component","Core")] [Trait("Area","<name>")]` (see `RecipeMetadataRegistryTests.cs:12-14`).
+  - `StubPlcSyncService.NotifyRecipeChangedCallCount` is the deterministic completion signal used by existing reconnect tests for the "push local recipe" path; `NotifyLocalRecipe()` (`PlcLifecycleManager.cs:368-371`) calls `_syncService.NotifyRecipeChanged`, so the equal branch increments that counter.
+- Dependencies / blast radius:
+  - Grep confirms **no** `HashSet<Recipe>`/`HashSet<Step>`/`Dictionary<Recipe>`/`Dictionary<Step>` anywhere, and the only direct `Recipe.Equals` call is `PlcLifecycleManager.cs:320`. Changing structural equality on the records is therefore safe; no other call site depends on the old reference semantics.
+
+## Development Approach
+- **Testing approach**: Regular (code first, then tests).
+- Complete each task fully before moving to the next.
+- Make small, focused changes.
+- **Every task includes new/updated tests.** Tests are a required deliverable, not optional.
+- **All tests must pass before starting the next task.**
+- Run tests after each change. Keep this plan in sync if scope shifts.
+
+## Testing Strategy
+- **Unit tests**: required for every task. New file `RecipeStructuralEqualityTests.cs` for `Recipe`/`Step` equality and hash-code consistency.
+- **Integration tests**: extend `PlcLifecycleManagerReconnectTests` with the identical-content -> no-conflict case (the reconnect path is integration-traited).
+- **e2e tests**: project has no Playwright/Cypress UI e2e suite; Avalonia headless tests are not relevant to this Core-only change.
+
+## Progress Tracking
+- Mark completed items `[x]` immediately when done.
+- New tasks get a `➕` prefix; blockers get a `⚠️` prefix.
+- Update the plan if implementation deviates from scope.
+
+## Solution Overview
+- Override `Equals(Step?)` and `GetHashCode()` on `Step`:
+  - Equal when `ActionKey` matches and `Properties` have identical content (same count, and every key maps to an equal `PropertyValue`), independent of insertion order.
+  - `GetHashCode` combines `ActionKey` with an order-independent XOR of per-pair hashes so equal steps hash equally.
+- Override `Equals(Recipe?)` and `GetHashCode()` on `Recipe`:
+  - Equal when `Steps.SequenceEqual(other.Steps)` (order-sensitive; step order is semantically significant), using `Step`'s new content equality for element comparison.
+  - `GetHashCode` combines step hashes in order via `HashCode`.
+- `with` expressions, `Deconstruct`, `==`/`!=`, and `ToString` remain compiler-synthesized; only `Equals(T?)` and `GetHashCode()` are user-provided. Both must be overridden together to stay consistent (a user `Equals` with a synthesized member-wise `GetHashCode` would hash equal recipes differently).
+
+## Technical Details
+- `Step.Equals(Step? other)`: `other is not null && ActionKey == other.ActionKey && Properties.Count == other.Properties.Count && all pairs in Properties have a matching key in other with `PropertyValue`-equal value`.
+- `Step.GetHashCode()`: start from `ActionKey`, XOR in `HashCode.Combine(pair.Key, pair.Value)` per pair (order-independent, consistent with content equality). This folds in `PropertyValue.GetHashCode`, which is the compiler-synthesized record hash routing `object Value` through `EqualityComparer<object>.Default` -> value-based for boxed `int`/`float` and `string`; so equal `PropertyValue`s hash equally and the `Step` hash/equality contract holds transitively.
+- `Recipe.Equals(Recipe? other)`: `other is not null && Steps.SequenceEqual(other.Steps)`.
+- `Recipe.GetHashCode()`: fold step hashes through `HashCode` in sequence order.
+- No change to `PropertyValue`, `PropertyId`, or the `PlcLifecycleManager.cs:320` call site.
+
+## What Goes Where
+- **Implementation Steps** (`[ ]`): record equality overrides, unit tests, the reconnect no-conflict integration test, acceptance verification, docs.
+- **Post-Completion** (no checkboxes): the user-guide match criterion can now be stated honestly; manual reconnect smoke test on real hardware.
+
+## Implementation Steps
+
+### Task 1: Content-based equality for `Step`
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/Step.cs`
+- Create: `SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs`
+
+- [ ] Add `public bool Equals(Step? other)` to `Step`: compare `ActionKey`, then `Properties` by content (count + per-key `PropertyValue` equality), order-independent.
+- [ ] Add `public override int GetHashCode()` consistent with the new equality: `ActionKey` XOR-combined with per-pair hashes (order-independent).
+- [ ] Keep the record positional definition, `WithProperty`, `with`/`Deconstruct` intact; only `Equals(T?)`/`GetHashCode` are user-provided.
+- [ ] Write unit tests: identical content in distinct `ImmutableDictionary` instances are equal; different `ActionKey` not equal; different property value not equal; different property key-set / different count not equal; same content built in different insertion order is equal; equal steps produce equal `GetHashCode`; `Equals(null)` is `false` and `Equals(self)` is `true` (null/reflexivity contract).
+- [ ] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=RecipeEquality"` — must pass before Task 2.
+
+### Task 2: Content-based equality for `Recipe`
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/Recipe.cs`
+- Modify: `SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs`
+
+- [ ] Add `public bool Equals(Recipe? other)` to `Recipe`: `other is not null && Steps.SequenceEqual(other.Steps)` (order-sensitive), relying on `Step`'s content equality.
+- [ ] Add `public override int GetHashCode()` folding step hashes in order via `HashCode`.
+- [ ] Keep `Empty`, `StepCount`, and all mutation helpers (`AppendStep`, `InsertStep`, etc.) intact.
+- [ ] Write unit tests: two recipes with identical steps in distinct list instances are equal; `Recipe.Empty` equals `new Recipe([])`; recipes differing in step order are not equal; differing step count not equal; a recipe with one content-equal step but a fresh inner `Step`/`Properties` instance is equal (the reconnect scenario at the unit level); equal recipes produce equal `GetHashCode`; `Equals(null)` is `false` and `Equals(self)` is `true`.
+- [ ] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=RecipeEquality"` — must pass before Task 3.
+
+### Task 3: Reconnect identical-content -> no conflict regression test
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs`
+
+- [ ] Add `StateChanged_Connected_WhenRecipesIdentical_DoesNotFireConflict_AndPushesLocal`: append a step to `session` (non-empty local), then build the PLC stub recipe as a **fresh-instance deep copy of `session.Current`** — reconstruct each step as `new Step(step.ActionKey, ImmutableDictionary.CreateRange(step.Properties))` wrapped via `ImmutableList.Create(...)`. Set `ManagingAreaToReturn` committed=true.
+  - **Do NOT reuse `BuildSingleStepRecipe()` (`PlcLifecycleManagerReconnectTests.cs:62-69`)**: it builds a step with `ImmutableDictionary.Empty`, but `session.AppendStep(WaitActionId)` routes through `StepInitializer.Create` and populates one default `PropertyValue` per action property. Empty vs. populated properties would differ, the conflict branch would fire, `NotifyRecipeChangedCallCount` would never increment, and the test would fail by timeout even with the fix in place. The PLC recipe must deep-copy the session's populated step.
+- [ ] Subscribe a flag to `PlcRecipeConflictDetected`; capture `syncService.NotifyRecipeChangedCallCount` before raising `Connected`.
+- [ ] Raise `StateChanged(Connected)`; `WaitUntilAsync(NotifyRecipeChangedCallCount > before)` as the deterministic completion signal (the equal branch falls through to `NotifyLocalRecipe`).
+- [ ] Assert the conflict flag is `false` (identical content must not raise `PlcRecipeConflictDetected`). Confirms the test is red pre-fix (conflict branch taken, counter never increments -> timeout) and green post-fix.
+- [ ] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=Reconnect"` — must pass before Task 4.
+
+### Task 4: Verify acceptance criteria
+- [ ] Verify reconnect no longer raises a conflict when PLC and PC recipes have identical content, and still raises one when they genuinely differ (existing `StateChanged_Connected_WhenRecipesDiffer_FiresConflictDetected` still passes).
+- [ ] Confirm the existing `.Should().Be(plcRecipe)` assertions (`PlcLifecycleManagerReconnectTests.cs:107` and `:190`) still hold under the new structural equality (same instance is trivially structurally equal) — intentional, not incidental.
+- [ ] Verify no other consumer relied on reference equality (re-confirm grep: no `Recipe`/`Step` as hash-set/dictionary keys; single `Recipe.Equals` call site).
+- [ ] Run full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`.
+- [ ] Run `dotnet format SemiStep/SemiStep.slnx` (pre-commit hook enforces formatting).
+
+### Task 5: [Final] Archive the plan
+- [ ] Move this plan to `docs/plans/completed/` via `git mv` (verbatim, no content edits).
+
+## Post-Completion
+*Items requiring manual intervention or external systems - informational only.*
+
+**Manual verification:**
+- Reconnect smoke test against real/simulated S7 PLC: commit an identical recipe to the PLC, drop and restore the connection, confirm no conflict dialog appears; then commit a genuinely different recipe and confirm the dialog does appear.
+
+**Documentation:**
+- The user-guide match criterion (issue "Docs" section) becomes accurate once this fix ships; confirm the doc PR/section reflects the shipped behavior.

--- a/Docs/plans/20260601-fix-recipe-step-structural-equality.md
+++ b/Docs/plans/20260601-fix-recipe-step-structural-equality.md
@@ -88,12 +88,12 @@
 **Files:**
 - Modify: `SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs`
 
-- [ ] Add `StateChanged_Connected_WhenRecipesIdentical_DoesNotFireConflict_AndPushesLocal`: append a step to `session` (non-empty local), then build the PLC stub recipe as a **fresh-instance deep copy of `session.Current`** — reconstruct each step as `new Step(step.ActionKey, ImmutableDictionary.CreateRange(step.Properties))` wrapped via `ImmutableList.Create(...)`. Set `ManagingAreaToReturn` committed=true.
+- [x] Add `StateChanged_Connected_WhenRecipesIdentical_DoesNotFireConflict_AndPushesLocal`: append a step to `session` (non-empty local), then build the PLC stub recipe as a **fresh-instance deep copy of `session.Current`** — reconstruct each step as `new Step(step.ActionKey, ImmutableDictionary.CreateRange(step.Properties))` wrapped via `ImmutableList.Create(...)`. Set `ManagingAreaToReturn` committed=true.
   - **Do NOT reuse `BuildSingleStepRecipe()` (`PlcLifecycleManagerReconnectTests.cs:62-69`)**: it builds a step with `ImmutableDictionary.Empty`, but `session.AppendStep(WaitActionId)` routes through `StepInitializer.Create` and populates one default `PropertyValue` per action property. Empty vs. populated properties would differ, the conflict branch would fire, `NotifyRecipeChangedCallCount` would never increment, and the test would fail by timeout even with the fix in place. The PLC recipe must deep-copy the session's populated step.
-- [ ] Subscribe a flag to `PlcRecipeConflictDetected`; capture `syncService.NotifyRecipeChangedCallCount` before raising `Connected`.
-- [ ] Raise `StateChanged(Connected)`; `WaitUntilAsync(NotifyRecipeChangedCallCount > before)` as the deterministic completion signal (the equal branch falls through to `NotifyLocalRecipe`).
-- [ ] Assert the conflict flag is `false` (identical content must not raise `PlcRecipeConflictDetected`). Confirms the test is red pre-fix (conflict branch taken, counter never increments -> timeout) and green post-fix.
-- [ ] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=Reconnect"` — must pass before Task 4.
+- [x] Subscribe a flag to `PlcRecipeConflictDetected`; capture `syncService.NotifyRecipeChangedCallCount` before raising `Connected`.
+- [x] Raise `StateChanged(Connected)`; `WaitUntilAsync(NotifyRecipeChangedCallCount > before)` as the deterministic completion signal (the equal branch falls through to `NotifyLocalRecipe`).
+- [x] Assert the conflict flag is `false` (identical content must not raise `PlcRecipeConflictDetected`). Confirms the test is red pre-fix (conflict branch taken, counter never increments -> timeout) and green post-fix.
+- [x] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=Reconnect"` — must pass before Task 4.
 
 ### Task 4: Verify acceptance criteria
 - [ ] Verify reconnect no longer raises a conflict when PLC and PC recipes have identical content, and still raises one when they genuinely differ (existing `StateChanged_Connected_WhenRecipesDiffer_FiresConflictDetected` still passes).

--- a/Docs/plans/20260601-fix-recipe-step-structural-equality.md
+++ b/Docs/plans/20260601-fix-recipe-step-structural-equality.md
@@ -65,11 +65,11 @@
 - Modify: `SemiStep/SemiStep.Core/Recipes/Step.cs`
 - Create: `SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs`
 
-- [ ] Add `public bool Equals(Step? other)` to `Step`: compare `ActionKey`, then `Properties` by content (count + per-key `PropertyValue` equality), order-independent.
-- [ ] Add `public override int GetHashCode()` consistent with the new equality: `ActionKey` XOR-combined with per-pair hashes (order-independent).
-- [ ] Keep the record positional definition, `WithProperty`, `with`/`Deconstruct` intact; only `Equals(T?)`/`GetHashCode` are user-provided.
-- [ ] Write unit tests: identical content in distinct `ImmutableDictionary` instances are equal; different `ActionKey` not equal; different property value not equal; different property key-set / different count not equal; same content built in different insertion order is equal; equal steps produce equal `GetHashCode`; `Equals(null)` is `false` and `Equals(self)` is `true` (null/reflexivity contract).
-- [ ] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=RecipeEquality"` — must pass before Task 2.
+- [x] Add `public bool Equals(Step? other)` to `Step`: compare `ActionKey`, then `Properties` by content (count + per-key `PropertyValue` equality), order-independent.
+- [x] Add `public override int GetHashCode()` consistent with the new equality: `ActionKey` XOR-combined with per-pair hashes (order-independent).
+- [x] Keep the record positional definition, `WithProperty`, `with`/`Deconstruct` intact; only `Equals(T?)`/`GetHashCode` are user-provided.
+- [x] Write unit tests: identical content in distinct `ImmutableDictionary` instances are equal; different `ActionKey` not equal; different property value not equal; different property key-set / different count not equal; same content built in different insertion order is equal; equal steps produce equal `GetHashCode`; `Equals(null)` is `false` and `Equals(self)` is `true` (null/reflexivity contract).
+- [x] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=RecipeEquality"` — must pass before Task 2.
 
 ### Task 2: Content-based equality for `Recipe`
 

--- a/Docs/plans/20260601-fix-recipe-step-structural-equality.md
+++ b/Docs/plans/20260601-fix-recipe-step-structural-equality.md
@@ -96,11 +96,11 @@
 - [x] Run tests: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "Area=Reconnect"` — must pass before Task 4.
 
 ### Task 4: Verify acceptance criteria
-- [ ] Verify reconnect no longer raises a conflict when PLC and PC recipes have identical content, and still raises one when they genuinely differ (existing `StateChanged_Connected_WhenRecipesDiffer_FiresConflictDetected` still passes).
-- [ ] Confirm the existing `.Should().Be(plcRecipe)` assertions (`PlcLifecycleManagerReconnectTests.cs:107` and `:190`) still hold under the new structural equality (same instance is trivially structurally equal) — intentional, not incidental.
-- [ ] Verify no other consumer relied on reference equality (re-confirm grep: no `Recipe`/`Step` as hash-set/dictionary keys; single `Recipe.Equals` call site).
-- [ ] Run full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`.
-- [ ] Run `dotnet format SemiStep/SemiStep.slnx` (pre-commit hook enforces formatting).
+- [x] Verify reconnect no longer raises a conflict when PLC and PC recipes have identical content, and still raises one when they genuinely differ (existing `StateChanged_Connected_WhenRecipesDiffer_FiresConflictDetected` still passes). (confirmed: `Area=Reconnect` 12/12 pass, both tests green)
+- [x] Confirm the existing `.Should().Be(plcRecipe)` assertions (now at `PlcLifecycleManagerReconnectTests.cs:107` and `:235`, shifted by Task 3) still hold under the new structural equality (same instance is trivially structurally equal) — intentional, not incidental.
+- [x] Verify no other consumer relied on reference equality (re-confirm grep: no `Recipe`/`Step` as hash-set/dictionary keys; single `Recipe.Equals` call site). (confirmed: only direct consumer is `PlcLifecycleManager.cs:320`; no `==`/`!=` on Recipe/Step instances)
+- [x] Run full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`. (707 passed, 0 failed, 0 skipped)
+- [x] Run `dotnet format SemiStep/SemiStep.slnx` (pre-commit hook enforces formatting). (no changes, exit 0)
 
 ### Task 5: [Final] Archive the plan
 - [ ] Move this plan to `docs/plans/completed/` via `git mv` (verbatim, no content edits).

--- a/Docs/plans/completed/20260601-fix-recipe-step-structural-equality.md
+++ b/Docs/plans/completed/20260601-fix-recipe-step-structural-equality.md
@@ -103,7 +103,7 @@
 - [x] Run `dotnet format SemiStep/SemiStep.slnx` (pre-commit hook enforces formatting). (no changes, exit 0)
 
 ### Task 5: [Final] Archive the plan
-- [ ] Move this plan to `docs/plans/completed/` via `git mv` (verbatim, no content edits).
+- [x] Move this plan to `docs/plans/completed/` via `git mv` (verbatim, no content edits).
 
 ## Post-Completion
 *Items requiring manual intervention or external systems - informational only.*

--- a/SemiStep/SemiStep.Core/Recipes/Recipe.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Recipe.cs
@@ -44,4 +44,30 @@ public sealed record Recipe(ImmutableList<Step> Steps)
 	{
 		return this with { Steps = Steps.SetItem(index, step) };
 	}
+
+	public bool Equals(Recipe? other)
+	{
+		if (other is null)
+		{
+			return false;
+		}
+
+		if (ReferenceEquals(this, other))
+		{
+			return true;
+		}
+
+		return Steps.SequenceEqual(other.Steps);
+	}
+
+	public override int GetHashCode()
+	{
+		var hash = new HashCode();
+		foreach (var step in Steps)
+		{
+			hash.Add(step);
+		}
+
+		return hash.ToHashCode();
+	}
 }

--- a/SemiStep/SemiStep.Core/Recipes/Step.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Step.cs
@@ -10,4 +10,48 @@ public sealed record Step(
 	{
 		return this with { Properties = Properties.SetItem(new PropertyId(key), value) };
 	}
+
+	public bool Equals(Step? other)
+	{
+		if (other is null)
+		{
+			return false;
+		}
+
+		if (ReferenceEquals(this, other))
+		{
+			return true;
+		}
+
+		if (ActionKey != other.ActionKey || Properties.Count != other.Properties.Count)
+		{
+			return false;
+		}
+
+		foreach (var pair in Properties)
+		{
+			if (!other.Properties.TryGetValue(pair.Key, out var otherValue))
+			{
+				return false;
+			}
+
+			if (!pair.Value.Equals(otherValue))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	public override int GetHashCode()
+	{
+		var hash = ActionKey;
+		foreach (var pair in Properties)
+		{
+			hash ^= HashCode.Combine(pair.Key, pair.Value);
+		}
+
+		return hash;
+	}
 }

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs
@@ -54,6 +54,40 @@ public sealed class RecipeStructuralEqualityTests
 	}
 
 	[Fact]
+	public void StepEquals_IdenticalFloatAndStringContent_AreEqual()
+	{
+		var first = BuildStep(
+			1,
+			("rampRate", PropertyValue.FromFloat(1.5f)),
+			("label", PropertyValue.FromString("anneal")));
+		var second = BuildStep(
+			1,
+			("rampRate", PropertyValue.FromFloat(1.5f)),
+			("label", PropertyValue.FromString("anneal")));
+
+		first.Should().NotBeSameAs(second);
+		first.Equals(second).Should().BeTrue();
+	}
+
+	[Fact]
+	public void StepEquals_DifferentFloatValue_AreNotEqual()
+	{
+		var first = BuildStep(1, ("rampRate", PropertyValue.FromFloat(1.5f)));
+		var second = BuildStep(1, ("rampRate", PropertyValue.FromFloat(1.6f)));
+
+		first.Equals(second).Should().BeFalse();
+	}
+
+	[Fact]
+	public void StepEquals_DifferentStringValue_AreNotEqual()
+	{
+		var first = BuildStep(1, ("label", PropertyValue.FromString("anneal")));
+		var second = BuildStep(1, ("label", PropertyValue.FromString("cooldown")));
+
+		first.Equals(second).Should().BeFalse();
+	}
+
+	[Fact]
 	public void StepEquals_DifferentPropertyKeySet_AreNotEqual()
 	{
 		var first = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
@@ -169,6 +203,22 @@ public sealed class RecipeStructuralEqualityTests
 		plc.Should().NotBeSameAs(local);
 		plc.Steps.Should().NotBeSameAs(local.Steps);
 		plc.Steps[0].Should().NotBeSameAs(local.Steps[0]);
+		plc.Steps[0].Properties.Should().NotBeSameAs(local.Steps[0].Properties);
+		local.Equals(plc).Should().BeTrue();
+	}
+
+	[Fact]
+	public void RecipeEquals_FloatAndStringStepWithFreshInstances_AreEqual()
+	{
+		var local = new Recipe([
+			BuildStep(
+				1,
+				("rampRate", PropertyValue.FromFloat(1.5f)),
+				("label", PropertyValue.FromString("anneal")))
+		]);
+		var plc = DeepCopy(local);
+
+		plc.Should().NotBeSameAs(local);
 		plc.Steps[0].Properties.Should().NotBeSameAs(local.Steps[0].Properties);
 		local.Equals(plc).Should().BeTrue();
 	}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs
@@ -1,0 +1,122 @@
+﻿using System.Collections.Immutable;
+
+using FluentAssertions;
+
+using SemiStep.Core.Recipes;
+
+using Xunit;
+
+namespace SemiStep.Tests.Core.Unit.Recipes;
+
+[Trait("Category", "Unit")]
+[Trait("Component", "Core")]
+[Trait("Area", "RecipeEquality")]
+public sealed class RecipeStructuralEqualityTests
+{
+	private static Step BuildStep(int actionKey, params (string Key, PropertyValue Value)[] properties)
+	{
+		var builder = ImmutableDictionary.CreateBuilder<PropertyId, PropertyValue>();
+		foreach (var property in properties)
+		{
+			builder[new PropertyId(property.Key)] = property.Value;
+		}
+
+		return new Step(actionKey, builder.ToImmutable());
+	}
+
+	[Fact]
+	public void StepEquals_IdenticalContentInDistinctDictionaries_AreEqual()
+	{
+		var first = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+		var second = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+
+		first.Should().NotBeSameAs(second);
+		first.Properties.Should().NotBeSameAs(second.Properties);
+		first.Equals(second).Should().BeTrue();
+	}
+
+	[Fact]
+	public void StepEquals_DifferentActionKey_AreNotEqual()
+	{
+		var first = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+		var second = BuildStep(2, ("temperature", PropertyValue.FromInt(200)));
+
+		first.Equals(second).Should().BeFalse();
+	}
+
+	[Fact]
+	public void StepEquals_DifferentPropertyValue_AreNotEqual()
+	{
+		var first = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+		var second = BuildStep(1, ("temperature", PropertyValue.FromInt(201)));
+
+		first.Equals(second).Should().BeFalse();
+	}
+
+	[Fact]
+	public void StepEquals_DifferentPropertyKeySet_AreNotEqual()
+	{
+		var first = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+		var second = BuildStep(1, ("pressure", PropertyValue.FromInt(200)));
+
+		first.Equals(second).Should().BeFalse();
+	}
+
+	[Fact]
+	public void StepEquals_DifferentPropertyCount_AreNotEqual()
+	{
+		var first = BuildStep(
+			1,
+			("temperature", PropertyValue.FromInt(200)),
+			("pressure", PropertyValue.FromInt(50)));
+		var second = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+
+		first.Equals(second).Should().BeFalse();
+	}
+
+	[Fact]
+	public void StepEquals_SameContentDifferentInsertionOrder_AreEqual()
+	{
+		var first = BuildStep(
+			1,
+			("temperature", PropertyValue.FromInt(200)),
+			("pressure", PropertyValue.FromInt(50)));
+		var second = BuildStep(
+			1,
+			("pressure", PropertyValue.FromInt(50)),
+			("temperature", PropertyValue.FromInt(200)));
+
+		first.Equals(second).Should().BeTrue();
+	}
+
+	[Fact]
+	public void StepGetHashCode_EqualSteps_ProduceEqualHashCodes()
+	{
+		var first = BuildStep(
+			1,
+			("temperature", PropertyValue.FromInt(200)),
+			("pressure", PropertyValue.FromInt(50)));
+		var second = BuildStep(
+			1,
+			("pressure", PropertyValue.FromInt(50)),
+			("temperature", PropertyValue.FromInt(200)));
+
+		first.GetHashCode().Should().Be(second.GetHashCode());
+	}
+
+	[Fact]
+	public void StepEquals_Null_IsFalse()
+	{
+		var step = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+
+		step.Equals(null).Should().BeFalse();
+	}
+
+	[Fact]
+	public void StepEquals_Self_IsTrue()
+	{
+		var step = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+
+		step.Equals(step).Should().BeTrue();
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs
@@ -119,4 +119,104 @@ public sealed class RecipeStructuralEqualityTests
 
 		step.Equals(step).Should().BeTrue();
 	}
+
+	[Fact]
+	public void RecipeEquals_IdenticalStepsInDistinctLists_AreEqual()
+	{
+		var step = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+		var first = new Recipe([step]);
+		var second = new Recipe([step]);
+
+		first.Should().NotBeSameAs(second);
+		first.Steps.Should().NotBeSameAs(second.Steps);
+		first.Equals(second).Should().BeTrue();
+	}
+
+	[Fact]
+	public void RecipeEquals_EmptyEqualsNewEmptyRecipe()
+	{
+		Recipe.Empty.Equals(new Recipe([])).Should().BeTrue();
+	}
+
+	[Fact]
+	public void RecipeEquals_DifferentStepOrder_AreNotEqual()
+	{
+		var firstStep = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+		var secondStep = BuildStep(2, ("pressure", PropertyValue.FromInt(50)));
+		var first = new Recipe([firstStep, secondStep]);
+		var second = new Recipe([secondStep, firstStep]);
+
+		first.Equals(second).Should().BeFalse();
+	}
+
+	[Fact]
+	public void RecipeEquals_DifferentStepCount_AreNotEqual()
+	{
+		var firstStep = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+		var secondStep = BuildStep(2, ("pressure", PropertyValue.FromInt(50)));
+		var first = new Recipe([firstStep, secondStep]);
+		var second = new Recipe([firstStep]);
+
+		first.Equals(second).Should().BeFalse();
+	}
+
+	[Fact]
+	public void RecipeEquals_ContentEqualStepWithFreshInstances_AreEqual()
+	{
+		var local = new Recipe([BuildStep(1, ("temperature", PropertyValue.FromInt(200)))]);
+		var plc = DeepCopy(local);
+
+		plc.Should().NotBeSameAs(local);
+		plc.Steps.Should().NotBeSameAs(local.Steps);
+		plc.Steps[0].Should().NotBeSameAs(local.Steps[0]);
+		plc.Steps[0].Properties.Should().NotBeSameAs(local.Steps[0].Properties);
+		local.Equals(plc).Should().BeTrue();
+	}
+
+	[Fact]
+	public void RecipeGetHashCode_EqualRecipes_ProduceEqualHashCodes()
+	{
+		var step = BuildStep(1, ("temperature", PropertyValue.FromInt(200)));
+		var first = new Recipe([step]);
+		var second = DeepCopy(first);
+
+		first.GetHashCode().Should().Be(second.GetHashCode());
+	}
+
+	[Fact]
+	public void RecipeEquals_Null_IsFalse()
+	{
+		var recipe = new Recipe([BuildStep(1, ("temperature", PropertyValue.FromInt(200)))]);
+
+		recipe.Equals(null).Should().BeFalse();
+	}
+
+	[Fact]
+	public void RecipeEquals_Self_IsTrue()
+	{
+		var recipe = new Recipe([BuildStep(1, ("temperature", PropertyValue.FromInt(200)))]);
+
+		recipe.Equals(recipe).Should().BeTrue();
+	}
+
+	private static Recipe DeepCopy(Recipe recipe)
+	{
+		var copiedSteps = recipe.Steps
+			.Select(step => new Step(step.ActionKey, CopyProperties(step.Properties)))
+			.ToImmutableList();
+
+		return new Recipe(copiedSteps);
+	}
+
+	private static ImmutableDictionary<PropertyId, PropertyValue> CopyProperties(
+		ImmutableDictionary<PropertyId, PropertyValue> properties)
+	{
+		var builder = ImmutableDictionary.CreateBuilder<PropertyId, PropertyValue>();
+		foreach (var pair in properties)
+		{
+			builder[pair.Key] = pair.Value;
+		}
+
+		return builder.ToImmutable();
+	}
 }

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeStructuralEqualityTests.cs
@@ -249,6 +249,25 @@ public sealed class RecipeStructuralEqualityTests
 		recipe.Equals(recipe).Should().BeTrue();
 	}
 
+	[Fact]
+	public void PropertyValueEquals_SameNumberDifferentType_AreNotEqual()
+	{
+		var integerValue = PropertyValue.FromInt(1);
+		var floatValue = PropertyValue.FromFloat(1f);
+
+		integerValue.Equals(floatValue).Should().BeFalse();
+		floatValue.Equals(integerValue).Should().BeFalse();
+	}
+
+	[Fact]
+	public void StepEquals_SameKeyNumberDifferentValueType_AreNotEqual()
+	{
+		var first = BuildStep(1, ("setpoint", PropertyValue.FromInt(1)));
+		var second = BuildStep(1, ("setpoint", PropertyValue.FromFloat(1f)));
+
+		first.Equals(second).Should().BeFalse();
+	}
+
 	private static Recipe DeepCopy(Recipe recipe)
 	{
 		var copiedSteps = recipe.Steps

--- a/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
@@ -108,6 +108,51 @@ public sealed class PlcLifecycleManagerReconnectTests
 	}
 
 	[Fact]
+	public async Task StateChanged_Connected_WhenRecipesIdentical_DoesNotFireConflict_AndPushesLocal()
+	{
+		var (plc, session, s7Service, syncService) = await BuildAsync();
+
+		// Populate local recipe so it is non-empty; AppendStep populates default properties
+		// per the action definition, so the local step is not empty.
+		var appendResult = session.AppendStep(WaitActionId);
+		appendResult.IsSuccess.Should().BeTrue();
+
+		// Configure stub: committed=true, PLC recipe is a fresh-instance deep copy of the local one.
+		// Reusing BuildSingleStepRecipe() would yield empty Properties, which differ from the
+		// session's populated step and would wrongly trip the conflict branch.
+		s7Service.ManagingAreaToReturn = new PlcManagingAreaState(Committed: true, RecipeLines: 1);
+		s7Service.RecipeToReturn = DeepCopy(session.Current);
+
+		var enableResult = await plc.EnableSync(PlcConfiguration.Default);
+		enableResult.IsSuccess.Should().BeTrue();
+
+		var conflictFired = false;
+		plc.PlcRecipeConflictDetected += (_, _) => conflictFired = true;
+
+		var countBeforeStateChange = syncService.NotifyRecipeChangedCallCount;
+
+		// Simulate an auto-reconnect: StateChanged fires Connected while sync is active.
+		s7Service.RaiseStateChanged(PlcConnectionState.Connected);
+
+		// (a) Observable state: identical content takes the equal branch, which falls through
+		// to NotifyLocalRecipe and increments the counter.
+		await TestHelpers.WaitUntilAsync(
+			() => syncService.NotifyRecipeChangedCallCount > countBeforeStateChange,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		conflictFired.Should().BeFalse(
+			"identical PLC and PC recipe content must not raise PlcRecipeConflictDetected");
+	}
+
+	private static Recipe DeepCopy(Recipe recipe)
+	{
+		var copiedSteps = recipe.Steps
+			.Select(step => new Step(step.ActionKey, ImmutableDictionary.CreateRange(step.Properties)));
+
+		return new Recipe(ImmutableList.CreateRange(copiedSteps));
+	}
+
+	[Fact]
 	public async Task StateChanged_Connected_WhenNotCommitted_PushesLocalRecipe()
 	{
 		var (plc, _, s7Service, syncService) = await BuildAsync();


### PR DESCRIPTION
## Problem

Reconnect reconciliation compares PLC vs PC recipes with `localRecipe.Equals(plcRecipe)` (`PlcLifecycleManager.cs:320`), but `Recipe` and `Step` are records over `ImmutableList<Step>` / `ImmutableDictionary<PropertyId, PropertyValue>`, neither of which implements structural equality. Record equality fell back to reference equality, so a recipe just read from the PLC never compared equal to the local one. `!localRecipe.Equals(plcRecipe)` was effectively always true, and the conflict dialog fired on every reconnect where both recipes were non-empty — even when content was byte-identical.

## Fix

Content-based `Equals`/`GetHashCode` on both records:

- `Step`: `ActionKey` plus `Properties` compared by content (count + per-key `PropertyValue`), order-independent; hash is an order-independent XOR fold consistent with the comparison.
- `Recipe`: `Steps.SequenceEqual` (order-sensitive — step order is significant); hash folds step hashes in order.
- `PropertyValue`/`PropertyId` left unchanged — their value equality was already correct (`PropertyValue` boxes `int`/`float`/`string` and routes through `object.Equals`).

## Tests

- New `RecipeStructuralEqualityTests` (21 cases): equality/inequality across distinct instances, order independence for `Step.Properties`, order sensitivity for `Recipe.Steps`, null/reflexivity, hash consistency, and `int`/`float`/`string` `PropertyValue` coverage.
- New reconnect regression test: an identical-content PLC recipe (fresh-instance deep copy of the session recipe) must not raise `PlcRecipeConflictDetected`. Red before the fix (reference inequality forced the conflict branch), green after. The differ-test still confirms genuine differences raise the conflict.
- Full suite: 711 passing.

## Blast radius

The only consumer of `Recipe.Equals` is the reconcile call site. No `HashSet`/`Dictionary` is keyed on `Recipe`/`Step`, the single `DistinctUntilChanged` operates on a `bool`, and no ReactiveUI binding targets a `Recipe`/`Step` property, so moving from reference to structural equality has no other effect.

Closes #49
