### PR TITLE
feat: serialize S7 transport round-trips to prevent PDU interleaving (issue #48)

### DIFF
--- a/SemiStep/SemiStep.Core/Plc/S7/S7Driver.cs
+++ b/SemiStep/SemiStep.Core/Plc/S7/S7Driver.cs
@@ -8,6 +8,7 @@ namespace SemiStep.Core.Plc.S7;
 
 internal sealed class S7Driver : IS7Driver
 {
+	private readonly TransportSerializer _serializer = new();
 	private S7NetPlc? _plc;
 
 	public bool IsConnected => _plc?.IsConnected ?? false;
@@ -18,6 +19,8 @@ internal sealed class S7Driver : IS7Driver
 		{
 			await DisconnectAsync();
 		}
+
+		_serializer.Dispose();
 	}
 
 	public async Task ConnectAsync(PlcConnectionSettings settings)
@@ -40,17 +43,17 @@ internal sealed class S7Driver : IS7Driver
 		return Task.CompletedTask;
 	}
 
-	public async Task<byte[]> ReadBytesAsync(int dbNumber, int startByte, int count, CancellationToken ct = default)
+	public Task<byte[]> ReadBytesAsync(int dbNumber, int startByte, int count, CancellationToken ct = default)
 	{
-		ct.ThrowIfCancellationRequested();
-
-		return await _plc!.ReadBytesAsync(S7NetDataType.DataBlock, dbNumber, startByte, count, ct);
+		return _serializer.RunAsync(
+			() => _plc!.ReadBytesAsync(S7NetDataType.DataBlock, dbNumber, startByte, count, ct),
+			ct);
 	}
 
-	public async Task WriteBytesAsync(int dbNumber, int startByte, byte[] data, CancellationToken ct = default)
+	public Task WriteBytesAsync(int dbNumber, int startByte, byte[] data, CancellationToken ct = default)
 	{
-		ct.ThrowIfCancellationRequested();
-
-		await _plc!.WriteBytesAsync(S7NetDataType.DataBlock, dbNumber, startByte, data, ct);
+		return _serializer.RunAsync(
+			() => _plc!.WriteBytesAsync(S7NetDataType.DataBlock, dbNumber, startByte, data, ct),
+			ct);
 	}
 }

