### PR TITLE
fix: stop spurious 'PLC connection lost' on sync re-enable

### DIFF
--- a/Docs/plans/20260603-plc-sync-state-rework.md
+++ b/Docs/plans/20260603-plc-sync-state-rework.md
@@ -1,0 +1,156 @@
+# PLC Sync State Rework (re-enable bug fix + status single-source-of-truth)
+
+## Overview
+
+Two stacked PRs against the PLC sync subsystem (`SemiStep.Core/Plc`).
+
+- **PR 1 — bug fix.** Toggling Sync Off then On emits a spurious `PLC connection lost`. Root cause: `PlcSyncCoordinator.Reset()` sets `Status = Disconnected` and is called for two opposite intents — clean `DisableSync` teardown and runtime connection-loss. A clean disable leaves `Status = Disconnected`; the next `EnableSync` calls `SetSyncEnabled(true)`, which publishes synchronously while the stale `Disconnected` status trips the predicate `(status == Disconnected && isSyncEnabled)` in `PublishSnapshot` before any connection attempt. Fix: split `Reset()` by intent.
+- **PR 2 — architecture refactor (stacked on PR 1).** Make `PlcConnectionState` the single source of truth for connectivity. Remove the duplicated `PlcSyncStatus.Disconnected`; replace the connection-loss predicate-inference with an explicit, event-driven signal so the disconnected+enabled ambiguity is structurally impossible.
+
+Problem solved: removes the spurious failure (PR 1) and the duplicated/overloaded state that enabled it (PR 2), leaving a smaller, clearer status model.
+
+## Context (from discovery)
+
+- Files/components involved:
+  - `SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs` — owns `_status`, `_connectionState`, `_isSyncEnabled`, the `BehaviorSubject`, `Reset()`, `PublishSnapshot`.
+  - `SemiStep.Core/Plc/PlcLifecycleManager.cs` — `DisableSync` (line ~171) and `OnConnectionStateChanged` loss branch (line ~267) both call `Reset()`.
+  - `SemiStep.Core/Plc/IPlcSyncService.cs` — declares `Reset()`.
+  - `SemiStep.Core/Plc/Sync/PlcSyncExecutor.cs` — `CheckCanSyncAsync` (line ~208) writes `Disconnected` on `!IsConnected`.
+  - `SemiStep.Core/Plc/State/PlcSyncStatus.cs`, `PlcSessionSnapshot.cs` — enum + DTO (`InitialState` seeds `Disconnected`).
+  - `SemiStep.UI/MainWindow/MainWindowViewModel.cs` — `MapSyncStatus` (has a `Disconnected` case); independent `ConnectionStatus` already renders "Connected/Disconnected" from `IsConnected` (line 99).
+  - Tests: `SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs`, `SemiStep.Tests/Domain/PlcLifecycleManager*Tests.cs`.
+- Related patterns found: status mutation centralized through the coordinator `Status` setter under a single `Lock`; `IPlcSyncService` is the Core/UI boundary; failures currently carried as `Result.Fail(...).WithValue(snapshot)` on a hot `BehaviorSubject`.
+- Dependencies: `S7Service.StateChanged` drives `OnConnectionStateChanged`; the UI consumes the stream via a single `ObserveOn(MainThreadScheduler)` + `Publish().RefCount()`.
+
+## Development Approach
+
+- **Testing approach**: Regular (code change, then regression/updated tests within the same task).
+- Complete each task fully before the next; build + `dotnet format` + tests must pass before advancing.
+- Each task includes new/updated tests. Success and failure scenarios both covered.
+- Keep PR 1 minimal — do NOT touch the enum, the predicate, the `Result` wrapper, or the UI. PR 2 owns the structural change.
+
+## Testing Strategy
+
+- **Unit tests** (`SemiStep.Tests`): the headline regression (enable→disable→enable emits no failed snapshot) plus genuine-loss still emits failure; PR 2 updates status-model tests and adds a "disconnected label derives from ConnectionState" assertion where practical.
+- **Avalonia headless**: PR 2 touches `MapSyncStatus`; rely on existing UI tests to catch binding regressions.
+- Commands: `dotnet build SemiStep/SemiStep.slnx`, `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`, `dotnet format SemiStep/SemiStep.slnx`.
+
+## Progress Tracking
+
+- Mark `[x]` immediately on completion. New tasks prefixed ➕, blockers ⚠️. Keep this file in sync.
+
+## Solution Overview
+
+- **PR 1**: `Reset()` → two intent-named methods. `ResetForDisable()` = `_executor.Reset()` + `Status = Idle`. `HandleConnectionLost()` = `_executor.Reset()` + `Status = Disconnected`. `DisableSync` calls the former; the connection-loss branch calls the latter. The predicate and enum are untouched, so genuine loss still surfaces `PLC connection lost` while a clean disable can no longer poison the next enable.
+- **PR 2**: Delete `PlcSyncStatus.Disconnected`. Connectivity reads from `PlcConnectionState`. Connection-loss becomes an explicit coordinator field `_connectionLost` (set only by `HandleConnectionLost`, cleared on `SetSyncEnabled(true)`, on `UpdateConnectionState(Connected)`, and by `ResetForDisable`). `PublishSnapshot` emits `Fail("PLC connection lost")` when `_connectionLost && isSyncEnabled` — an event-driven flag instead of a stale-prone status predicate. `CheckCanSyncAsync` still aborts the write when disconnected but no longer writes a status. `InitialState` seeds `Idle`. `MapSyncStatus` loses its `Disconnected` case (connection label already covered by `ConnectionStatus`).
+
+## Technical Details
+
+- `_connectionLost` is owned entirely by the coordinator (no reach into `PlcSyncExecutor` state, preserving the SRP boundary). It is mutated under the existing `_lock` and read inside `PublishSnapshot` alongside `status`/`isSyncEnabled` for a consistent snapshot point.
+- The `Result<PlcSessionSnapshot>` wrapper and the failure-as-value channel are intentionally retained (P3 deferred). PR 2 only changes what TRIGGERS the failure, not how it is transported.
+- Genuine-loss path is unchanged end to end: `S7Service` detects loss → `StateChanged(Disconnected)` → `OnConnectionStateChanged` → `HandleConnectionLost` sets `_connectionLost` → `PublishSnapshot` emits the failure. `CheckCanSyncAsync` hitting `!IsConnected` implies a drop already signalled by that path (sync is only enabled after a successful `ConnectAsync`), so dropping its status write is safe.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]`): all code + tests + branch/PR mechanics, achievable in this repo.
+- **Post-Completion** (no checkboxes): live PLC re-verification of the original Off→On scenario; capturing the `.Value` stack trace that gates the deferred P3.
+
+## Implementation Steps
+
+### Task 1 (PR 1): Split Reset() into intent-named operations
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs`
+- Modify: `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs`
+- Modify: `SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs`
+
+- [ ] In `IPlcSyncService`, replace `void Reset();` with `void ResetForDisable();` and `void HandleConnectionLost();`.
+- [ ] In `PlcSyncCoordinator`, implement `ResetForDisable()` (`_executor.Reset()` + `Status = PlcSyncStatus.Idle`) and `HandleConnectionLost()` (`_executor.Reset()` + `Status = PlcSyncStatus.Disconnected`); remove old `Reset()`.
+- [ ] In `PlcLifecycleManager.DisableSync`, call `ResetForDisable()` (was `Reset()`).
+- [ ] In `PlcLifecycleManager.OnConnectionStateChanged` loss branch, call `HandleConnectionLost()` (was `Reset()`).
+- [ ] Update any other `Reset()` callers/stubs (`SemiStep.Tests/Helpers/StubPlcSyncService.cs`).
+- [ ] `dotnet build SemiStep/SemiStep.slnx` — must compile.
+
+### Task 2 (PR 1): Regression test for enable→disable→enable
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs`
+
+- [ ] Add a test: after `SetSyncEnabled(true)` → `ResetForDisable()` + `SetSyncEnabled(false)` → `SetSyncEnabled(true)`, the latest `PlcState` emission is NOT failed (the spurious-failure regression).
+- [ ] Add/confirm a test: `HandleConnectionLost()` while enabled DOES produce a failed snapshot (`PLC connection lost`) — genuine loss preserved.
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName~PlcSyncCoordinator"` — must pass.
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green.
+
+### Task 3 (PR 1): Format, commit, push, open PR
+
+- [ ] `dotnet format SemiStep/SemiStep.slnx`.
+- [ ] `git add` changed files; commit on branch `plc-sync-reenable-fix` (message: `fix: stop spurious 'PLC connection lost' on sync re-enable`).
+- [ ] Verify `git log origin/master..HEAD --oneline` contains only this change.
+- [ ] `git push -u origin plc-sync-reenable-fix`; `gh pr create --base master` with a focused description.
+
+### Task 4 (PR 2): Branch off PR 1 (stacked)
+
+- [ ] From the worktree on `plc-sync-reenable-fix`, `git switch -c plc-sync-status-refactor`.
+
+### Task 5 (PR 2): Make connection-loss an explicit signal; remove PlcSyncStatus.Disconnected
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Plc/State/PlcSyncStatus.cs`
+- Modify: `SemiStep/SemiStep.Core/Plc/State/PlcSessionSnapshot.cs`
+- Modify: `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs`
+- Modify: `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncExecutor.cs`
+
+- [ ] Add `_connectionLost` (bool) to `PlcSyncCoordinator`, mutated under `_lock`. Set `true` in `HandleConnectionLost()`; set `false` in `SetSyncEnabled(true)`, `ResetForDisable()`, and `UpdateConnectionState(PlcConnectionState.Connected)`.
+- [ ] Change `HandleConnectionLost()` to set `_connectionLost = true` instead of `Status = Disconnected`.
+- [ ] Rewrite the loss branch in `PublishSnapshot`: emit `Fail("PLC connection lost")` when `_connectionLost && isSyncEnabled` (read under lock with the other fields); keep the `Failed` branch unchanged.
+- [ ] Remove `Disconnected` from `PlcSyncStatus`; set `PlcSessionSnapshot.InitialState` `SyncStatus` to `Idle`.
+- [ ] In `PlcSyncExecutor.CheckCanSyncAsync`, keep the `!connection.IsConnected` early abort (`return Result.Fail`) but remove the `setStatus(PlcSyncStatus.Disconnected)` write.
+- [ ] `dotnet build SemiStep/SemiStep.slnx` — resolve all references to the removed enum value.
+
+### Task 6 (PR 2): Re-point UI status label to ConnectionState
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs`
+
+- [ ] Remove the `PlcSyncStatus.Disconnected` case from `MapSyncStatus`; confirm `ConnectionStatus` (line ~99) still renders the connection label independently.
+- [ ] Verify no other UI/XAML binding depends on a `Disconnected` sync-status string.
+- [ ] `dotnet build SemiStep/SemiStep.UI/SemiStep.UI.csproj`.
+
+### Task 7 (PR 2): Update and extend tests
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs`
+- Modify: affected tests under `SemiStep/SemiStep.Tests` referencing `PlcSyncStatus.Disconnected`
+
+- [ ] Update any test asserting `PlcSyncStatus.Disconnected` to the new model (connectivity via `ConnectionState`; loss via the failed snapshot).
+- [ ] Re-run the PR 1 regression test against the new representation; adjust if it referenced the enum value.
+- [ ] Add a test that `HandleConnectionLost` then `SetSyncEnabled(true)` clears `_connectionLost` (no lingering failure on re-enable).
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green.
+
+### Task 8 (PR 2): Format, commit, push, open stacked PR
+
+- [ ] `dotnet format SemiStep/SemiStep.slnx`.
+- [ ] Commit on `plc-sync-status-refactor` (message: `refactor: make ConnectionState the single source of truth for PLC connectivity`).
+- [ ] `git push -u origin plc-sync-status-refactor`; `gh pr create --base plc-sync-reenable-fix` (stacked) with a description noting it depends on PR 1.
+
+### Task 9: Verify acceptance criteria
+
+- [ ] Re-read Overview: spurious failure gone (PR 1), `PlcSyncStatus.Disconnected` removed and loss explicit (PR 2).
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green on the PR 2 branch.
+- [ ] Confirm out-of-scope items (P3/P4/P5) and preserved subsystems (S7Service FSM, file-lock ownership, TransportSerializer, threading model) were not modified: `git diff origin/master...HEAD --stat`.
+
+### Task 10: [Final] Plan housekeeping
+
+- [ ] Mark all checkboxes; note any deviations.
+- [ ] Move this plan to `Docs/plans/completed/` (commit on the PR 2 branch).
+
+## Post-Completion
+
+*Manual / external — no checkboxes.*
+
+**Manual verification:**
+- Re-run the original scenario against the real PLC (192.168.0.150): Sync On → Off → On must reconnect with no `PLC connection lost`.
+- Confirm a genuine link drop (disconnect cable / power) still surfaces the failure and auto-reconnect resumes.
+
+**Deferred (separate future PR, gated):**
+- Capture the real `InvalidOperationException: Result is in status failed. Value is not set` stack trace (first-chance on `InvalidOperationException`) before executing P3 (drop the `Result` wrapper / move faults to a discrete channel with Core-owned text routed to `MessagePanel`).

--- a/Docs/plans/20260603-plc-sync-state-rework.md
+++ b/Docs/plans/20260603-plc-sync-state-rework.md
@@ -27,7 +27,7 @@ Problem solved: removes the spurious failure (PR 1) and the duplicated/overloade
 - **Testing approach**: Regular (code change, then regression/updated tests within the same task).
 - Complete each task fully before the next; build + `dotnet format` + tests must pass before advancing.
 - Each task includes new/updated tests. Success and failure scenarios both covered.
-- Keep PR 1 minimal — do NOT touch the enum, the predicate, the `Result` wrapper, or the UI. PR 2 owns the structural change.
+- Keep PR 1 minimal — do NOT touch the enum, the predicate, or the UI. PR 2 owns the structural change. (See "Implementation note (PR 1 deviation)" below regarding the `Result` wrapper.)
 
 ## Testing Strategy
 
@@ -47,7 +47,11 @@ Problem solved: removes the spurious failure (PR 1) and the duplicated/overloade
 ## Technical Details
 
 - `_connectionLost` is owned entirely by the coordinator (no reach into `PlcSyncExecutor` state, preserving the SRP boundary). It is mutated under the existing `_lock` and read inside `PublishSnapshot` alongside `status`/`isSyncEnabled` for a consistent snapshot point.
-- The `Result<PlcSessionSnapshot>` wrapper and the failure-as-value channel are intentionally retained (P3 deferred). PR 2 only changes what TRIGGERS the failure, not how it is transported.
+- The `Result<PlcSessionSnapshot>` wrapper is intentionally retained (P3 deferred). PR 2 only changes what TRIGGERS the failure, not how it is transported. The failure-as-*value* channel (`.WithValue(snapshot)` on the failed branches) was removed in PR 1 — see the implementation note below.
+
+## Implementation note (PR 1 deviation)
+
+- PR 1 removed `.WithValue(snapshot)` from both failed-`Result` branches in `PublishSnapshot` (the `Failed` and the connection-lost branches). FluentResults throws `InvalidOperationException: Result is in status failed. Value is not set` when a value is later read off a failed result, and constructing/consuming a failed result that carries a value is the same fault surface. Removing `.WithValue` from the failed branches both keeps PR 1 internally consistent and fixed the genuine-loss `Value is not set` exception. The `Result<PlcSessionSnapshot>` wrapper type itself is unchanged; only the no-longer-needed value payload on the failed branches was dropped. The full move off the `Result` wrapper / to a discrete fault channel remains the deferred P3 item.
 - Genuine-loss path is unchanged end to end: `S7Service` detects loss → `StateChanged(Disconnected)` → `OnConnectionStateChanged` → `HandleConnectionLost` sets `_connectionLost` → `PublishSnapshot` emits the failure. `CheckCanSyncAsync` hitting `!IsConnected` implies a drop already signalled by that path (sync is only enabled after a successful `ConnectAsync`), so dropping its status write is safe.
 
 ## What Goes Where

--- a/Docs/plans/20260603-plc-sync-state-rework.md
+++ b/Docs/plans/20260603-plc-sync-state-rework.md
@@ -64,29 +64,29 @@ Problem solved: removes the spurious failure (PR 1) and the duplicated/overloade
 - Modify: `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs`
 - Modify: `SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs`
 
-- [ ] In `IPlcSyncService`, replace `void Reset();` with `void ResetForDisable();` and `void HandleConnectionLost();`.
-- [ ] In `PlcSyncCoordinator`, implement `ResetForDisable()` (`_executor.Reset()` + `Status = PlcSyncStatus.Idle`) and `HandleConnectionLost()` (`_executor.Reset()` + `Status = PlcSyncStatus.Disconnected`); remove old `Reset()`.
-- [ ] In `PlcLifecycleManager.DisableSync`, call `ResetForDisable()` (was `Reset()`).
-- [ ] In `PlcLifecycleManager.OnConnectionStateChanged` loss branch, call `HandleConnectionLost()` (was `Reset()`).
-- [ ] Update any other `Reset()` callers/stubs (`SemiStep.Tests/Helpers/StubPlcSyncService.cs`).
-- [ ] `dotnet build SemiStep/SemiStep.slnx` — must compile.
+- [x] In `IPlcSyncService`, replace `void Reset();` with `void ResetForDisable();` and `void HandleConnectionLost();`.
+- [x] In `PlcSyncCoordinator`, implement `ResetForDisable()` (`_executor.Reset()` + `Status = PlcSyncStatus.Idle`) and `HandleConnectionLost()` (`_executor.Reset()` + `Status = PlcSyncStatus.Disconnected`); remove old `Reset()`.
+- [x] In `PlcLifecycleManager.DisableSync`, call `ResetForDisable()` (was `Reset()`).
+- [x] In `PlcLifecycleManager.OnConnectionStateChanged` loss branch, call `HandleConnectionLost()` (was `Reset()`).
+- [x] Update any other `Reset()` callers/stubs (`SemiStep.Tests/Helpers/StubPlcSyncService.cs`).
+- [x] `dotnet build SemiStep/SemiStep.slnx` — must compile.
 
 ### Task 2 (PR 1): Regression test for enable→disable→enable
 
 **Files:**
 - Modify: `SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs`
 
-- [ ] Add a test: after `SetSyncEnabled(true)` → `ResetForDisable()` + `SetSyncEnabled(false)` → `SetSyncEnabled(true)`, the latest `PlcState` emission is NOT failed (the spurious-failure regression).
-- [ ] Add/confirm a test: `HandleConnectionLost()` while enabled DOES produce a failed snapshot (`PLC connection lost`) — genuine loss preserved.
-- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName~PlcSyncCoordinator"` — must pass.
-- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green.
+- [x] Add a test: after `SetSyncEnabled(true)` → `ResetForDisable()` + `SetSyncEnabled(false)` → `SetSyncEnabled(true)`, the latest `PlcState` emission is NOT failed (the spurious-failure regression).
+- [x] Add/confirm a test: `HandleConnectionLost()` while enabled DOES produce a failed snapshot (`PLC connection lost`) — genuine loss preserved.
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName~PlcSyncCoordinator"` — must pass.
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green.
 
 ### Task 3 (PR 1): Format, commit, push, open PR
 
