### PR TITLE
feat: single-writer PLC sync ownership across app instances (issue #48)

### DIFF
--- a/Docs/plans/20260601-plc-write-concurrency-protection.md
+++ b/Docs/plans/20260601-plc-write-concurrency-protection.md
@@ -1,0 +1,375 @@
+# PLC Write Concurrency Protection (issue #48)
+
+## Overview
+
+Issue #48 reports that two concurrent writers to the same PLC can interleave the
+`committed = false → data → recipe_lines → committed = true` sequence and leave a
+corrupted recipe in the PLC.
+
+Investigation established two distinct, separately-reachable failure modes:
+
+1. **Cross-process (the reachable form of #48).** The app is single-window-per-process
+   (`App.EnsureSingleStart`), and in-process writes are already serialized
+   (`PlcSyncExecutor` is the only writer and queues rather than parallelizes). The real
+   reachable race is **two app instances on one machine** both enabling PLC sync against
+   the same PLC: each process opens its own independent S7 connection with zero
+   cross-process arbitration. The design intent is that only one instance may sync to the
+   PLC at a time; the rest are local-only editors. This is foolproofing, not a security
+   boundary.
+
+2. **In-process transport interleaving (adjacent finding).** Within the single syncing
+   process, several background tasks share the **one** `S7.Net.Plc` TCP connection with no
+   transport-level lock: the execution monitor poll loop reads, the keep-alive loop reads,
+   the reader paths (reconnect reconciliation, read-from-PLC) read, and the sync executor
+   writes. Concurrent request/response round-trips on one socket can corrupt PDU framing.
+   This is a different bug from #48 and was discovered during investigation.
+
+The work is split into **two PRs** (one logical change each, per the project git
+workflow), implemented back-to-back:
+
+- **PR1 — cross-process sync ownership** via an exclusive OS file lock.
+- **PR2 — in-process transport serialization** via a per-round-trip gate in the driver.
+
+A finding documenting failure mode 2 is also posted to issue #48 during the work.
+
+## Context (from discovery)
+
+- Single PLC writer path in production: `PlcSyncExecutor.WriteSyncAsync` →
+  `PlcTransactionExecutor.WriteRecipeWithRetryAsync` (`PlcTransactionExecutor.cs:109`).
+- Sync enable/disable chokepoint: `PlcLifecycleManager.EnableSync` (`PlcLifecycleManager.cs:97-124`),
+  which couples `ConnectAsync` with sync; release points: `DisableSync` (`:149`),
+  `FailProtocolVersionHandshakeAsync` (`:143`), `Dispose` (`:72`).
+- "Window" in this codebase == app **instance/process**: `App.EnsureSingleStart`
+  (`App.axaml.cs:129`) allows one window per process; VMs are singletons (`UiDi.cs`); the
+  per-window edit/connect plan (`Docs/plans/completed/20260520-per-window-edit-connect-mode.md`)
+  treats windows as independent because each is a separate process. A refused instance
+  stays sync-disabled, so `RecipeCoordinator.CanEditRecipe` keeps it a full local editor.
+- UI already handles `EnableSync` failure: `MainWindowViewModel.ExecuteToggleSyncAsync`
+  reports `Result.Fail` via `MessagePanel.ReportError` and leaves the toggle off
+  (`MainWindowViewModel.cs:139-144`). No UI rework needed beyond message text.
+- `PlcConnectionSettings(IpAddress, Port, Rack, Slot)` (`PlcConnectionSettings.cs`) — the
+  ownership key.
+- DI: `PlcLifecycleManager` registered in `RecipeDi.cs:21`; S7 stack in `S7Di.cs`.
+- **All in-process socket users funnel through one `S7Driver` singleton**, reached via two
+  interfaces (both registered to the same instance, `S7Di.cs:16-17`):
+  - `IS7Transport`: `PlcTransactionExecutor` (`PlcTransactionExecutor.cs:25`) — covers the
+    monitor read (`PlcExecutionMonitor.PollLoopAsync` → `ReadExecutionStateAsync`,
+    read at `PlcExecutionMonitor.cs:104`), the sync write (`PlcSyncExecutor.StartDebounce`
+    → `PlcTransactionExecutor.WriteRecipeDataAsync`, `PlcTransactionExecutor.cs:236-269`),
+    and the reader paths (`ReadRecipeFromPlcAsync`/`ReadManagingAreaAsync`/
+    `ReadProtocolVersionAsync`).
+  - `IS7Driver`: `S7Service` (`S7Service.cs:13`) — the **keep-alive loop**
+    (`S7Service.KeepAliveLoopAsync`, `S7Service.cs:229-253`) reads 1 byte of `ManagingDb`
+    via `transport.ReadBytesAsync` (`S7Service.cs:239`). `ManagingDb` IS mutated by the
+    writer (`PlcTransactionExecutor.WriteManagingAreaAsync`, `:282-303`).
+- Tests: `SemiStep.Tests/Domain/` (`PlcLifecycleManagerReconnectTests.cs` uses
+  `[Trait("Component","Domain")]`, `[Trait("Category","Integration")]`),
+  `SemiStep.Tests/S7/`. Traits: `[Trait("Component","S7|Core|Domain")]`,
+  `[Trait("Category","Unit|Integration")]`.
+
+## Development Approach
+
+- **Testing approach: Regular** (implement, then write tests in the same task) — matches
+  project convention.
+- Complete each task fully before the next; all tests pass before moving on.
+- Small, focused changes; constructor injection; `var`; UTC timestamps; FluentResults for
+  fallible operations (refusal is `Result.Fail`, not an exception).
+- `dotnet format SemiStep/SemiStep.slnx` before any commit (pre-commit hook).
+- New files are auto-included (SDK-style projects); no manual csproj edits.
+- **Each task MUST include new/updated tests** covering success and failure paths.
+
+## Testing Strategy
+
+- **Unit tests:**
+  - (Component=S7) Endpoint-token builder produces a stable, filesystem-safe token from
+    `PlcConnectionSettings`.
+  - (Component=Domain) `PlcLifecycleManager.EnableSync` with a mocked `IPlcSyncOwnership`:
+    acquire succeeds → proceeds to connect; acquire refused → returns `Result.Fail`
+    carrying owner info and does **not** connect / does not set sync enabled;
+    `DisableSync` / failed handshake / `Dispose` release the lease exactly once
+    (idempotent). Tests live next to `PlcLifecycleManagerReconnectTests.cs` and reuse its
+    `[Trait("Component","Domain")]`.
+  - (Component=S7) `TransportSerializer`: concurrent operations never overlap (probe
+    delegate records max concurrency == 1); a `WaitAsync` canceled before entry does not
+    `Release` (no `SemaphoreFullException`); throwing operations still release the gate.
+- **Integration tests (Component=S7, Category=Integration):**
+  - Real `FileSyncOwnership` with an injected temp lock root (no real `%ProgramData%`
+    writes): first `TryAcquire` succeeds; a second `TryAcquire` for the same endpoint is
+    refused while the first lease is held; after disposing the first, re-acquire succeeds.
+  - Owner metadata written by the holder is readable by the refused caller.
+  - Lease double-dispose is safe (idempotent).
+  - Acquire when the lock file/dir is inaccessible (`UnauthorizedAccessException`) returns
+    a refusal `Result.Fail`, not an unhandled throw.
+
+## Progress Tracking
+
+- Mark completed items `[x]` immediately. Add discovered tasks with ➕. Blockers with ⚠️.
+- Keep this plan in sync if scope changes.
+
+## Solution Overview
+
+**PR1 — cross-process ownership (file lock).** A small Core service `IPlcSyncOwnership`
+with one production implementation `FileSyncOwnership`. Acquisition opens a dedicated
+lock file (`FileMode.Create`, `FileAccess.ReadWrite`, `FileShare.Read` — see the Task 2
+note for why `FileShare.Read` rather than `FileShare.None`); the open **is** the atomic
+test-and-set (no TOCTOU). The
+handle is held for the whole ownership lifetime in the returned `ISyncOwnershipLease`;
+disposing it closes the handle. Chosen over named `Mutex` (thread-affine — breaks
+acquire-on-one-thread / release-on-another across `await`), named `Semaphore` (leaks the
+permit on crash — not crash-safe), and `EventWaitHandle`/PID-file/PLC-flag (no atomic
+ownership / TOCTOU). The file lock is crash-safe because Windows closes the process's
+handles on termination, releasing the lock with no manual cleanup. Scope is **machine-wide**:
+the lock file lives under `%ProgramData%\SemiStep\locks\`, keyed by the PLC endpoint, so a
+second Windows user/RDP session cannot become a second writer.
+
+`PlcLifecycleManager` acquires the lease at the start of `EnableSync` (before
+`ConnectAsync`); on refusal it returns `Result.Fail` with the current owner's metadata and
+does not connect. It releases the lease in `DisableSync`, in the failed-handshake rollback,
+and in `Dispose`, guarding against double-release. The UI surfaces the refusal message via
+the existing `MessagePanel.ReportError` path.
+
+`TryAcquire` is **synchronous** (opening a file handle does no awaitable work) to avoid
+fake-async; it is called from the async `EnableSync` without issue.
+
+**PR2 — in-process transport serialization.** First confirm whether `S7.Net.Plc` already
+serializes calls internally. If not, place a `SemaphoreSlim(1,1)` **inside `S7Driver`**
+(extracted into a tiny `TransportSerializer` helper that the driver delegates to), gating
+every `ReadBytesAsync`/`WriteBytesAsync` round-trip.
+
+The gate must live in `S7Driver`, not in a decorator over `IS7Transport`: every socket user
+reaches the single `S7Driver` singleton, but through **two** interfaces — `IS7Transport`
+(the executor: monitor reads, sync writes, reader paths) and `IS7Driver` (the keep-alive
+read). A decorator on `IS7Transport` alone would miss the keep-alive path. Putting the gate
+in `S7Driver` covers all of them.
+
+Granularity and scope (explicit, answering the design question): per-round-trip locking
+fixes **PDU-framing corruption only**. It intentionally does **not** make the multi-round-trip
+write transaction (`PlcTransactionExecutor.WriteRecipeDataAsync`, `:236-269`) atomic with
+respect to concurrent reads. That is acceptable because:
+- cross-process arbitration is handled by PR1; and
+- a mid-transaction reader degrades gracefully: `ReadRecipeFromPlcAsync` checks the
+  `committed` flag first and bails when it is `false` (`PlcTransactionExecutor.cs:203-206`),
+  and the writer sets `committed = false` at the very start of the sequence (`:240-241`), so
+  an interleaving read sees `committed = false` and returns "not committed" rather than a
+  half-written mix; the keep-alive read fetches 1 byte and discards it (harmless).
+
+The `TransportSerializer` is unit-testable on its own (probe delegate asserting no overlap,
+cancellation, and exception-path release) without needing a test seam under `S7.Net.Plc`.
+
+## Technical Details
+
+- **Ownership contracts (Core, `SemiStep.Core/Plc/Sync/Ownership/`, namespace
+  `SemiStep.Core.Plc.Sync.Ownership`; imports `PlcConnectionSettings` from
+  `SemiStep.Core.Plc.Configuration`):**
+  - `interface IPlcSyncOwnership { Result<ISyncOwnershipLease> TryAcquire(PlcConnectionSettings endpoint); }`
+  - `interface ISyncOwnershipLease : IDisposable { OwnerInfo Owner { get; } }` (sync
+    `IDisposable` — closing a `FileStream` is synchronous and cheap, keeping
+    `PlcLifecycleManager.Dispose` simple; `Dispose` is idempotent).
+  - `record OwnerInfo(int ProcessId, string MachineName, string UserName, DateTimeOffset AcquiredUtc)`.
+- **`FileSyncOwnership`:** lock root defaults to
+  `Path.Combine(Environment.GetFolderPath(SpecialFolder.CommonApplicationData), "SemiStep", "locks")`;
+  the root is injectable (constructor parameter) so tests use a temp dir. File name:
+  `plc-sync-<token>.lock`, token = sanitized `{IpAddress}_{Port}_{Rack}_{Slot}`. On
+  `TryAcquire`: ensure root exists with a machine-wide ACL (see Task 2), open
+  `FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.Read)` (see the Task 2
+  note for the `FileShare.Read` rationale), write `OwnerInfo` (UTF-8 JSON) and flush; on
+  `IOException`, open the file `FileShare.ReadWrite` read-only to parse the current
+  `OwnerInfo` and return `Result.Fail` carrying it (or a generic refusal if the metadata is
+  empty/corrupt); on `UnauthorizedAccessException` (ACL-blocked open), return a refusal
+  `Result.Fail` (treated as "owned/unavailable", never an unhandled throw).
+- **`TransportSerializer` (Core, alongside `S7Driver`):** wraps a `SemaphoreSlim(1,1)`;
+  exposes `Task RunAsync(Func<Task> op, CancellationToken ct)` and
+  `Task<T> RunAsync<T>(Func<Task<T>> op, CancellationToken ct)`. Pattern:
+  `await _gate.WaitAsync(ct);` **outside** the try, then `try { return await op(); } finally { _gate.Release(); }`
+  so a canceled acquire never reaches `Release`. Disposed with the driver.
+- **Refusal message:** `PlcLifecycleManager` maps the failed `Result` to a message like
+  `"PLC sync is owned by another instance (user {UserName}, since {AcquiredUtc:HH:mm} UTC)"`.
+
+## What Goes Where
+
+- **Implementation Steps** (checkboxes): all code, tests, the issue-#48 finding comment
+  (doable in-session via `gh`).
+- **Post-Completion** (no checkboxes): two-instance manual verification (needs a real
+  second process and ideally a PLC), and any installer-time ACL provisioning if runtime
+  ACL setup proves insufficient.
+
+## Implementation Steps
+
+### PR1 — Cross-process PLC sync ownership
+
+#### Task 1: Define ownership contracts and endpoint-token builder
+
+**Files:**
+- Create: `SemiStep/SemiStep.Core/Plc/Sync/Ownership/IPlcSyncOwnership.cs`
+- Create: `SemiStep/SemiStep.Core/Plc/Sync/Ownership/ISyncOwnershipLease.cs`
+- Create: `SemiStep/SemiStep.Core/Plc/Sync/Ownership/OwnerInfo.cs`
+- Create: `SemiStep/SemiStep.Core/Plc/Sync/Ownership/SyncOwnershipEndpointToken.cs`
+- Create: `SemiStep/SemiStep.Tests/S7/SyncOwnershipEndpointTokenTests.cs`
+
+- [x] Define `IPlcSyncOwnership` with `Result<ISyncOwnershipLease> TryAcquire(PlcConnectionSettings endpoint)`.
+- [x] Define `ISyncOwnershipLease : IDisposable` exposing `OwnerInfo Owner`.
+- [x] Define `OwnerInfo` record (ProcessId, MachineName, UserName, AcquiredUtc).
+- [x] Implement `SyncOwnershipEndpointToken.For(PlcConnectionSettings)` (static helper, no
+      interface — single pure function) producing a stable, filesystem-safe token.
+- [x] Write tests: token is deterministic, stable across calls, and contains no
+      path-invalid characters for representative endpoints.
+- [x] Run tests — must pass before next task.
+
+#### Task 2: Implement `FileSyncOwnership`
+
+**Files:**
+- Create: `SemiStep/SemiStep.Core/Plc/Sync/Ownership/FileSyncOwnership.cs`
+- Create: `SemiStep/SemiStep.Core/Plc/Sync/Ownership/FileSyncOwnershipLease.cs`
+- Create: `SemiStep/SemiStep.Tests/S7/FileSyncOwnershipTests.cs`
+
+- [x] Implement `FileSyncOwnership` with an injectable lock-root path (default
+      `%ProgramData%\SemiStep\locks`); `TryAcquire` opens `FileShare.Read` (see note),
+      writes `OwnerInfo`, returns a lease holding the open `FileStream`.
+- [x] On `IOException`, read the holder's `OwnerInfo` (open `FileShare.ReadWrite`,
+      read-only) and return `Result.Fail` carrying it (`OwnedByAnotherInstanceError`); if
+      metadata is unreadable, fail with a generic "owned by another instance" message.
+- [x] On `UnauthorizedAccessException`, return a refusal `Result.Fail` (do not let it
+      propagate as an unhandled throw).
+- [x] Decide and implement ACL provisioning (first-class, not deferred): on first use,
+      create the lock root and grant `Users: Modify` so a different Windows user can open the
+      file. `DirectoryInfo` ACL APIs (`GetAccessControl`/`SetAccessControl`,
+      `DirectorySecurity`, `FileSystemAccessRule`, `SecurityIdentifier`) resolve on `net10.0`
+      from the shared framework — **no** `System.IO.FileSystem.AccessControl` package needed;
+      csproj unchanged. ACL is gated by `OperatingSystem.IsWindows()` and is best-effort
+      (`SyncLockRootProvisioner`): if it fails, the `UnauthorizedAccessException` → refusal
+      mapping keeps the cross-user case a clean refusal rather than a crash.
+- [x] Implement `FileSyncOwnershipLease.Dispose` to close the handle (any thread) and be
+      **idempotent** (guard a `_disposed` flag).
+- [x] Write integration tests (temp lock root): acquire → second acquire refused while held
+      → dispose → re-acquire succeeds; refused caller reads holder `OwnerInfo`; double-dispose
+      is safe; inaccessible path → refusal `Result.Fail`.
+- [x] Run tests — must pass before next task.
+
+> Note (`FileShare`): the holder opens with `FileShare.Read`, not `FileShare.None`. A
+> `FileShare.None` holder denies all sharing, so the refused caller could not open the file
+> to read holder `OwnerInfo`, defeating the "refused caller reads holder OwnerInfo"
+> requirement. `FileShare.Read` still denies a second writer (a second `TryAcquire` requests
+> `FileAccess.ReadWrite`, which the holder's read-only share mode rejects with `IOException`),
+> so the test-and-set remains atomic and exclusive for write access, while metadata readers
+> (`FileAccess.Read` + `FileShare.ReadWrite`) succeed.
+
+#### Task 3: Wire ownership into `PlcLifecycleManager` and DI
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs`
+- Modify: `SemiStep/SemiStep.Core/Plc/S7/S7Di.cs`
+- Create: `SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerOwnershipTests.cs`
+
+- [x] Inject `IPlcSyncOwnership` into `PlcLifecycleManager`; hold the `ISyncOwnershipLease`
+      in a field.
+- [x] In `EnableSync`: call `TryAcquire(config.Connection)` **before** `ConnectAsync`; on
+      failure return `Result.Fail` with the owner-info message and do not connect or set
+      sync enabled.
+- [x] Release the lease in `DisableSync`, `FailProtocolVersionHandshakeAsync`, and `Dispose`
+      (release at most once; guard against double-release).
+- [x] Register `IPlcSyncOwnership` → `FileSyncOwnership` as a singleton in `S7Di`.
+- [x] Write tests (mock `IPlcSyncOwnership`, `[Trait("Component","Domain")]` to match the
+      sibling file): success path acquires then connects; refusal path returns `Fail` with
+      owner message and skips connect (`IsSyncEnabled == false`); disable / failed-handshake /
+      dispose release the lease exactly once.
+- [x] Run tests — must pass before next task.
+
+#### Task 4: PR1 close-out
+
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green (710 passed, 0 failed, 0 skipped).
+- [x] `dotnet format SemiStep/SemiStep.slnx` — clean, no changes (verify-no-changes exit 0).
+- [x] Confirm PR1 scope contains only ownership changes (no PR2 transport edits). Verified
+      via `git diff origin/master...HEAD --stat`: only the plan doc, the new
+      `SemiStep.Core/Plc/Sync/Ownership/*` files (`IPlcSyncOwnership.cs`,
+      `ISyncOwnershipLease.cs`, `OwnerInfo.cs`, `OwnedByAnotherInstanceError.cs`,
+      `SyncOwnershipEndpointToken.cs`, `FileSyncOwnership.cs`, `FileSyncOwnershipLease.cs`,
+      `SyncLockRootProvisioner.cs`), `PlcLifecycleManager.cs`, `S7/S7Di.cs`, and test
+      files/helpers (`Domain/PlcLifecycleManagerOwnershipTests.cs`,
+      `S7/FileSyncOwnershipTests.cs`, `S7/SyncOwnershipEndpointTokenTests.cs`,
+      `Helpers/StubPlcSyncOwnership.cs`, `Helpers/StubSyncOwnershipLease.cs`,
+      `Helpers/StubS7Service.cs`, plus trait/helper touch-ups in
+      `Core/Helpers/CoreTestHelper.cs`, `Csv/Helpers/CsvTestHelper.cs`,
+      `Domain/PlcLifecycleManagerReconnectTests.cs`,
+      `UI/RecipeCoordinatorLoadRecipeTests.cs`, `UI/RecipeCoordinatorSaveGateTests.cs`).
+      No `S7Driver.cs` / `TransportSerializer.cs` / transport edits present.
+
+### Finding on issue #48
+
+#### Task 5: Document the in-process transport race as a finding
+
+- [ ] Post a comment on issue #48 (via `gh issue comment 48`) describing failure mode 2
+      (monitor read, keep-alive `ManagingDb` read, and reader paths interleaving with the
+      sync write on one `S7.Net.Plc` socket), noting it is distinct from the cross-process
+      race and is addressed in PR2. (User-approved external action.)
+
+### PR2 — In-process transport serialization
+
+#### Task 6: Confirm `S7.Net.Plc` threading and serialize transport round-trips
+
+**Files:**
+- Create: `SemiStep/SemiStep.Core/Plc/S7/TransportSerializer.cs`
+- Modify: `SemiStep/SemiStep.Core/Plc/S7/S7Driver.cs`
+- Create: `SemiStep/SemiStep.Tests/S7/TransportSerializerTests.cs`
+
+- [ ] Inspect the `S7.Net` package sources to confirm whether `Plc` already serializes
+      concurrent read/write on one connection; record the finding in this plan.
+- [ ] If not serialized: implement `TransportSerializer` (a `SemaphoreSlim(1,1)` with
+      `RunAsync(Func<Task>, ct)` / `RunAsync<T>(Func<Task<T>>, ct)`; `WaitAsync(ct)` outside
+      the try, `Release()` in `finally`).
+- [ ] In `S7Driver`, route every `ReadBytesAsync` and `WriteBytesAsync` round-trip through
+      the `TransportSerializer` (this covers both the `IS7Transport` and `IS7Driver`
+      consumers, since both resolve to the one `S7Driver` instance). Keep the existing
+      `ct.ThrowIfCancellationRequested()` semantics; decide whether the pre-check sits
+      before or after the gate wait and document it.
+- [ ] Dispose the `SemaphoreSlim` with the driver; ensure the cancellation path never leaks
+      or over-releases a slot.
+- [ ] Write tests for `TransportSerializer`: concurrent ops never overlap (max concurrency
+      == 1 via a probe delegate); a wait canceled before entry does not `Release`; a throwing
+      op still releases the gate.
+- [ ] Run tests — must pass before next task.
+
+#### Task 7: PR2 close-out
+
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green.
+- [ ] `dotnet format SemiStep/SemiStep.slnx`.
+- [ ] Confirm PR2 scope contains only transport-serialization changes.
+
+### Task 8: Verify acceptance criteria
+
+- [ ] Second instance enabling sync against the same PLC is refused with an owner-info
+      message and remains a local editor (covered by ownership tests).
+- [ ] Lease released on disable / failed handshake / dispose (no orphaned lock between
+      runs of the same process); double-release and double-dispose are safe.
+- [ ] Cross-user case (inaccessible lock file) degrades to a clean refusal, not a crash.
+- [ ] All transport round-trips (monitor read, keep-alive read, reader paths, sync write)
+      are serialized within one process (covered by `TransportSerializer` tests).
+- [ ] Full test suite green; `dotnet format` clean.
+
+### Task 9: Documentation and close-out
+
+- [ ] Update `Docs/*` user guide if the "PLC busy in another instance" behavior is
+      user-visible and warrants a note.
+- [ ] Update `CLAUDE.md` only if a genuinely new, reusable pattern emerged.
+- [ ] Move this plan to `Docs/plans/completed/`.
+
+## Post-Completion
+
+*Manual / external — informational only.*
+
+**Manual verification:**
+- Launch two instances on one machine pointed at the same PLC. Enable sync in instance A;
+  attempt to enable sync in instance B — B is refused with the owner-info message and stays
+  a local editor. Disable sync in A; B can now enable sync. Kill A while it holds sync
+  (Task Manager) — B can enable sync without reboot/manual cleanup (crash-safety).
+- If feasible, two different Windows users on one machine: only one can hold sync
+  (validates the machine-wide `%ProgramData%` scope and ACL).
+
+**External provisioning (only if runtime ACL proves insufficient):**
+- Provision `%ProgramData%\SemiStep\locks` with a Users:Modify ACL at install time so all
+  accounts can open the lock file.
+
+**Out of scope (by design):**
+- Two **different physical machines** syncing one PLC — a local file lock cannot coordinate
+  across machines; that would require PLC-side arbitration. Recorded as a known limitation.
+- Making the multi-round-trip write transaction atomic w.r.t. concurrent reads — not needed
+  (PR1 handles cross-process; the `committed` gate makes mid-transaction reads bail safely).

--- a/SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs
+++ b/SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.S7.Protocol;
 using SemiStep.Core.Plc.State;
+using SemiStep.Core.Plc.Sync.Ownership;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Helpers;
 
@@ -20,10 +21,12 @@ public sealed class PlcLifecycleManager : IDisposable
 	private readonly object _pendingLock = new();
 	private readonly IS7Reader _reader;
 	private readonly RecipeSession _session;
+	private readonly IPlcSyncOwnership _syncOwnership;
 	private readonly IPlcSyncService _syncService;
 	private Action<PlcConnectionState>? _connectionStateHandler;
 	private bool _disposed;
 	private bool _initialized;
+	private ISyncOwnershipLease? _ownershipLease;
 	private Recipe? _pendingPlcRecipe;
 	private Func<Recipe, Task<Result>>? _reconnectApplyCallback;
 
@@ -33,6 +36,7 @@ public sealed class PlcLifecycleManager : IDisposable
 		IS7Reader reader,
 		IS7ExecutionStream executionStream,
 		IPlcSyncService syncService,
+		IPlcSyncOwnership syncOwnership,
 		ImportedRecipeValidator importedRecipeValidator,
 		ILogger<PlcLifecycleManager> logger)
 	{
@@ -41,6 +45,7 @@ public sealed class PlcLifecycleManager : IDisposable
 		_reader = reader;
 		_executionStream = executionStream;
 		_syncService = syncService;
+		_syncOwnership = syncOwnership;
 		_importedRecipeValidator = importedRecipeValidator;
 		_logger = logger;
 	}