--- a/SemiStep/SemiStep.Core/Plc/S7/TransportSerializer.cs
+++ b/SemiStep/SemiStep.Core/Plc/S7/TransportSerializer.cs
@@ -1,0 +1,41 @@
+﻿namespace SemiStep.Core.Plc.S7;
+
+/// <summary>
+/// Serializes transport round-trips so concurrent reads and writes on the shared
+/// S7 connection cannot interleave and corrupt multi-PDU framing.
+/// </summary>
+internal sealed class TransportSerializer : IDisposable
+{
+	private readonly SemaphoreSlim _gate = new(1, 1);
+
+	public async Task RunAsync(Func<Task> operation, CancellationToken ct)
+	{
+		await _gate.WaitAsync(ct);
+		try
+		{
+			await operation();
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
+	public async Task<T> RunAsync<T>(Func<Task<T>> operation, CancellationToken ct)
+	{
+		await _gate.WaitAsync(ct);
+		try
+		{
+			return await operation();
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
+	public void Dispose()
+	{
+		_gate.Dispose();
+	}
+}

--- a/SemiStep/SemiStep.Tests/S7/S7DiTransportSingletonTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/S7DiTransportSingletonTests.cs
@@ -1,0 +1,55 @@
+﻿using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using SemiStep.Core.Configuration;
+using SemiStep.Core.Plc.Configuration;
+using SemiStep.Core.Plc.S7;
+using SemiStep.Core.Recipes;
+using SemiStep.Tests.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.S7;
+
+[Trait("Component", "S7")]
+[Trait("Area", "DI")]
+[Trait("Category", "Unit")]
+public sealed class S7DiTransportSingletonTests
+{
+	[Fact]
+	public async Task TransportConsumers_ResolvedFromContainer_ShareOneS7DriverInstance()
+	{
+		var appConfiguration = BuildAppConfiguration();
+
+		var services = new ServiceCollection();
+		services.AddSingleton(appConfiguration);
+		services.AddSingleton(appConfiguration.PlcConfiguration);
+		services.AddSingleton(new RecipeMetadataRegistry(appConfiguration));
+		services.AddS7();
+
+		await using var provider = services.BuildServiceProvider();
+
+		var driver = provider.GetRequiredService<S7Driver>();
+		var transport = provider.GetRequiredService<IS7Transport>();
+
+		transport.Should().BeSameAs(driver);
+	}
+
+	private static AppConfiguration BuildAppConfiguration()
+	{
+		var stringProperty = TestPropertyTypeDefinitionBuilder.CreateString("comment", 24);
+		var propertyMap = new Dictionary<string, PropertyTypeDefinition>(StringComparer.OrdinalIgnoreCase)
+		{
+			[stringProperty.Id] = stringProperty
+		};
+
+		return new AppConfiguration(
+			Properties: propertyMap,
+			Columns: new Dictionary<string, GridColumnDefinition>(),
+			Groups: new Dictionary<string, GroupDefinition>(),
+			Actions: new Dictionary<int, ActionDefinition>(),
+			GridStyle: GridStyleOptions.Default,
+			PlcConfiguration: PlcConfiguration.Default);
+	}
+}

--- a/SemiStep/SemiStep.Tests/S7/TransportSerializerTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/TransportSerializerTests.cs
@@ -1,0 +1,168 @@
+﻿using FluentAssertions;
+
+using SemiStep.Core.Plc.S7;
+
+using Xunit;
+
+namespace SemiStep.Tests.S7;
+
+[Trait("Component", "S7")]
+[Trait("Area", "TransportSerialization")]
+[Trait("Category", "Unit")]
+public sealed class TransportSerializerTests
+{
+	private const int ConcurrentOperationCount = 16;
+
+	[Fact]
+	public async Task RunAsync_ConcurrentOperations_NeverOverlap()
+	{
+		using var serializer = new TransportSerializer();
+		var currentConcurrency = 0;
+		var maxObservedConcurrency = 0;
+
+		async Task TrackedOperation()
+		{
+			var concurrency = Interlocked.Increment(ref currentConcurrency);
+			InterlockedMax(ref maxObservedConcurrency, concurrency);
+
+			await Task.Delay(5);
+
+			Interlocked.Decrement(ref currentConcurrency);
+		}
+
+		var operations = Enumerable
+			.Range(0, ConcurrentOperationCount)
+			.Select(_ => serializer.RunAsync(TrackedOperation, CancellationToken.None));
+
+		await Task.WhenAll(operations);
+
+		maxObservedConcurrency.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task RunAsync_GenericConcurrentOperations_NeverOverlap()
+	{
+		using var serializer = new TransportSerializer();
+		var currentConcurrency = 0;
+		var maxObservedConcurrency = 0;
+
+		async Task<int> TrackedOperation()
+		{
+			var concurrency = Interlocked.Increment(ref currentConcurrency);
+			InterlockedMax(ref maxObservedConcurrency, concurrency);
+
+			await Task.Delay(5);
+
+			return Interlocked.Decrement(ref currentConcurrency);
+		}
+
+		var operations = Enumerable
+			.Range(0, ConcurrentOperationCount)
+			.Select(_ => serializer.RunAsync(TrackedOperation, CancellationToken.None));
+
+		await Task.WhenAll(operations);
+
+		maxObservedConcurrency.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task RunAsync_PreCancelledToken_ThrowsAndLeavesGateUsable()
+	{
+		using var serializer = new TransportSerializer();
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		var act = () => serializer.RunAsync(() => Task.CompletedTask, cts.Token);
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+
+		var subsequentRan = false;
+		await serializer.RunAsync(
+			() =>
+			{
+				subsequentRan = true;
+				return Task.CompletedTask;
+			},
+			CancellationToken.None);
+
+		subsequentRan.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task RunAsync_TokenCancelledWhileGateHeld_ThrowsAndLeavesGateUsable()
+	{
+		using var serializer = new TransportSerializer();
+		using var cts = new CancellationTokenSource();
+
+		var gateEntered = new TaskCompletionSource();
+		var releaseHolder = new TaskCompletionSource();
+
+		var holder = serializer.RunAsync(
+			async () =>
+			{
+				gateEntered.SetResult();
+				await releaseHolder.Task;
+			},
+			CancellationToken.None);
+
+		await gateEntered.Task;
+
+		var waiter = serializer.RunAsync(() => Task.CompletedTask, cts.Token);
+		cts.Cancel();
+
+		var act = () => waiter;
+		await act.Should().ThrowAsync<OperationCanceledException>();
+
+		releaseHolder.SetResult();
+		await holder;
+
+		var subsequentRan = false;
+		await serializer.RunAsync(
+			() =>
+			{
+				subsequentRan = true;
+				return Task.CompletedTask;
+			},
+			CancellationToken.None);
+
+		subsequentRan.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task RunAsync_OperationThrows_ReleasesGate()
+	{
+		using var serializer = new TransportSerializer();
+
+		var act = () => serializer.RunAsync(
+			() => throw new InvalidOperationException("boom"),
+			CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>();
+
+		var subsequentRan = false;
+		await serializer.RunAsync(
+			() =>
+			{
+				subsequentRan = true;
+				return Task.CompletedTask;
+			},
+			CancellationToken.None);
+
+		subsequentRan.Should().BeTrue();
+	}
+
+	private static void InterlockedMax(ref int target, int candidate)
+	{
+		var observed = Volatile.Read(ref target);
+		while (candidate > observed)
+		{
+			var previous = Interlocked.CompareExchange(ref target, candidate, observed);
+			if (previous == observed)
+			{
+				return;
+			}
+
+			observed = previous;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Second part of #48 (in-process scope). Serializes all S7 transport round-trips so a keep-alive / execution-monitor read cannot interleave with a recipe write within a single app instance.

## Background — refines the original issue premise
S7.Net 0.20.0 already serializes *individual* PDU round-trips via an internal `TaskQueue`, so the raw wire-framing corruption originally described is largely prevented by the library itself. The real gap: `Plc.ReadBytesAsync`/`WriteBytesAsync` enqueue each PDU of a multi-PDU operation **separately**, so a read can slip a PDU between the PDUs of a multi-DB recipe write. This PR makes each multi-PDU round-trip indivisible. (Investigation done by decompiling the pinned S7.Net version.)

## Mechanism
A `SemaphoreSlim(1,1)` wrapped in a small `TransportSerializer`, held inside `S7Driver`, gating every `ReadBytesAsync`/`WriteBytesAsync` call. Placed in `S7Driver` (not a decorator over `IS7Transport`) because the keep-alive loop reaches the socket via `IS7Driver` while `PlcTransactionExecutor` uses `IS7Transport` — both resolve to the **one** `S7Driver` singleton, so the gate there covers every path. `WaitAsync(ct)` is outside the `try` and `Release()` is in `finally`, so a cancelled acquire never over-releases and a throwing operation still releases. Connect/Disconnect are intentionally left ungated (connection lifecycle, out of scope).

## Trade-off (intended)
A keep-alive probe now queues behind an in-flight recipe write, which can defer connection-loss detection until the write completes. This is the unavoidable, intended consequence of serializing one socket, and is acceptable at the 5s keep-alive interval.

## Tests
719 pass. New coverage:
- `TransportSerializer` unit tests: mutual exclusion (both overloads, max-concurrency == 1), pre-cancelled token, mid-wait cancellation, exception-path release — each verifying the gate remains usable afterward.
- A DI test asserting `IS7Transport` and `S7Driver` resolve to the **same** instance, locking the single-shared-gate invariant against future DI refactors.

Refs #48
(Companion to #53, which handles the cross-process half of #48.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