-- [ ] `dotnet format SemiStep/SemiStep.slnx`.
-- [ ] `git add` changed files; commit on branch `plc-sync-reenable-fix` (message: `fix: stop spurious 'PLC connection lost' on sync re-enable`).
-- [ ] Verify `git log origin/master..HEAD --oneline` contains only this change.
-- [ ] `git push -u origin plc-sync-reenable-fix`; `gh pr create --base master` with a focused description.
+- [x] `dotnet format SemiStep/SemiStep.slnx`.
+- [x] `git add` changed files; commit on branch `plc-sync-reenable-fix` (message: `fix: stop spurious 'PLC connection lost' on sync re-enable`).
+- [x] Verify `git log origin/master..HEAD --oneline` contains only this change.
+- [x] `git push -u origin plc-sync-reenable-fix`; `gh pr create --base master` with a focused description.
 
 ### Task 4 (PR 2): Branch off PR 1 (stacked)
 

--- a/SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs
+++ b/SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs
@@ -9,7 +9,9 @@ public interface IPlcSyncService
 {
 	void NotifyRecipeChanged(Recipe recipe, bool isValid);
 
-	void Reset();
+	void ResetForDisable();
+
+	void HandleConnectionLost();
 
 	void SetSyncEnabled(bool value);
 

--- a/SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs
+++ b/SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs
@@ -168,7 +168,7 @@ public sealed class PlcLifecycleManager : IDisposable
 	public async Task DisableSync()
 	{
 		_syncService.SetSyncEnabled(false);
-		_syncService.Reset();
+		_syncService.ResetForDisable();
 		ReleaseOwnershipLease();
 
 		try
@@ -264,7 +264,7 @@ public sealed class PlcLifecycleManager : IDisposable
 
 		if (state == PlcConnectionState.Disconnected && _syncService.IsSyncEnabled)
 		{
-			_syncService.Reset();
+			_syncService.HandleConnectionLost();
 		}
 		else if (state == PlcConnectionState.Connected && _syncService.IsSyncEnabled)
 		{

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
@@ -148,7 +148,13 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 		_subject.Dispose();
 	}
 
-	public void Reset()
+	public void ResetForDisable()
+	{
+		_executor.Reset();
+		Status = PlcSyncStatus.Idle;
+	}
+
+	public void HandleConnectionLost()
 	{
 		_executor.Reset();
 		Status = PlcSyncStatus.Disconnected;
@@ -183,17 +189,13 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 
 		if (status == PlcSyncStatus.Failed)
 		{
-			TryPublish(
-				Result.Fail<PlcSessionSnapshot>(new Error(errorMessage ?? "Sync failed"))
-					.WithValue(snapshot));
+			TryPublish(Result.Fail<PlcSessionSnapshot>(new Error(errorMessage ?? "Sync failed")));
 			return;
 		}
 
 		if (status == PlcSyncStatus.Disconnected && isSyncEnabled)
 		{
-			TryPublish(
-				Result.Fail<PlcSessionSnapshot>(new Error("PLC connection lost"))
-					.WithValue(snapshot));
+			TryPublish(Result.Fail<PlcSessionSnapshot>(new Error("PLC connection lost")));
 			return;
 		}
 

--- a/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
@@ -193,6 +193,8 @@ public sealed class PlcLifecycleManagerReconnectTests
 
 		syncService.WasHandleConnectionLostCalled.Should().BeTrue(
 			"IPlcSyncService.HandleConnectionLost() must be called when the PLC disconnects while sync is enabled");
+		syncService.WasResetForDisableCalled.Should().BeFalse(
+			"a connection drop is a loss alarm, not a clean teardown, so it must not take the disable path");
 	}
 
 	[Fact]

--- a/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
@@ -181,7 +181,7 @@ public sealed class PlcLifecycleManagerReconnectTests
 	}
 
 	[Fact]
-	public async Task StateChanged_Disconnected_WhenSyncEnabled_CallsReset()
+	public async Task StateChanged_Disconnected_WhenSyncEnabled_CallsHandleConnectionLost()
 	{
 		var (plc, _, s7Service, syncService) = await BuildAsync();
 
@@ -191,12 +191,12 @@ public sealed class PlcLifecycleManagerReconnectTests
 		// Simulate a connection drop while sync is active.
 		s7Service.RaiseStateChanged(PlcConnectionState.Disconnected);
 
-		syncService.WasResetCalled.Should().BeTrue(
-			"IPlcSyncService.Reset() must be called when the PLC disconnects while sync is enabled");
+		syncService.WasHandleConnectionLostCalled.Should().BeTrue(
+			"IPlcSyncService.HandleConnectionLost() must be called when the PLC disconnects while sync is enabled");
 	}
 
 	[Fact]
-	public async Task DisableSync_CallsResetOnSyncService()
+	public async Task DisableSync_CallsResetForDisableOnSyncService()
 	{
 		var (plc, _, _, syncService) = await BuildAsync();
 
@@ -205,8 +205,10 @@ public sealed class PlcLifecycleManagerReconnectTests
 
 		await plc.DisableSync();
 
-		syncService.WasResetCalled.Should().BeTrue(
-			"IPlcSyncService.Reset() must be called when sync is manually disabled");
+		syncService.WasHandleConnectionLostCalled.Should().BeFalse(
+			"manual disable is a clean teardown, not a connection-loss alarm");
+		syncService.WasResetForDisableCalled.Should().BeTrue(
+			"IPlcSyncService.ResetForDisable() must be called when sync is manually disabled");
 	}
 
 	[Fact]

--- a/SemiStep/SemiStep.Tests/Helpers/StubPlcSyncService.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/StubPlcSyncService.cs
@@ -21,8 +21,11 @@ public sealed class StubPlcSyncService : IPlcSyncService
 
 	public IObservable<Result<PlcSessionSnapshot>> PlcState => _plcStateSubject;
 
-	/// <summary>True if <see cref="Reset"/> was called at least once.</summary>
-	public bool WasResetCalled { get; private set; }
+	/// <summary>True if <see cref="ResetForDisable"/> was called at least once.</summary>
+	public bool WasResetForDisableCalled { get; private set; }
+
+	/// <summary>True if <see cref="HandleConnectionLost"/> was called at least once.</summary>
+	public bool WasHandleConnectionLostCalled { get; private set; }
 
 	/// <summary>Number of times <see cref="NotifyRecipeChanged"/> was called.</summary>
 	public int NotifyRecipeChangedCallCount { get; private set; }
@@ -42,9 +45,14 @@ public sealed class StubPlcSyncService : IPlcSyncService
 		NotifyRecipeChangedCalls.Add((recipe, isValid));
 	}
 