@@ -92,6 +97,7 @@ public sealed class PlcLifecycleManager : IDisposable
 		}
 
 		_lifetimeCts.Dispose();
+		ReleaseOwnershipLease();
 	}
 
 	public async Task<Result> EnableSync(PlcConfiguration config)
@@ -101,26 +107,38 @@ public sealed class PlcLifecycleManager : IDisposable
 			return Result.Ok();
 		}
 
+		var ownershipResult = _syncOwnership.TryAcquire(config.Connection);
+		if (ownershipResult.IsFailed)
+		{
+			_logger.LogWarning(
+				"PLC sync ownership refused: {Errors}",
+				string.Join("; ", ownershipResult.Errors.Select(e => e.Message)));
+			return ownershipResult.ToResult();
+		}
+
+		_ownershipLease = ownershipResult.Value;
+
 		try
 		{
 			_syncService.SetSyncEnabled(true);
 			await _connection.ConnectAsync(config.Connection);
+
+			var versionResult = await ValidateProtocolVersionAsync();
+			if (versionResult.IsFailed)
+			{
+				await FailProtocolVersionHandshakeAsync();
+				return versionResult;
+			}
+
+			return Result.Ok();
 		}
 		catch (Exception ex)
 		{
 			_syncService.SetSyncEnabled(false);
-			_logger.LogWarning("PLC connection failed: {Message}", ex.Message);
+			ReleaseOwnershipLease();
+			_logger.LogWarning("Enabling PLC sync failed: {Message}", ex.Message);
 			return Result.Fail(ex.Message);
 		}