-	public void Reset()
+	public void ResetForDisable()
 	{
-		WasResetCalled = true;
+		WasResetForDisableCalled = true;
+	}
+
+	public void HandleConnectionLost()
+	{
+		WasHandleConnectionLostCalled = true;
 	}
 
 	public void SetSyncEnabled(bool value)

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -224,4 +224,37 @@ public sealed class PlcSyncCoordinatorTests
 		coordinator.Status.Should().Be(PlcSyncStatus.Idle,
 			"after disposal, notifications must be ignored");
 	}
+
+	[Fact]
+	public void ReEnableAfterCleanDisable_DoesNotEmitConnectionLostFailure()
+	{
+		var (coordinator, _, _) = Build(connected: false);
+		Result<PlcSessionSnapshot>? latest = null;
+		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
+
+		coordinator.SetSyncEnabled(true);
+		coordinator.SetSyncEnabled(false);
+		coordinator.ResetForDisable();
+		coordinator.SetSyncEnabled(true);
+
+		latest.Should().NotBeNull();
+		latest!.IsFailed.Should().BeFalse(
+			"re-enabling sync after a clean disable must not emit a spurious connection-lost failure");
+	}
+
+	[Fact]
+	public void HandleConnectionLost_WhileSyncEnabled_EmitsConnectionLostFailure()
+	{
+		var (coordinator, _, _) = Build(connected: false);
+		coordinator.SetSyncEnabled(true);
+
+		Result<PlcSessionSnapshot>? latest = null;
+		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
+
+		coordinator.HandleConnectionLost();
+
+		latest.Should().NotBeNull();
+		latest!.IsFailed.Should().BeTrue(
+			"a runtime connection loss while sync is enabled must surface as a failed snapshot");
+	}
 }

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -243,6 +243,29 @@ public sealed class PlcSyncCoordinatorTests
 	}
 
 	[Fact]
+	public void ReEnableAfterConnectionLostThenCleanDisable_DoesNotEmitConnectionLostFailure()
+	{
+		var (coordinator, _, _) = Build(connected: false);
+		Result<PlcSessionSnapshot>? latest = null;
+		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
+
+		// Drive the coordinator into the stale state that produced the field bug: a genuine
+		// connection loss leaves Status = Disconnected. The user then toggles Sync off (clean
+		// disable) and back on. ResetForDisable must clear the stale status to Idle so the
+		// re-enable does not republish the connection-lost failure.
+		coordinator.SetSyncEnabled(true);
+		coordinator.HandleConnectionLost();
+		coordinator.SetSyncEnabled(false);
+		coordinator.ResetForDisable();
+		coordinator.SetSyncEnabled(true);
+
+		latest.Should().NotBeNull();
+		latest!.IsFailed.Should().BeFalse(
+			"after a genuine loss is cleared by a clean disable, re-enabling sync must not "
+			+ "republish the stale connection-lost failure");
+	}
+
+	[Fact]
 	public void HandleConnectionLost_WhileSyncEnabled_EmitsConnectionLostFailure()
 	{
 		var (coordinator, _, _) = Build(connected: false);


### PR DESCRIPTION
## Root cause

`PlcSyncCoordinator.Reset()` was called for two opposite intents — clean `DisableSync` teardown and runtime connection-loss — and unconditionally set `Status = Disconnected`. A clean disable left that status behind, so the next `EnableSync` tripped the `(status == Disconnected && isSyncEnabled)` predicate in `PublishSnapshot` before any connection attempt, emitting a false `PLC connection lost` failure.

## Fix

- Split `Reset()` into two intent-named methods: `ResetForDisable()` (`Status -> Idle`) and `HandleConnectionLost()` (`Status -> Disconnected`). Each call site in `PlcLifecycleManager` now calls the method matching its intent.
- Dropped the dead `.WithValue(snapshot)` on the two failure branches of `PublishSnapshot`. FluentResults' `WithValue` setter throws on a failed `Result`, so emitting the genuine `PLC connection lost` failure actually threw `InvalidOperationException` before reaching any subscriber. The snapshot value is never read on the failure path; the failure channel (`Result.Fail` on the `BehaviorSubject`) is otherwise unchanged. This was a latent pre-existing bug surfaced by the new genuine-loss regression test.

## Tests

Two regression tests added to `PlcSyncCoordinatorTests`:
- `ReEnableAfterCleanDisable_DoesNotEmitConnectionLostFailure` — the headline fix.
- `HandleConnectionLost_WhileSyncEnabled_EmitsConnectionLostFailure` — genuine loss still surfaces a failed snapshot.

Renamed reconnect tests and stub flags (`WasResetForDisableCalled` / `WasHandleConnectionLostCalled`) updated. Full suite: 748 passed, 0 failed.

This is PR 1 of 2. PR 2 (status-layer refactor making `ConnectionState` the single source of truth and removing `PlcSyncStatus.Disconnected`) will stack on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)