-
-		var versionResult = await ValidateProtocolVersionAsync();
-		if (versionResult.IsFailed)
-		{
-			await FailProtocolVersionHandshakeAsync();
-			return versionResult;
-		}
-
-		return Result.Ok();
 	}
 
 	private async Task<Result> ValidateProtocolVersionAsync()
@@ -143,6 +161,7 @@ public sealed class PlcLifecycleManager : IDisposable
 	private async Task FailProtocolVersionHandshakeAsync()
 	{
 		_syncService.SetSyncEnabled(false);
+		ReleaseOwnershipLease();
 		await _connection.DisconnectAsync();
 	}
 
@@ -150,6 +169,7 @@ public sealed class PlcLifecycleManager : IDisposable
 	{
 		_syncService.SetSyncEnabled(false);
 		_syncService.Reset();
+		ReleaseOwnershipLease();
 
 		try
 		{
@@ -159,6 +179,18 @@ public sealed class PlcLifecycleManager : IDisposable
 		{
 			_logger.LogWarning("Error while disconnecting from PLC: {Message}", ex.Message);
 		}
+	}
+
+	private void ReleaseOwnershipLease()
+	{
+		var lease = _ownershipLease;
+		if (lease is null)
+		{
+			return;
+		}
+
+		_ownershipLease = null;
+		lease.Dispose();
 	}
 
 	public async Task<Result<Recipe>> ReadRecipeFromPlcAsync()

--- a/SemiStep/SemiStep.Core/Plc/S7/S7Di.cs
+++ b/SemiStep/SemiStep.Core/Plc/S7/S7Di.cs
@@ -5,6 +5,7 @@ using SemiStep.Core.Configuration;
 using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.S7.Serialization;
 using SemiStep.Core.Plc.Sync;
+using SemiStep.Core.Plc.Sync.Ownership;
 using SemiStep.Core.Recipes;
 
 namespace SemiStep.Core.Plc.S7;
@@ -13,6 +14,7 @@ public static class S7Di
 {
 	public static IServiceCollection AddS7(this IServiceCollection services)
 	{
+		services.AddSingleton<IPlcSyncOwnership, FileSyncOwnership>();
 		services.AddSingleton<S7Driver>();
 		services.AddSingleton<IS7Transport>(sp => sp.GetRequiredService<S7Driver>());
 		services.AddSingleton<RecipeConverter>();

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/FileSyncOwnership.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/FileSyncOwnership.cs
@@ -1,0 +1,141 @@
+﻿using System.Text.Json;
+
+using FluentResults;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using SemiStep.Core.Plc.Configuration;
+
+namespace SemiStep.Core.Plc.Sync.Ownership;
+
+public sealed class FileSyncOwnership : IPlcSyncOwnership
+{
+	private const string UnavailableMessage = "PLC sync is owned by another instance or the lock is unavailable.";
+	private const string OwnedByUnknownMessage = "PLC sync is owned by another instance.";
+
+	private readonly string _lockRoot;
+	private readonly ILogger<FileSyncOwnership> _logger;
+	private readonly SyncLockRootProvisioner _rootProvisioner = new();
+
+	public FileSyncOwnership(ILogger<FileSyncOwnership> logger)
+		: this(DefaultLockRoot(), logger)
+	{
+	}
+
+	public FileSyncOwnership(string lockRoot, ILogger<FileSyncOwnership>? logger = null)
+	{
+		_lockRoot = lockRoot;
+		_logger = logger ?? NullLogger<FileSyncOwnership>.Instance;
+	}
+
+	public Result<ISyncOwnershipLease> TryAcquire(PlcConnectionSettings endpoint)
+	{
+		var lockFilePath = BuildLockFilePath(endpoint);
+
+		try
+		{
+			_rootProvisioner.EnsureRoot(_lockRoot);
+		}
+		catch (Exception exception) when (exception is UnauthorizedAccessException or IOException)
+		{
+			return RefuseUnavailable(exception);
+		}
+
+		try
+		{
+			return Acquire(lockFilePath);
+		}
+		catch (UnauthorizedAccessException exception)
+		{
+			return RefuseUnavailable(exception);
+		}
+		catch (IOException)
+		{
+			return RefuseHeldBy(lockFilePath);
+		}
+	}
+
+	private static Result<ISyncOwnershipLease> Acquire(string lockFilePath)
+	{
+		var owner = OwnerInfo.ForCurrentProcess();
+		var lockFile = new FileStream(lockFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+
+		try
+		{
+			WriteOwner(lockFile, owner);
+		}
+		catch
+		{
+			lockFile.Dispose();
+			throw;
+		}
+
+		return Result.Ok<ISyncOwnershipLease>(new FileSyncOwnershipLease(lockFile, owner));
+	}
+
+	private static void WriteOwner(FileStream lockFile, OwnerInfo owner)
+	{
+		var payload = JsonSerializer.SerializeToUtf8Bytes(owner);
+		lockFile.SetLength(0);
+		lockFile.Write(payload);
+		lockFile.Flush(flushToDisk: true);
+	}
+
+	private static Result<ISyncOwnershipLease> RefuseHeldBy(string lockFilePath)
+	{
+		var holder = TryReadOwner(lockFilePath);
+
+		if (holder is null)
+		{
+			return Result.Fail<ISyncOwnershipLease>(OwnedByUnknownMessage);
+		}
+
+		return Result.Fail<ISyncOwnershipLease>(new OwnedByAnotherInstanceError(holder));
+	}
+
+	private static OwnerInfo? TryReadOwner(string lockFilePath)
+	{
+		try
+		{
+			using var reader = new FileStream(
+				lockFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+			using var memory = new MemoryStream();
+			reader.CopyTo(memory);
+
+			if (memory.Length == 0)
+			{
+				return null;
+			}
+
+			return JsonSerializer.Deserialize<OwnerInfo>(memory.ToArray());
+		}
+		catch (Exception exception) when (exception is IOException
+			or UnauthorizedAccessException
+			or JsonException)
+		{
+			return null;
+		}
+	}
+
+	private Result<ISyncOwnershipLease> RefuseUnavailable(Exception detail)
+	{
+		_logger.LogWarning(detail, "PLC sync lock is unavailable; refusing ownership.");
+		return Result.Fail<ISyncOwnershipLease>(UnavailableMessage);
+	}
+
+	private string BuildLockFilePath(PlcConnectionSettings endpoint)
+	{
+		var token = SyncOwnershipEndpointToken.For(endpoint);
+		return Path.Combine(_lockRoot, $"plc-sync-{token}.lock");
+	}
+
+	private static string DefaultLockRoot()
+	{
+		return Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+			"SemiStep",
+			"locks");
+	}
+}

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/FileSyncOwnershipLease.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/FileSyncOwnershipLease.cs
@@ -1,0 +1,26 @@
+﻿namespace SemiStep.Core.Plc.Sync.Ownership;
+
+public sealed class FileSyncOwnershipLease : ISyncOwnershipLease
+{
+	private readonly FileStream _lockFile;
+	private bool _disposed;
+
+	public FileSyncOwnershipLease(FileStream lockFile, OwnerInfo owner)
+	{
+		_lockFile = lockFile;
+		Owner = owner;
+	}
+
+	public OwnerInfo Owner { get; }
+
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		_disposed = true;
+		_lockFile.Dispose();
+	}
+}

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/IPlcSyncOwnership.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/IPlcSyncOwnership.cs
@@ -1,0 +1,10 @@
+﻿using FluentResults;
+
+using SemiStep.Core.Plc.Configuration;
+
+namespace SemiStep.Core.Plc.Sync.Ownership;
+
+public interface IPlcSyncOwnership
+{
+	Result<ISyncOwnershipLease> TryAcquire(PlcConnectionSettings endpoint);
+}

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/ISyncOwnershipLease.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/ISyncOwnershipLease.cs
@@ -1,0 +1,6 @@
+﻿namespace SemiStep.Core.Plc.Sync.Ownership;
+
+public interface ISyncOwnershipLease : IDisposable
+{
+	OwnerInfo Owner { get; }
+}

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/OwnedByAnotherInstanceError.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/OwnedByAnotherInstanceError.cs
@@ -1,0 +1,20 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Plc.Sync.Ownership;
+
+public sealed class OwnedByAnotherInstanceError : Error
+{
+	public OwnedByAnotherInstanceError(OwnerInfo holder)
+		: base(BuildMessage(holder))
+	{
+		Holder = holder;
+	}
+
+	public OwnerInfo Holder { get; }
+
+	private static string BuildMessage(OwnerInfo holder)
+	{
+		return $"PLC sync is owned by another instance "
+			+ $"(user {holder.UserName}, since {holder.AcquiredUtc:HH:mm} UTC).";
+	}
+}

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/OwnerInfo.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/OwnerInfo.cs
@@ -1,0 +1,17 @@
+﻿namespace SemiStep.Core.Plc.Sync.Ownership;
+
+public sealed record OwnerInfo(
+	int ProcessId,
+	string MachineName,
+	string UserName,
+	DateTimeOffset AcquiredUtc)
+{
+	public static OwnerInfo ForCurrentProcess()
+	{
+		return new OwnerInfo(
+			ProcessId: Environment.ProcessId,
+			MachineName: Environment.MachineName,
+			UserName: Environment.UserName,
+			AcquiredUtc: DateTimeOffset.UtcNow);
+	}
+}

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/SyncLockRootProvisioner.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/SyncLockRootProvisioner.cs
@@ -1,0 +1,53 @@
+﻿using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace SemiStep.Core.Plc.Sync.Ownership;
+
+internal sealed class SyncLockRootProvisioner
+{
+	public void EnsureRoot(string lockRoot)
+	{
+		var directory = new DirectoryInfo(lockRoot);
+
+		if (directory.Exists)
+		{
+			return;
+		}
+
+		directory.Create();
+
+		if (OperatingSystem.IsWindows())
+		{
+			TryGrantUsersModify(directory);
+		}
+	}
+
+	[SupportedOSPlatform("windows")]
+	private static void TryGrantUsersModify(DirectoryInfo directory)
+	{
+		try
+		{
+			var usersSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, domainSid: null);
+			var rule = new FileSystemAccessRule(
+				usersSid,
+				FileSystemRights.Modify,
+				InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+				PropagationFlags.None,
+				AccessControlType.Allow);
+
+			var security = directory.GetAccessControl();
+			security.AddAccessRule(rule);
+			directory.SetAccessControl(security);
+		}
+		catch (Exception exception) when (exception is UnauthorizedAccessException
+			or IOException
+			or PlatformNotSupportedException)
+		{
+			// Best-effort ACL provisioning. A different Windows user that cannot open the
+			// lock file is mapped to a clean refusal in FileSyncOwnership.TryAcquire,
+			// so a failure to widen the ACL here does not crash the caller. Installer-time
+			// provisioning is documented in the plan's Post-Completion section.
+		}
+	}
+}

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/SyncOwnershipEndpointToken.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/SyncOwnershipEndpointToken.cs
@@ -1,0 +1,42 @@
+﻿using System.Text;
+
+using SemiStep.Core.Plc.Configuration;
+
+namespace SemiStep.Core.Plc.Sync.Ownership;
+
+public static class SyncOwnershipEndpointToken
+{
+	public static string For(PlcConnectionSettings endpoint)
+	{
+		var raw = $"{endpoint.IpAddress}_{endpoint.Port}_{endpoint.Rack}_{endpoint.Slot}";
+		return Sanitize(raw);
+	}
+
+	private static string Sanitize(string value)
+	{
+		var invalidCharacters = Path.GetInvalidFileNameChars();
+		var builder = new StringBuilder(value.Length);
+
+		foreach (var character in value)
+		{
+			builder.Append(IsAllowed(character, invalidCharacters) ? character : '_');
+		}
+
+		return builder.ToString();
+	}
+
+	private static bool IsAllowed(char character, char[] invalidCharacters)
+	{
+		if (character == '.' || character == '_')
+		{
+			return true;
+		}
+
+		if (!char.IsLetterOrDigit(character))
+		{
+			return false;
+		}
+
+		return Array.IndexOf(invalidCharacters, character) < 0;
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Helpers/CoreTestHelper.cs
+++ b/SemiStep/SemiStep.Tests/Core/Helpers/CoreTestHelper.cs
@@ -2,6 +2,7 @@
 
 using SemiStep.Core.Configuration.Facade;
 using SemiStep.Core.Plc;
+using SemiStep.Core.Plc.Sync.Ownership;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Import;
@@ -42,6 +43,7 @@ public static class CoreTestHelper
 			.AddSingleton<IS7Reader>(sp => sp.GetRequiredService<StubS7Service>())
 			.AddSingleton<IS7ExecutionStream>(sp => sp.GetRequiredService<StubS7Service>())
 			.AddSingleton<IPlcSyncService, StubPlcSyncService>()
+			.AddSingleton<IPlcSyncOwnership, StubPlcSyncOwnership>()
 			.BuildServiceProvider();
 	}
 

--- a/SemiStep/SemiStep.Tests/Csv/Helpers/CsvTestHelper.cs
+++ b/SemiStep/SemiStep.Tests/Csv/Helpers/CsvTestHelper.cs
@@ -2,6 +2,7 @@
 
 using SemiStep.Core.Configuration.Facade;
 using SemiStep.Core.Plc;
+using SemiStep.Core.Plc.Sync.Ownership;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Import;
@@ -29,6 +30,7 @@ internal static class CsvTestHelper
 			.AddSingleton<IS7Reader>(sp => sp.GetRequiredService<StubS7Service>())
 			.AddSingleton<IS7ExecutionStream>(sp => sp.GetRequiredService<StubS7Service>())
 			.AddSingleton<IPlcSyncService, StubPlcSyncService>()
+			.AddSingleton<IPlcSyncOwnership, StubPlcSyncOwnership>()
 			.BuildServiceProvider();
 
 		var session = services.GetRequiredService<RecipeSession>();

--- a/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerOwnershipTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerOwnershipTests.cs
@@ -1,0 +1,216 @@
+﻿using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using SemiStep.Core.Configuration.Facade;
+using SemiStep.Core.Plc;
+using SemiStep.Core.Plc.Configuration;
+using SemiStep.Core.Plc.Sync.Ownership;
+using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Clipboard;
+using SemiStep.Core.Recipes.Import;
+using SemiStep.Tests.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Domain;
+
+[Trait("Component", "Domain")]
+[Trait("Area", "Ownership")]
+[Trait("Category", "Integration")]
+public sealed class PlcLifecycleManagerOwnershipTests
+{
+	private static async Task<(PlcLifecycleManager Plc, StubS7Service S7Service, StubPlcSyncService SyncService, StubPlcSyncOwnership Ownership)> BuildAsync()
+	{
+		var configDir = TestConfigLocator.GetConfigDirectory("Standard");
+		var configLoadResult = await ConfigFacade.LoadAndValidateAsync(configDir);
+
+		var s7Service = new StubS7Service();
+		var syncService = new StubPlcSyncService();
+		var ownership = new StubPlcSyncOwnership();
+
+		var services = new ServiceCollection()
+			.AddLogging()
+			.AddSingleton(configLoadResult.Value)
+			.AddRecipe()
+			.AddCsv()
+			.AddClipboard()
+			.AddSingleton<IS7Connection>(s7Service)
+			.AddSingleton<IS7Reader>(s7Service)
+			.AddSingleton<IS7ExecutionStream>(s7Service)
+			.AddSingleton<IPlcSyncService>(syncService)
+			.AddSingleton<IPlcSyncOwnership>(ownership)
+			.BuildServiceProvider();
+
+		var session = services.GetRequiredService<RecipeSession>();
+		var plc = services.GetRequiredService<PlcLifecycleManager>();
+		plc.Initialize();
+		session.Reset();
+
+		return (plc, s7Service, syncService, ownership);
+	}
+
+	[Fact]
+	public async Task EnableSync_WhenOwnershipAcquired_AcquiresThenConnects()
+	{
+		var (plc, s7Service, syncService, ownership) = await BuildAsync();
+
+		var result = await plc.EnableSync(PlcConfiguration.Default);
+
+		result.IsSuccess.Should().BeTrue("acquiring ownership must let the connect proceed");
+		ownership.TryAcquireCallCount.Should().Be(1,
+			"EnableSync must attempt to acquire ownership exactly once");
+		s7Service.ConnectCallCount.Should().Be(1,
+			"a successful acquire must be followed by a connect");
+		syncService.IsSyncEnabled.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task EnableSync_WhenAlreadyEnabled_DoesNotReacquireOwnership()
+	{
+		var (plc, _, _, ownership) = await BuildAsync();
+		(await plc.EnableSync(PlcConfiguration.Default)).IsSuccess.Should().BeTrue();
+
+		var secondResult = await plc.EnableSync(PlcConfiguration.Default);
+
+		secondResult.IsSuccess.Should().BeTrue("a redundant EnableSync must short-circuit to success");
+		ownership.TryAcquireCallCount.Should().Be(1,
+			"the already-enabled short-circuit must not attempt to acquire ownership again");
+	}
+
+	[Fact]
+	public async Task EnableSync_AfterDisableSync_ReacquiresOwnershipAndConnectsAgain()
+	{
+		var (plc, s7Service, _, ownership) = await BuildAsync();
+		(await plc.EnableSync(PlcConfiguration.Default)).IsSuccess.Should().BeTrue();
+		var firstLease = ownership.LastLease;
+		await plc.DisableSync();
+
+		var reEnableResult = await plc.EnableSync(PlcConfiguration.Default);
+
+		reEnableResult.IsSuccess.Should().BeTrue("re-enabling after a clean release must succeed");
+		ownership.TryAcquireCallCount.Should().Be(2,
+			"each enable cycle must acquire ownership afresh");
+		s7Service.ConnectCallCount.Should().Be(2,
+			"re-enabling must connect to the PLC again");
+		ownership.LastLease.Should().NotBeSameAs(firstLease,
+			"re-enabling must hand out a fresh lease, not reuse the released one");
+	}
+
+	[Fact]
+	public async Task EnableSync_WhenOwnershipRefused_FailsWithOwnerMessageAndDoesNotConnect()
+	{
+		var (plc, s7Service, syncService, ownership) = await BuildAsync();
+		ownership.ShouldRefuse = true;
+		ownership.RefusalOwner = new OwnerInfo(
+			ProcessId: 4321,
+			MachineName: "OTHER-MACHINE",
+			UserName: "rival-user",
+			AcquiredUtc: DateTimeOffset.UnixEpoch);
+
+		var result = await plc.EnableSync(PlcConfiguration.Default);
+
+		result.IsFailed.Should().BeTrue("a refused acquire must fail EnableSync");
+		result.HasError<OwnedByAnotherInstanceError>().Should().BeTrue(
+			"the failure must carry the typed owner error so the UI can surface holder metadata");
+		result.Errors[0].Message.Should().Contain("rival-user",
+			"the refusal message must name the current owner");
+		s7Service.ConnectCallCount.Should().Be(0,
+			"a refused acquire must not connect to the PLC");
+		syncService.IsSyncEnabled.Should().BeFalse(
+			"a refused acquire must leave sync disabled");
+		plc.IsSyncEnabled.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task DisableSync_ReleasesLeaseExactlyOnce()
+	{
+		var (plc, _, _, ownership) = await BuildAsync();
+		(await plc.EnableSync(PlcConfiguration.Default)).IsSuccess.Should().BeTrue();
+		var lease = ownership.LastLease;
+		lease.Should().NotBeNull();
+
+		await plc.DisableSync();
+
+		lease!.DisposeCallCount.Should().Be(1,
+			"disabling sync must release the ownership lease exactly once");
+	}
+
+	[Fact]
+	public async Task DisableSync_CalledTwice_DoesNotReleaseLeaseAgain()
+	{
+		var (plc, _, _, ownership) = await BuildAsync();
+		(await plc.EnableSync(PlcConfiguration.Default)).IsSuccess.Should().BeTrue();
+		var lease = ownership.LastLease;
+
+		await plc.DisableSync();
+		await plc.DisableSync();
+
+		lease!.DisposeCallCount.Should().Be(1,
+			"a second DisableSync must not dispose the lease again (idempotent release)");
+	}
+
+	[Fact]
+	public async Task FailedProtocolHandshake_ReleasesLeaseExactlyOnce()
+	{
+		var (plc, s7Service, syncService, ownership) = await BuildAsync();
+		s7Service.ProtocolVersionToReturn = FluentResults.Result.Ok(int.MaxValue);
+
+		var result = await plc.EnableSync(PlcConfiguration.Default);
+
+		result.IsFailed.Should().BeTrue("a protocol mismatch must fail EnableSync");
+		syncService.IsSyncEnabled.Should().BeFalse();
+		ownership.TryAcquireCallCount.Should().Be(1,
+			"a handshake-failing enable must still have acquired ownership exactly once before connecting");
+		ownership.LastLease.Should().NotBeNull();
+		ownership.LastLease!.DisposeCallCount.Should().Be(1,
+			"a failed handshake rollback must release the ownership lease exactly once");
+	}
+
+	[Fact]
+	public async Task EnableSync_WhenProtocolVersionReadThrowsCanceled_ReleasesLeaseAndDisablesSync()
+	{
+		var (plc, s7Service, syncService, ownership) = await BuildAsync();
+		s7Service.ProtocolVersionReadShouldThrowCanceled = true;
+
+		var result = await plc.EnableSync(PlcConfiguration.Default);
+
+		result.IsFailed.Should().BeTrue(
+			"a handshake read that throws after a successful connect must fail EnableSync, not propagate");
+		ownership.TryAcquireCallCount.Should().Be(1,
+			"the lease must have been acquired before the throwing handshake");
+		ownership.LastLease.Should().NotBeNull();
+		ownership.LastLease!.DisposeCallCount.Should().Be(1,
+			"a handshake that throws must release the ownership lease, not orphan it");
+		syncService.IsSyncEnabled.Should().BeFalse(
+			"a handshake that throws must reset sync state");
+		plc.IsSyncEnabled.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task Dispose_ReleasesLeaseExactlyOnce()
+	{
+		var (plc, _, _, ownership) = await BuildAsync();
+		(await plc.EnableSync(PlcConfiguration.Default)).IsSuccess.Should().BeTrue();
+		var lease = ownership.LastLease;
+
+		plc.Dispose();
+
+		lease!.DisposeCallCount.Should().Be(1,
+			"disposing the manager must release a held lease exactly once");
+	}
+
+	[Fact]
+	public async Task Dispose_AfterDisableSync_DoesNotReleaseLeaseAgain()
+	{
+		var (plc, _, _, ownership) = await BuildAsync();
+		(await plc.EnableSync(PlcConfiguration.Default)).IsSuccess.Should().BeTrue();
+		var lease = ownership.LastLease;
+
+		await plc.DisableSync();
+		plc.Dispose();
+
+		lease!.DisposeCallCount.Should().Be(1,
+			"the lease released on DisableSync must not be released again on Dispose");
+	}
+}

--- a/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
@@ -11,6 +11,7 @@ using SemiStep.Core.Plc;
 using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Plc.S7.Protocol;
 using SemiStep.Core.Plc.State;
+using SemiStep.Core.Plc.Sync.Ownership;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Import;
@@ -49,6 +50,7 @@ public sealed class PlcLifecycleManagerReconnectTests
 			.AddSingleton<IS7Reader>(s7Service)
 			.AddSingleton<IS7ExecutionStream>(s7Service)
 			.AddSingleton<IPlcSyncService>(syncService)
+			.AddSingleton<IPlcSyncOwnership, StubPlcSyncOwnership>()
 			.BuildServiceProvider();
 
 		var session = services.GetRequiredService<RecipeSession>();

--- a/SemiStep/SemiStep.Tests/Helpers/StubPlcSyncOwnership.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/StubPlcSyncOwnership.cs
@@ -1,0 +1,51 @@
+﻿using FluentResults;
+
+using SemiStep.Core.Plc.Configuration;
+using SemiStep.Core.Plc.Sync.Ownership;
+
+namespace SemiStep.Tests.Helpers;
+
+/// <summary>
+/// Test double for <see cref="IPlcSyncOwnership"/>. Acquires successfully by default,
+/// hands out a lease that records its dispose count, and can be switched to a refusal
+/// mode that returns the configured <see cref="OwnedByAnotherInstanceError"/>.
+/// </summary>
+public sealed class StubPlcSyncOwnership : IPlcSyncOwnership
+{
+	private readonly OwnerInfo _owner;
+
+	public StubPlcSyncOwnership()
+	{
+		_owner = new OwnerInfo(
+			ProcessId: 1234,
+			MachineName: "TEST-MACHINE",
+			UserName: "test-user",
+			AcquiredUtc: DateTimeOffset.UnixEpoch);
+	}
+
+	public bool ShouldRefuse { get; set; }
+
+	public OwnerInfo RefusalOwner { get; set; } = new OwnerInfo(
+		ProcessId: 9999,
+		MachineName: "OTHER-MACHINE",
+		UserName: "other-user",
+		AcquiredUtc: DateTimeOffset.UnixEpoch);
+
+	public int TryAcquireCallCount { get; private set; }
+
+	public StubSyncOwnershipLease? LastLease { get; private set; }
+
+	public Result<ISyncOwnershipLease> TryAcquire(PlcConnectionSettings endpoint)
+	{
+		TryAcquireCallCount++;
+
+		if (ShouldRefuse)
+		{
+			return Result.Fail<ISyncOwnershipLease>(new OwnedByAnotherInstanceError(RefusalOwner));
+		}
+
+		var lease = new StubSyncOwnershipLease(_owner);
+		LastLease = lease;
+		return Result.Ok<ISyncOwnershipLease>(lease);
+	}
+}

--- a/SemiStep/SemiStep.Tests/Helpers/StubS7Service.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/StubS7Service.cs
@@ -58,14 +58,27 @@ public sealed class StubS7Service : IS7Connection, IS7Reader, IS7ExecutionStream
 	/// </summary>
 	public Result<int> ProtocolVersionToReturn { get; set; } = Result.Ok(1);
 
+	/// <summary>
+	/// When true, <see cref="ReadProtocolVersionAsync"/> throws a <see cref="TaskCanceledException"/>,
+	/// mirroring an S7.Net socket/read timeout that surfaces as an <see cref="OperationCanceledException"/>
+	/// derivative. This exercises the <c>EnableSync</c> rollback path for a handshake that throws rather
+	/// than returning a failed result.
+	/// </summary>
+	public bool ProtocolVersionReadShouldThrowCanceled { get; set; }
+
 	/// <summary>Raises <see cref="StateChanged"/> with the given state.</summary>
 	public void RaiseStateChanged(PlcConnectionState state)
 	{
 		StateChanged?.Invoke(state);
 	}
 
+	/// <summary>Number of times <see cref="ConnectAsync"/> was called.</summary>
+	public int ConnectCallCount { get; private set; }
+
 	public Task ConnectAsync(PlcConnectionSettings settings)
 	{
+		ConnectCallCount++;
+
 		if (ConnectShouldFail)
 		{
 			throw new InvalidOperationException("Stub PLC connection failure");
@@ -115,6 +128,11 @@ public sealed class StubS7Service : IS7Connection, IS7Reader, IS7ExecutionStream
 
 	public Task<Result<int>> ReadProtocolVersionAsync()
 	{
+		if (ProtocolVersionReadShouldThrowCanceled)
+		{
+			throw new TaskCanceledException("Stub protocol version read timed out");
+		}
+
 		return Task.FromResult(ProtocolVersionToReturn);
 	}
 

--- a/SemiStep/SemiStep.Tests/Helpers/StubSyncOwnershipLease.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/StubSyncOwnershipLease.cs
@@ -1,0 +1,24 @@
+﻿using SemiStep.Core.Plc.Sync.Ownership;
+
+namespace SemiStep.Tests.Helpers;
+
+/// <summary>
+/// Lease handed out by <see cref="StubPlcSyncOwnership"/>. Counts dispose calls so tests
+/// can assert the lease is released exactly once and that disposal is idempotent.
+/// </summary>
+public sealed class StubSyncOwnershipLease : ISyncOwnershipLease
+{
+	public StubSyncOwnershipLease(OwnerInfo owner)
+	{
+		Owner = owner;
+	}
+
+	public OwnerInfo Owner { get; }
+
+	public int DisposeCallCount { get; private set; }
+
+	public void Dispose()
+	{
+		DisposeCallCount++;
+	}
+}

--- a/SemiStep/SemiStep.Tests/S7/FileSyncOwnershipTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/FileSyncOwnershipTests.cs
@@ -1,0 +1,181 @@
+﻿using System.IO;
+
+using FluentAssertions;
+
+using SemiStep.Core.Plc.Configuration;
+using SemiStep.Core.Plc.Sync.Ownership;
+using SemiStep.Tests.Config.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.S7;
+
+[Trait("Component", "S7")]
+[Trait("Area", "Ownership")]
+[Trait("Category", "Integration")]
+public sealed class FileSyncOwnershipTests : IDisposable
+{
+	private readonly TempDirectory _lockRoot = new();
+	private readonly PlcConnectionSettings _endpoint = new("192.168.0.150", 102, 0, 2);
+
+	public void Dispose()
+	{
+		_lockRoot.Dispose();
+	}
+
+	[Fact]
+	public void TryAcquire_FreeEndpoint_Succeeds()
+	{
+		var ownership = CreateOwnership();
+
+		var result = ownership.TryAcquire(_endpoint);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Owner.ProcessId.Should().Be(Environment.ProcessId);
+		result.Value.Dispose();
+	}
+
+	[Fact]
+	public void TryAcquire_WhileHeld_IsRefused()
+	{
+		var ownership = CreateOwnership();
+		using var firstLease = ownership.TryAcquire(_endpoint).Value;
+
+		var secondResult = ownership.TryAcquire(_endpoint);
+
+		secondResult.IsFailed.Should().BeTrue();
+	}
+
+	[Fact]
+	public void TryAcquire_AfterReleasingLease_Succeeds()
+	{
+		var ownership = CreateOwnership();
+		var firstResult = ownership.TryAcquire(_endpoint);
+		firstResult.IsSuccess.Should().BeTrue();
+
+		firstResult.Value.Dispose();
+
+		var secondResult = ownership.TryAcquire(_endpoint);
+		secondResult.IsSuccess.Should().BeTrue();
+		secondResult.Value.Dispose();
+	}
+
+	[Fact]
+	public void TryAcquire_DifferentEndpointWhileHeld_Succeeds()
+	{
+		var ownership = CreateOwnership();
+		using var firstLease = ownership.TryAcquire(_endpoint).Value;
+
+		var otherEndpoint = new PlcConnectionSettings("192.168.0.151", 102, 0, 2);
+		var secondResult = ownership.TryAcquire(otherEndpoint);
+
+		secondResult.IsSuccess.Should().BeTrue();
+		secondResult.Value.Dispose();
+	}
+
+	[Fact]
+	public void TryAcquire_WhileHeld_ExposesHolderOwnerInfo()
+	{
+		var ownership = CreateOwnership();
+		using var firstLease = ownership.TryAcquire(_endpoint).Value;
+
+		var secondResult = ownership.TryAcquire(_endpoint);
+
+		var holderError = secondResult.Errors
+			.OfType<OwnedByAnotherInstanceError>()
+			.Single();
+		holderError.Holder.ProcessId.Should().Be(firstLease.Owner.ProcessId);
+		holderError.Holder.MachineName.Should().Be(firstLease.Owner.MachineName);
+		holderError.Holder.UserName.Should().Be(firstLease.Owner.UserName);
+	}
+
+	[Fact]
+	public void LeaseDispose_CalledTwice_IsSafe()
+	{
+		var ownership = CreateOwnership();
+		var lease = ownership.TryAcquire(_endpoint).Value;
+
+		lease.Dispose();
+		var secondDispose = () => lease.Dispose();
+
+		secondDispose.Should().NotThrow();
+	}
+
+	[Fact]
+	public void TryAcquire_WhileHeldWithCorruptMetadata_RefusesWithoutHolderInfo()
+	{
+		var locksRoot = Path.Combine(_lockRoot.Path, "locks");
+		Directory.CreateDirectory(locksRoot);
+		var lockFilePath = Path.Combine(locksRoot, $"plc-sync-{SyncOwnershipEndpointToken.For(_endpoint)}.lock");
+
+		using var holder = new FileStream(lockFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+		holder.Write("not-json-at-all"u8);
+		holder.Flush(flushToDisk: true);
+		var ownership = new FileSyncOwnership(locksRoot);
+
+		var result = ownership.TryAcquire(_endpoint);
+
+		result.IsFailed.Should().BeTrue("the lock is held, so acquisition must be refused");
+		result.Errors.OfType<OwnedByAnotherInstanceError>().Should().BeEmpty(
+			"unreadable holder metadata must fall back to a generic refusal, not a typed owner error");
+	}
+
+	[Fact]
+	public void TryAcquire_WhileHeldWithEmptyMetadata_RefusesWithoutHolderInfo()
+	{
+		var locksRoot = Path.Combine(_lockRoot.Path, "locks");
+		Directory.CreateDirectory(locksRoot);
+		var lockFilePath = Path.Combine(locksRoot, $"plc-sync-{SyncOwnershipEndpointToken.For(_endpoint)}.lock");
+
+		using var holder = new FileStream(lockFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+		var ownership = new FileSyncOwnership(locksRoot);
+
+		var result = ownership.TryAcquire(_endpoint);
+
+		result.IsFailed.Should().BeTrue("the lock is held, so acquisition must be refused");
+		result.Errors.OfType<OwnedByAnotherInstanceError>().Should().BeEmpty(
+			"empty holder metadata must fall back to a generic refusal, not a typed owner error");
+	}
+
+	[Fact]
+	public void TryAcquire_WhenLockFileCannotBeOpenedForWrite_ReturnsRefusal()
+	{
+		var locksRoot = Path.Combine(_lockRoot.Path, "locks");
+		Directory.CreateDirectory(locksRoot);
+		var lockFilePath = Path.Combine(locksRoot, $"plc-sync-{SyncOwnershipEndpointToken.For(_endpoint)}.lock");
+		File.WriteAllText(lockFilePath, "preexisting");
+		File.SetAttributes(lockFilePath, FileAttributes.ReadOnly);
+		var ownership = new FileSyncOwnership(locksRoot);
+
+		try
+		{
+			var result = ownership.TryAcquire(_endpoint);
+
+			result.IsFailed.Should().BeTrue(
+				"an UnauthorizedAccessException opening the lock file must map to a clean refusal, not a throw");
+			result.Errors.OfType<OwnedByAnotherInstanceError>().Should().BeEmpty(
+				"the ACL-blocked acquire path returns a generic refusal without holder metadata");
+		}
+		finally
+		{
+			File.SetAttributes(lockFilePath, FileAttributes.Normal);
+		}
+	}
+
+	[Fact]
+	public void TryAcquire_WhenLockRootProvisioningFails_ReturnsRefusal()
+	{
+		var inaccessibleRoot = Path.Combine(_lockRoot.Path, "not-a-directory");
+		File.WriteAllText(inaccessibleRoot, "occupied");
+		var ownership = new FileSyncOwnership(inaccessibleRoot);
+
+		var result = ownership.TryAcquire(_endpoint);
+
+		result.IsFailed.Should().BeTrue();
+	}
+
+	private FileSyncOwnership CreateOwnership()
+	{
+		return new FileSyncOwnership(Path.Combine(_lockRoot.Path, "locks"));
+	}
+}

--- a/SemiStep/SemiStep.Tests/S7/SyncOwnershipEndpointTokenTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/SyncOwnershipEndpointTokenTests.cs
@@ -1,0 +1,72 @@
+﻿using System.IO;
+
+using FluentAssertions;
+
+using SemiStep.Core.Plc.Configuration;
+using SemiStep.Core.Plc.Sync.Ownership;
+
+using Xunit;
+
+namespace SemiStep.Tests.S7;
+
+[Trait("Component", "S7")]
+[Trait("Area", "Ownership")]
+[Trait("Category", "Unit")]
+public sealed class SyncOwnershipEndpointTokenTests
+{
+	[Fact]
+	public void For_SameEndpoint_ProducesIdenticalTokenAcrossCalls()
+	{
+		var endpoint = new PlcConnectionSettings("192.168.0.150", 102, 0, 2);
+
+		var first = SyncOwnershipEndpointToken.For(endpoint);
+		var second = SyncOwnershipEndpointToken.For(endpoint);
+
+		first.Should().Be(second);
+	}
+
+	[Fact]
+	public void For_EqualEndpointInstances_ProduceIdenticalTokens()
+	{
+		var endpoint = new PlcConnectionSettings("10.0.0.1", 102, 1, 3);
+		var equalEndpoint = new PlcConnectionSettings("10.0.0.1", 102, 1, 3);
+
+		SyncOwnershipEndpointToken.For(endpoint)
+			.Should().Be(SyncOwnershipEndpointToken.For(equalEndpoint));
+	}
+
+	[Fact]
+	public void For_DifferentEndpoints_ProduceDifferentTokens()
+	{
+		var first = SyncOwnershipEndpointToken.For(new PlcConnectionSettings("10.0.0.1", 102, 0, 2));
+		var second = SyncOwnershipEndpointToken.For(new PlcConnectionSettings("10.0.0.2", 102, 0, 2));
+
+		first.Should().NotBe(second);
+	}
+
+	[Theory]
+	[InlineData("192.168.0.150", 102, 0, 2)]
+	[InlineData("10.0.0.1", 102, 1, 3)]
+	[InlineData("255.255.255.255", 65535, 7, 31)]
+	public void For_RepresentativeEndpoints_ContainsNoPathInvalidCharacters(
+		string ipAddress, int port, int rack, int slot)
+	{
+		var token = SyncOwnershipEndpointToken.For(new PlcConnectionSettings(ipAddress, port, rack, slot));
+
+		token.Should().NotBeNullOrEmpty();
+		token.IndexOfAny(Path.GetInvalidFileNameChars()).Should().Be(-1);
+	}
+
+	[Fact]
+	public void For_EndpointWithPathHostileCharacters_SanitizesThemAway()
+	{
+		var endpoint = new PlcConnectionSettings("a/b\\c:d", 102, 0, 2);
+
+		var token = SyncOwnershipEndpointToken.For(endpoint);
+
+		token.IndexOfAny(Path.GetInvalidFileNameChars()).Should().Be(-1);
+		token.Should().NotContain("/");
+		token.Should().NotContain("\\");
+		token.Should().NotContain(":");
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorLoadRecipeTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using SemiStep.Core.Configuration;
 using SemiStep.Core.Configuration.Facade;
 using SemiStep.Core.Plc;
+using SemiStep.Core.Plc.Sync.Ownership;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Helpers;
@@ -255,7 +256,8 @@ public sealed class RecipeCoordinatorLoadRecipeTests
 			.AddSingleton<IS7Connection>(sp => sp.GetRequiredService<StubS7Service>())
 			.AddSingleton<IS7Reader>(sp => sp.GetRequiredService<StubS7Service>())
 			.AddSingleton<IS7ExecutionStream>(sp => sp.GetRequiredService<StubS7Service>())
-			.AddSingleton<IPlcSyncService, StubPlcSyncService>();
+			.AddSingleton<IPlcSyncService, StubPlcSyncService>()
+			.AddSingleton<IPlcSyncOwnership, StubPlcSyncOwnership>();
 
 		registerCsvService(serviceCollection);
 

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorSaveGateTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorSaveGateTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using SemiStep.Core.Configuration;
 using SemiStep.Core.Configuration.Facade;
 using SemiStep.Core.Plc;
+using SemiStep.Core.Plc.Sync.Ownership;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Helpers;
@@ -79,6 +80,7 @@ public sealed class RecipeCoordinatorSaveGateTests
 			.AddSingleton<IS7Reader>(sp => sp.GetRequiredService<StubS7Service>())
 			.AddSingleton<IS7ExecutionStream>(sp => sp.GetRequiredService<StubS7Service>())
 			.AddSingleton<IPlcSyncService, StubPlcSyncService>()
+			.AddSingleton<IPlcSyncOwnership, StubPlcSyncOwnership>()
 			.BuildServiceProvider();
 
 		var session = services.GetRequiredService<RecipeSession>();


### PR DESCRIPTION
## Summary
Addresses the reachable form of #48: two app instances on one machine writing to the same PLC. Adds a single-writer guard so at most one instance can enable PLC sync at a time; other instances stay local-only editors (foolproofing against silent recipe corruption).

## Mechanism
Exclusive OS file lock (`FileStream` with `FileShare.Read`) under `%ProgramData%\SemiStep\locks\`, keyed by the PLC endpoint (machine-wide). Acquired in `PlcLifecycleManager.EnableSync` before connecting; the open is an atomic test-and-set (no TOCTOU). A refused instance receives the current owner info (user, machine, time) and never connects. The handle is held for the ownership lifetime and released by the OS on process death (crash-safe), and on disable / failed handshake / dispose.

Chosen over a named Mutex (thread-affine, breaks async acquire/release across threads), a named Semaphore (leaks the permit on crash), and PID-file / PLC-flag schemes (TOCTOU). Full rationale in `Docs/plans/20260601-plc-write-concurrency-protection.md`.

## Scope
- PR1 of 2 for #48. This PR is the cross-process ownership guard only.
- PR2 (separate) adds in-process transport serialization (monitor read vs sync write on one S7 socket) and a finding comment on #48.

## Tests
740 pass. New coverage: endpoint-token builder; FileSyncOwnership integration (acquire / refuse-while-held / re-acquire-after-release, corrupt-metadata generic refusal, ACL-blocked open -> clean refusal, double-dispose); PlcLifecycleManager ownership (acquire-before-connect, refusal keeps sync off, exactly-once lease release on disable / failed-handshake / dispose, and release on a handshake-throw).

Refs #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)