### PR TITLE
refactor: unify Result-to-MessagePanel reporting

### DIFF
--- a/Docs/error-reporting.md
+++ b/Docs/error-reporting.md
@@ -23,10 +23,10 @@ How a failed operation reaches the user. Read this before adding a new error-sur
 
 ## The reporting seam
 
-All `Result`-to-panel routing goes through `ResultReportingExtensions`
+`Result`-to-panel routing goes through `ResultReportingExtensions`
 (`SemiStep.UI/MessageService/`):
 
-- `string FormatErrors(this IResultBase)` — joins every error message with `"; "`. The single idiom
+- `string FormatErrors(this IResultBase)` — joins every error message with `"; "`. The default idiom
   for rendering a failed result, used by both panel sites and log statements.
 - `void ReportFailure(this MessagePanelViewModel, IResultBase, string? context = null)` — surfaces
   `FormatErrors()` on the transient operation channel, optionally prefixed with `"{context}: "`.
@@ -42,3 +42,6 @@ read `Errors[0]` directly.
   `RefreshReasons`, and from there to the status-bar counts.
 - **Exception handlers** (`ReportError($"... {ex.Message}")` on `ThrownExceptions`) are not
   `Result`-based and stay as-is.
+- **One deliberate exception** to the `"; "` idiom: the clipboard *paste* failure lists each error on
+  its own line (`Environment.NewLine`), because a rejected paste can carry many per-step errors that
+  read better stacked. It still surfaces every error (never just `Errors[0]`).

--- a/Docs/error-reporting.md
+++ b/Docs/error-reporting.md
@@ -1,0 +1,44 @@
+# Error Reporting Contract
+
+How a failed operation reaches the user. Read this before adding a new error-surfacing site.
+
+## The two MessagePanel channels
+
+`MessagePanelViewModel` holds two independent channels that it merges into one `Entries` list:
+
+- **Transient operation channel** (`_operationEntry`). A single slot for the outcome of the most
+  recent user-initiated operation. Written through `ReportError` / `ReportWarning` / `ReportSuccess`
+  and cleared on the next successful mutation (`ClearOperation`). One operation entry at a time; a
+  new outcome overwrites the previous one. Not counted in the panel's error/warning totals.
+- **Persistent validation channel** (`_validationEntries`). The structural validity of the *current*
+  recipe. Rebuilt wholesale from the recipe snapshot's `IReason` list through `RefreshReasons`.
+  These entries drive the status-bar error/warning counts and persist until the recipe changes.
+
+## Ownership
+
+- **Core owns the error text.** Failures are `FluentResults.Result` with typed `IError` reasons; the
+  message string lives in Core, never in the UI.
+- **The UI only routes.** A view model takes a failed `Result` and hands it to the panel; it does not
+  compose error wording beyond an optional operation prefix (e.g. `"Step 3"`).
+
+## The reporting seam
+
+All `Result`-to-panel routing goes through `ResultReportingExtensions`
+(`SemiStep.UI/MessageService/`):
+
+- `string FormatErrors(this IResultBase)` — joins every error message with `"; "`. The single idiom
+  for rendering a failed result, used by both panel sites and log statements.
+- `void ReportFailure(this MessagePanelViewModel, IResultBase, string? context = null)` — surfaces
+  `FormatErrors()` on the transient operation channel, optionally prefixed with `"{context}: "`.
+
+A failed operation surfaces **all** of its error messages, matching what the log records. Do not
+read `Errors[0]` directly.
+
+## Routing rules
+
+- **Transient operation outcomes** (save/load failed, paste rejected, step edit rejected) go to the
+  operation channel via `ReportFailure` (or `ReportError` when the message is composed mid-string).
+- **Persistent structural state** (the current recipe's validity) goes to the validation channel via
+  `RefreshReasons`, and from there to the status-bar counts.
+- **Exception handlers** (`ReportError($"... {ex.Message}")` on `ThrownExceptions`) are not
+  `Result`-based and stay as-is.

--- a/Docs/plans/20260603-error-reporting-tidy.md
+++ b/Docs/plans/20260603-error-reporting-tidy.md
@@ -1,0 +1,153 @@
+# Error-Reporting Tidy (reporting seam + PLC fault channel / P3)
+
+## Overview
+
+Two stacked PRs that tidy how errors reach the user, building on already-merged #57/#58.
+
+- **PR A — reporting seam.** The UI surfaces only the FIRST error of a failed `Result` (`result.Errors[0].Message`, ~8 sites) while logging shows ALL of them (`string.Join("; ", Errors.Select(e => e.Message))`, ~9 sites). The user sees less than the log, and both idioms are duplicated. Introduce one seam (`FormatErrors` / `ReportFailure`) that removes the duplication and fixes the asymmetry.
+- **PR B — PLC fault channel ("P3", stacked on PR A).** The PLC state stream is `IObservable<Result<PlcSessionSnapshot>>` on a hot `BehaviorSubject`, conflating state with transient failures that no consumer reads (the failure text is invisible to the user). Make the state stream a bare `IObservable<PlcSessionSnapshot>` and deliver faults as discrete one-shot events routed to the MessagePanel via the PR A seam, so "PLC connection lost" / sync failures become user-visible. Persistent "disconnected" stays in the status bar.
+
+Benefit: errors become consistently visible, event and state are separated, the FluentResults-on-hot-observable anti-pattern is removed, and the reporting path is consistent across the whole app.
+
+## Context (from discovery)
+
+- `SemiStep.UI/MessageService/MessagePanelViewModel.cs` — two channels: transient `_operationEntry` (`ReportError/Warning/Success`) + persistent `_validationEntries` (`RefreshReasons`).
+- Panel sites using `Errors[0].Message`: `RecipeFileViewModel.cs:106,126,141`; `RecipeCoordinator.cs:408`; `ClipboardViewModel.cs:115,155`; `MainWindowViewModel.cs:143,181`; `RecipeGridViewModel.cs:204,226`.
+- Logging join-sites: `RecipeCoordinator.cs:177,215,339,378,407,504`; `ClipboardViewModel.cs:140`; `App.axaml.cs:107`; `Program.cs:77`.
+- PLC: `SemiStep.Core/Plc/IPlcSyncService.cs` (`PlcState`), `Sync/PlcSyncCoordinator.cs` (`BehaviorSubject<Result<PlcSessionSnapshot>>`, `PublishSnapshot`, `_connectionLost`), `Sync/PlcSyncExecutor.cs` (`setStatus` callback, `_pendingErrorMessage`), `State/PlcSessionSnapshot.cs` (`InitialState` is `Result<...>`), `SemiStep.UI/Coordinator/RecipeCoordinator.cs` (subscribes `PlcState`, re-publishes), `MainWindow/MainWindowViewModel.cs` (discards payload), `SemiStep.Tests/Helpers/StubPlcSyncService.cs`.
+- Conventions: FluentResults; tabs size 4; usings above file-scoped namespace; constructor injection; KISS/YAGNI.
+
+## Development Approach
+
+- **Testing approach**: Regular (code change, then tests within the same task).
+- One PR = one logical change; PR B stacks on PR A.
+- Build + `dotnet format` + full test suite green before advancing.
+- Preserve untouched: S7Service connection FSM, file-lock ownership, TransportSerializer, the single-`ObserveOn`-at-source + `Publish().RefCount()` threading model.
+
+## Testing Strategy
+
+- Unit tests: `FormatErrors` (single + multi error), `ReportFailure` (context prefix, all-errors visibility); PLC coordinator tests re-pointed from `IsFailed`-on-`PlcState` to the `Faults` channel; fault emitted once on connection-loss and on sync failure; bare `PlcState` always emits Ok-equivalent snapshots.
+- Commands: `dotnet build SemiStep/SemiStep.slnx`, `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`, `dotnet format SemiStep/SemiStep.slnx`.
+
+## Progress Tracking
+
+- Mark `[x]` on completion; ➕ new tasks; ⚠️ blockers. Keep in sync.
+
+## Solution Overview
+
+- **PR A**: `ResultReportingExtensions` in `SemiStep.UI/MessageService/` with `FormatErrors(this IResultBase)` and `ReportFailure(this MessagePanelViewModel, IResultBase, string? context = null)`. All panel sites route through `ReportFailure`; logging join-sites route through `FormatErrors`. The `_operationEntry`/validation two-channel model is unchanged — only the routing into it is unified. A short `Docs/` note codifies the contract.
+- **PR B**: `PlcState` becomes `IObservable<PlcSessionSnapshot>`; a new `IObservable<IError> Faults` carries transient faults emitted once at the event sites. `RecipeCoordinator` bridges `Faults` to the MessagePanel via the PR A seam. Because faults are now one-shot events (not a retained `Result.Fail`), the `_connectionLost` flag (and its three clear-sites) and the executor's `_pendingErrorMessage` lose their only consumer and are removed — see the deviation note.
+
+> **Deviation from the brief (confirm):** the brief said "preserve `_connectionLost` mechanics." Event-based fault delivery makes the persisted flag and `_pendingErrorMessage` dead code (their sole purpose was to drive the now-removed `Result.Fail` on the state stream). This plan removes them as the clean result; the *trigger* (`HandleConnectionLost`) and the *timing* are preserved. If literal preservation is required, keep the flag and skip its removal — but it will be flagged as dead by review.
+
+## Technical Details
+
+- `Faults` is `Subject<IError>` in the coordinator, exposed as `IObservable<IError>`. The executor gets a new `Action<IError> reportFault` constructor callback wired by the coordinator to `_faults.OnNext`. `HandleConnectionLost` calls `_faults.OnNext(new Error("PLC connection lost"))`.
+- **Executor fault sites (enumerate explicitly).** `PlcSyncExecutor` has four `setStatus(Failed)` sites plus one silent abort:
+  - `StartDebounce` catch (unhandled sync exception) → emit `reportFault`.
+  - `CheckCanSyncAsync` `IsRecipeActiveAsync` failure → emit `reportFault`.
+  - `CheckCanSyncAsync` "recipe active" block → emit `reportFault`.
+  - `WriteSyncAsync` write failure → emit `reportFault`.
+  - `CheckCanSyncAsync` `!IsConnected` early-return → **stays silent (no fault, no `setStatus(Failed)`)** — `HandleConnectionLost` already fired the connection-lost fault; emitting here would duplicate the message. (Documented in completed plan `20260603-plc-sync-state-rework.md`.)
+- **`PlcLifecycleManager` is a pass-through facade** (`PlcState => _syncService.PlcState`); it must mirror the new `PlcState` type and add a `Faults => _syncService.Faults` pass-through. `RecipeCoordinator` subscribes `_plc.PlcState`/`_plc.Faults` (the lifecycle manager), not the coordinator directly.
+- **`Faults` is single-consumer** (only `RecipeCoordinator`): a plain `ObserveOn(MainThreadScheduler)` subscription is correct; no `Publish().RefCount()` (that pattern is for the shared multi-subscriber channels). The change from a replaying `BehaviorSubject` to a fire-and-forget `Subject` is safe because `RecipeCoordinator` subscribes once in `Initialize()` before any PLC activity — no fault can fire before the subscription exists.
+- `PlcSyncStatus` (incl. `Failed`) is retained as the state label; the fault is the additional transient message — the two-channel model end to end (state stream + fault event; persistent connection label in the status bar).
+- Fault text is created in Core (typed `Error`), per the agreed ownership; the UI only routes `error.Message` through the seam.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]`): code + tests + branch/PR mechanics.
+- **Post-Completion** (no checkboxes): live PLC check that a real drop now shows a MessagePanel message and the status bar still shows "Disconnected".
+
+## Implementation Steps
+
+### Task 1 (PR A): Add the reporting seam
+
+**Files:**
+- Create: `SemiStep/SemiStep.UI/MessageService/ResultReportingExtensions.cs`
+- Create: `SemiStep/SemiStep.Tests/UI/ResultReportingExtensionsTests.cs`
+
+- [ ] Add `FormatErrors(this IResultBase result)` => `string.Join("; ", result.Errors.Select(e => e.Message))`.
+- [ ] Add `ReportFailure(this MessagePanelViewModel panel, IResultBase result, string? context = null)` => `panel.ReportError(context is null ? result.FormatErrors() : $"{context}: {result.FormatErrors()}")`.
+- [ ] Write tests: `FormatErrors` single error, multi error (join order); `ReportFailure` with and without context (assert the panel entry contains ALL error messages).
+- [ ] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
+- [ ] Run the new tests — must pass.
+
+### Task 2 (PR A): Route all panel + logging sites through the seam
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs`, `SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs`, `SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs`, `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs`, `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs`, `SemiStep/SemiStep.UI/App.axaml.cs`, `SemiStep/SemiStep.UI/Program.cs`
+
+- [ ] Replace the ~8 `ReportError(result.Errors[0].Message)` sites with `ReportFailure(result, context)`, preserving existing prefixes via `context` ("Failed to save recipe", "Step {n}", "PLC reconnect", etc.). Exception-based `ReportError($"... {ex.Message}")` sites are NOT Result-based — leave them.
+- [ ] **Per-site decision for embedded-literal messages.** The `context: message` template only fits two-part `prefix: message` strings. Sites where the literal sits mid-string — notably `RecipeGridViewModel.cs:226` (`"Step {n}: Failed to change action - {message}"`) — cannot be reproduced by `context`. For each such site, either (a) accept the reworded message (`"Step {n}: Failed to change action: {all-errors}"`) and pin the new text with a test, or (b) keep manual composition via `ReportError($"... {result.FormatErrors()}")`. Decide explicitly per site; do not assume all fit the `context` mold. This is the one place message text may change beyond the all-errors fix.
+- [ ] Replace the UI-side logging `string.Join("; ", ...Errors.Select(e => e.Message))` sites with `result.FormatErrors()`.
+- [ ] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green (behavior change: failed operations now surface ALL error messages; update any test asserting a single-message panel entry).
+
+### Task 3 (PR A): Document the contract; format, commit, push, PR
+
+**Files:**
+- Create: `Docs/error-reporting.md`
+
+- [ ] Write a short `Docs/error-reporting.md`: the two channels (transient operation entry vs persistent validation reasons), Core owns error text, UI routes via `ReportFailure`, events -> operation channel, state -> reasons/status bar. Match the language of surrounding `Docs/` files.
+- [ ] `dotnet format SemiStep/SemiStep.slnx`.
+- [ ] Commit on `error-report-seam` (`refactor: unify Result-to-MessagePanel reporting; surface all operation errors`); verify `git log origin/master..HEAD --oneline` is only this change; push; `gh pr create --base master`.
+
+### Task 4 (PR B): Branch off PR A (stacked)
+
+- [ ] From the worktree on `error-report-seam`, `git switch -c plc-fault-channel`.
+
+### Task 5 (PR B): Bare PlcState + Faults channel in Core
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs`, `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs`, `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncExecutor.cs`, `SemiStep/SemiStep.Core/Plc/State/PlcSessionSnapshot.cs`, `SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs`
+
+- [ ] `IPlcSyncService`: change `PlcState` to `IObservable<PlcSessionSnapshot>`; add `IObservable<IError> Faults`.
+- [ ] `PlcSessionSnapshot.InitialState`: bare `PlcSessionSnapshot` (drop the `Result.Ok` wrapper).
+- [ ] `PlcSyncCoordinator`: `BehaviorSubject<PlcSessionSnapshot>` + `Subject<IError> _faults` (expose as `Faults`); `PublishSnapshot` always publishes the snapshot (remove both `Fail` branches); `HandleConnectionLost` emits `_faults.OnNext(new Error("PLC connection lost"))`; remove `_connectionLost` and its clear-sites (see deviation note); dispose `_faults` in `Dispose`.
+- [ ] `PlcSyncExecutor`: add `Action<IError> reportFault` ctor callback; emit `reportFault(new Error(message))` at the four `setStatus(Failed)` sites enumerated in Technical Details; keep the `!IsConnected` early-return SILENT (no fault — avoids duplicating the connection-lost message); remove `_pendingErrorMessage`/`PendingErrorMessage` (now unused).
+- [ ] `PlcLifecycleManager`: change the `PlcState` pass-through property type to `IObservable<PlcSessionSnapshot>`; add `public IObservable<IError> Faults => _syncService.Faults;`.
+- [ ] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — resolve all references to the removed `Result` wrapper / fields.
+
+### Task 6 (PR B): Bridge faults to the MessagePanel in the UI
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs`, `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs`
+
+- [ ] `RecipeCoordinator`: subscribe `_plc.Faults`, `ObserveOn(MainThreadScheduler)`, route each `IError` to the MessagePanel via the PR A seam (`ReportFailure`/`ReportError(error.Message)`); dispose the subscription with the others. Single-consumer channel → a plain `ObserveOn` subscription, NOT `Publish().RefCount()`.
+- [ ] Change `PlcState`/`PlcStateChanged` and `OnPlcStateChanged`/`LogPlcStateChange` to carry bare `PlcSessionSnapshot` (drop `Result`/`IsFailed` handling). `MainWindowViewModel` already discards the payload — adjust the type only.
+- [ ] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
+
+### Task 7 (PR B): Update stub + tests
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/Helpers/StubPlcSyncService.cs`, `SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs`, `SemiStep/SemiStep.Tests/UI/RecipeCoordinatorTests.cs`, `SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs`, any other test asserting `IsFailed` on `PlcState`
+
+- [ ] `StubPlcSyncService`: `PlcState` -> bare snapshot subject; add a `Faults` subject + push helpers. Update `PushPlcState(Result.Ok(...))` signature to bare snapshot and fix its callers — incl. `UIFixture.cs` (`PushPlcState(Result.Ok(...))`) and `RecipeCoordinatorTests.cs` (`PushPlcState(Result.Fail(...))`).
+- [ ] **Replace the now-contradicting UI test** `RecipeCoordinatorTests.PlcStateChange_Failure_DoesNotAddEntriesToMessagePanel` (it asserted a `Result.Fail` on `PlcState` adds NO panel entry — the opposite of the new contract). Replace with a positive test: a `Faults` emission routes to the MessagePanel operation channel (entry appears with the fault message).
+- [ ] **Rewrite, don't re-point, the `_connectionLost`-clearing regression tests** in `PlcSyncCoordinatorTests` (the re-enable-clears-flag / reconnect-clears-flag tests). With one-shot faults there is nothing lingering to clear; replace with: connection-loss emits exactly ONE fault on `Faults`, and a subsequent reconnect/re-enable emits NO further fault.
+- [ ] Re-point remaining assertions that checked `IsFailed`/`Errors` on `PlcState` to assert on `Faults`; `PlcState` now always carries a snapshot.
+- [ ] Add: sync-write failure emits a fault carrying the message; the `!IsConnected` debounce-abort emits NO fault (no duplicate of the connection-lost fault).
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green.
+
+### Task 8 (PR B): Format, commit, push, stacked PR
+
+- [ ] `dotnet format SemiStep/SemiStep.slnx`.
+- [ ] Commit on `plc-fault-channel` (`refactor: deliver PLC faults via a discrete channel; bare PlcState snapshot stream`); push; `gh pr create --base error-report-seam` (stacked; note dependency on PR A).
+
+### Task 9: Verify acceptance criteria
+
+- [ ] PR A: failed operations surface all error messages. Grep acceptance: `Errors[0]` and `string.Join("; "` across `SemiStep/SemiStep.UI` return only intentionally-excluded sites (exception-based handlers), nothing Result-based.
+- [ ] PR B: `PlcState` is bare; `Faults` channel delivers connection-loss/sync-failure once; `_connectionLost`/`_pendingErrorMessage` removed; preserved subsystems untouched (`git diff origin/master...HEAD --stat`).
+- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green on the PR B branch.
+
+### Task 10: [Final] Plan housekeeping
+
+- [ ] Mark all checkboxes; note deviations.
+- [ ] Move this plan to `Docs/plans/completed/` (commit on the PR B branch).
+
+## Post-Completion
+
+*Manual / external — no checkboxes.*
+
+- Live PLC (192.168.0.150): trigger a real connection drop while sync is enabled → a "PLC connection lost" message must appear in the MessagePanel (transient) AND the status bar must still show "Disconnected" (persistent). Confirm a sync write failure surfaces its message in the panel.

--- a/Docs/plans/20260603-error-reporting-tidy.md
+++ b/Docs/plans/20260603-error-reporting-tidy.md
@@ -67,31 +67,31 @@ Benefit: errors become consistently visible, event and state are separated, the 
 - Create: `SemiStep/SemiStep.UI/MessageService/ResultReportingExtensions.cs`
 - Create: `SemiStep/SemiStep.Tests/UI/ResultReportingExtensionsTests.cs`
 
-- [ ] Add `FormatErrors(this IResultBase result)` => `string.Join("; ", result.Errors.Select(e => e.Message))`.
-- [ ] Add `ReportFailure(this MessagePanelViewModel panel, IResultBase result, string? context = null)` => `panel.ReportError(context is null ? result.FormatErrors() : $"{context}: {result.FormatErrors()}")`.
-- [ ] Write tests: `FormatErrors` single error, multi error (join order); `ReportFailure` with and without context (assert the panel entry contains ALL error messages).
-- [ ] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
-- [ ] Run the new tests — must pass.
+- [x] Add `FormatErrors(this IResultBase result)` => `string.Join("; ", result.Errors.Select(e => e.Message))`.
+- [x] Add `ReportFailure(this MessagePanelViewModel panel, IResultBase result, string? context = null)` => `panel.ReportError(context is null ? result.FormatErrors() : $"{context}: {result.FormatErrors()}")`.
+- [x] Write tests: `FormatErrors` single error, multi error (join order); `ReportFailure` with and without context (assert the panel entry contains ALL error messages).
+- [x] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
+- [x] Run the new tests — must pass.
 
 ### Task 2 (PR A): Route all panel + logging sites through the seam
 
 **Files:**
 - Modify: `SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs`, `SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs`, `SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs`, `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs`, `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs`, `SemiStep/SemiStep.UI/App.axaml.cs`, `SemiStep/SemiStep.UI/Program.cs`
 
-- [ ] Replace the ~8 `ReportError(result.Errors[0].Message)` sites with `ReportFailure(result, context)`, preserving existing prefixes via `context` ("Failed to save recipe", "Step {n}", "PLC reconnect", etc.). Exception-based `ReportError($"... {ex.Message}")` sites are NOT Result-based — leave them.
-- [ ] **Per-site decision for embedded-literal messages.** The `context: message` template only fits two-part `prefix: message` strings. Sites where the literal sits mid-string — notably `RecipeGridViewModel.cs:226` (`"Step {n}: Failed to change action - {message}"`) — cannot be reproduced by `context`. For each such site, either (a) accept the reworded message (`"Step {n}: Failed to change action: {all-errors}"`) and pin the new text with a test, or (b) keep manual composition via `ReportError($"... {result.FormatErrors()}")`. Decide explicitly per site; do not assume all fit the `context` mold. This is the one place message text may change beyond the all-errors fix.
-- [ ] Replace the UI-side logging `string.Join("; ", ...Errors.Select(e => e.Message))` sites with `result.FormatErrors()`.
-- [ ] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
-- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green (behavior change: failed operations now surface ALL error messages; update any test asserting a single-message panel entry).
+- [x] Replace the ~8 `ReportError(result.Errors[0].Message)` sites with `ReportFailure(result, context)`, preserving existing prefixes via `context` ("Failed to save recipe", "Step {n}", "PLC reconnect", etc.). Exception-based `ReportError($"... {ex.Message}")` sites are NOT Result-based — leave them.
+- [x] **Per-site decision for embedded-literal messages.** `RecipeGridViewModel.cs:226` kept its verbatim wording via option (b): `ReportError($"Step {n}: Failed to change action - {result.FormatErrors()}")`.
+- [x] Replace the UI-side logging `string.Join("; ", ...Errors.Select(e => e.Message))` sites with `result.FormatErrors()`.
+- [x] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green (behavior change: failed operations now surface ALL error messages; update any test asserting a single-message panel entry).
 
 ### Task 3 (PR A): Document the contract; format, commit, push, PR
 
 **Files:**
 - Create: `Docs/error-reporting.md`
 
-- [ ] Write a short `Docs/error-reporting.md`: the two channels (transient operation entry vs persistent validation reasons), Core owns error text, UI routes via `ReportFailure`, events -> operation channel, state -> reasons/status bar. Match the language of surrounding `Docs/` files.
-- [ ] `dotnet format SemiStep/SemiStep.slnx`.
-- [ ] Commit on `error-report-seam` (`refactor: unify Result-to-MessagePanel reporting; surface all operation errors`); verify `git log origin/master..HEAD --oneline` is only this change; push; `gh pr create --base master`.
+- [x] Write a short `Docs/error-reporting.md`: the two channels (transient operation entry vs persistent validation reasons), Core owns error text, UI routes via `ReportFailure`, events -> operation channel, state -> reasons/status bar. Match the language of surrounding `Docs/` files.
+- [x] `dotnet format SemiStep/SemiStep.slnx`.
+- [x] Commit on `error-report-seam` (`refactor: unify Result-to-MessagePanel reporting; surface all operation errors`); verify `git log origin/master..HEAD --oneline` is only this change; push; `gh pr create --base master`.
 
 ### Task 4 (PR B): Branch off PR A (stacked)
 

--- a/SemiStep/SemiStep.Tests/UI/ResultReportingExtensionsTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/ResultReportingExtensionsTests.cs
@@ -1,0 +1,71 @@
+﻿using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using FluentResults;
+
+using SemiStep.UI.MessageService;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI;
+
+[Trait("Component", "UI")]
+[Trait("Area", "MessageReporting")]
+[Trait("Category", "Unit")]
+public sealed class ResultReportingExtensionsTests
+{
+	[Fact]
+	public void FormatErrors_SingleError_ReturnsThatMessage()
+	{
+		var result = Result.Fail("only error");
+
+		result.FormatErrors().Should().Be("only error");
+	}
+
+	[Fact]
+	public void FormatErrors_MultipleErrors_JoinsAllMessagesInOrder()
+	{
+		var result = Result.Fail("first").WithError("second").WithError("third");
+
+		result.FormatErrors().Should().Be("first; second; third");
+	}
+
+	[AvaloniaFact]
+	public void ReportFailure_WithoutContext_SurfacesAllErrorMessages()
+	{
+		var panel = new MessagePanelViewModel();
+		var result = Result.Fail("first").WithError("second");
+
+		try
+		{
+			panel.ReportFailure(result);
+
+			var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+			entry.Message.Should().Be("first; second");
+		}
+		finally
+		{
+			panel.Dispose();
+		}
+	}
+
+	[AvaloniaFact]
+	public void ReportFailure_WithContext_PrefixesAndSurfacesAllErrorMessages()
+	{
+		var panel = new MessagePanelViewModel();
+		var result = Result.Fail("first").WithError("second");
+
+		try
+		{
+			panel.ReportFailure(result, "Step 1");
+
+			var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+			entry.Message.Should().Be("Step 1: first; second");
+		}
+		finally
+		{
+			panel.Dispose();
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/ResultReportingExtensionsTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/ResultReportingExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Headless.XUnit;
+﻿using System;
+
+using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
@@ -13,8 +15,23 @@ namespace SemiStep.Tests.UI;
 [Trait("Component", "UI")]
 [Trait("Area", "MessageReporting")]
 [Trait("Category", "Unit")]
-public sealed class ResultReportingExtensionsTests
+public sealed class ResultReportingExtensionsTests : IDisposable
 {
+	private readonly MessagePanelViewModel _panel = new();
+
+	public void Dispose()
+	{
+		_panel.Dispose();
+	}
+
+	[Fact]
+	public void FormatErrors_SuccessResult_ReturnsEmptyString()
+	{
+		var result = Result.Ok();
+
+		result.FormatErrors().Should().BeEmpty();
+	}
+
 	[Fact]
 	public void FormatErrors_SingleError_ReturnsThatMessage()
 	{
@@ -32,40 +49,35 @@ public sealed class ResultReportingExtensionsTests
 	}
 
 	[AvaloniaFact]
+	public void ReportFailure_SingleErrorWithoutContext_SurfacesThatMessage()
+	{
+		var result = Result.Fail("only error");
+
+		_panel.ReportFailure(result);
+
+		var entry = _panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+		entry.Message.Should().Be("only error");
+	}
+
+	[AvaloniaFact]
 	public void ReportFailure_WithoutContext_SurfacesAllErrorMessages()
 	{
-		var panel = new MessagePanelViewModel();
 		var result = Result.Fail("first").WithError("second");
 
-		try
-		{
-			panel.ReportFailure(result);
+		_panel.ReportFailure(result);
 
-			var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
-			entry.Message.Should().Be("first; second");
-		}
-		finally
-		{
-			panel.Dispose();
-		}
+		var entry = _panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+		entry.Message.Should().Be("first; second");
 	}
 
 	[AvaloniaFact]
 	public void ReportFailure_WithContext_PrefixesAndSurfacesAllErrorMessages()
 	{
-		var panel = new MessagePanelViewModel();
 		var result = Result.Fail("first").WithError("second");
 
-		try
-		{
-			panel.ReportFailure(result, "Step 1");
+		_panel.ReportFailure(result, "Step 1");
 
-			var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
-			entry.Message.Should().Be("Step 1: first; second");
-		}
-		finally
-		{
-			panel.Dispose();
-		}
+		var entry = _panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+		entry.Message.Should().Be("Step 1: first; second");
 	}
 }

--- a/SemiStep/SemiStep.UI/App.axaml.cs
+++ b/SemiStep/SemiStep.UI/App.axaml.cs
@@ -11,6 +11,7 @@ using SemiStep.Core.Recipes;
 using SemiStep.UI.Coordinator;
 using SemiStep.UI.Dialogs;
 using SemiStep.UI.MainWindow;
+using SemiStep.UI.MessageService;
 using SemiStep.UI.RecipeGrid;
 using SemiStep.UI.Styles;
 
@@ -104,7 +105,7 @@ public class App : Application
 		if (resetResult.IsFailed)
 		{
 			Log.Warning("Session reset reported failures at startup: {Errors}",
-				string.Join("; ", resetResult.Errors.Select(e => e.Message)));
+				resetResult.FormatErrors());
 		}
 
 		var coordinator = provider.GetRequiredService<RecipeCoordinator>();

--- a/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
+++ b/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
@@ -112,7 +112,7 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 		var result = _coordinator.RemoveSteps(_recipeGrid.SelectedRowIndices);
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportError(result.Errors[0].Message);
+			_messagePanel.ReportFailure(result);
 			return;
 		}
 
@@ -152,7 +152,7 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 		var insertResult = _coordinator.InsertSteps(insertIndex, recipeResult.Value.Steps);
 		if (insertResult.IsFailed)
 		{
-			_messagePanel.ReportError(insertResult.Errors[0].Message);
+			_messagePanel.ReportFailure(insertResult);
 			return;
 		}
 

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -174,7 +174,7 @@ public sealed class RecipeCoordinator : IDisposable
 		{
 			_logger.LogWarning(
 				"PLC sync enable failed: {Errors}",
-				string.Join("; ", result.Errors.Select(e => e.Message)));
+				result.FormatErrors());
 		}
 		else
 		{
@@ -212,7 +212,7 @@ public sealed class RecipeCoordinator : IDisposable
 			RebuildMessagePanel();
 			_logger.LogWarning(
 				"Failed to load recipe from PLC: {Errors}",
-				string.Join("; ", result.Errors.Select(e => e.Message)));
+				result.FormatErrors());
 			return result;
 		}
 
@@ -336,7 +336,7 @@ public sealed class RecipeCoordinator : IDisposable
 			_logger.LogWarning(
 				"Failed to load recipe from {FilePath}: {Errors}",
 				filePath,
-				string.Join("; ", result.Errors.Select(e => e.Message)));
+				result.FormatErrors());
 			return result;
 		}
 
@@ -375,7 +375,7 @@ public sealed class RecipeCoordinator : IDisposable
 		{
 			_logger.LogError("Failed to save recipe to {FilePath}: {Errors}",
 				filePath,
-				string.Join("; ", result.Errors.Select(e => e.Message)));
+				result.FormatErrors());
 		}
 		else
 		{
@@ -404,8 +404,8 @@ public sealed class RecipeCoordinator : IDisposable
 				RebuildMessagePanel();
 				_logger.LogWarning(
 					"Reconnect reconciliation failed to apply PLC recipe: {Errors}",
-					string.Join("; ", applyResult.Errors.Select(e => e.Message)));
-				_messagePanel.ReportError($"PLC reconnect: {applyResult.Errors[0].Message}");
+					applyResult.FormatErrors());
+				_messagePanel.ReportFailure(applyResult, "PLC reconnect");
 				return applyResult;
 			}
 
@@ -501,7 +501,7 @@ public sealed class RecipeCoordinator : IDisposable
 		{
 			_logger.LogWarning(
 				"PLC state change: failure {Errors}",
-				string.Join("; ", result.Errors.Select(e => e.Message)));
+				result.FormatErrors());
 			return;
 		}
 

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
@@ -140,7 +140,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 
 			if (result.IsFailed)
 			{
-				MessagePanel.ReportError(result.Errors[0].Message);
+				MessagePanel.ReportFailure(result);
 			}
 		}
 
@@ -178,7 +178,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 
 		if (result.IsFailed)
 		{
-			MessagePanel.ReportError(result.Errors[0].Message);
+			MessagePanel.ReportFailure(result);
 		}
 	}
 

--- a/SemiStep/SemiStep.UI/MessageService/ResultReportingExtensions.cs
+++ b/SemiStep/SemiStep.UI/MessageService/ResultReportingExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+
+using FluentResults;
+
+namespace SemiStep.UI.MessageService;
+
+public static class ResultReportingExtensions
+{
+	public static string FormatErrors(this IResultBase result)
+	{
+		return string.Join("; ", result.Errors.Select(error => error.Message));
+	}
+
+	public static void ReportFailure(this MessagePanelViewModel panel, IResultBase result, string? context = null)
+	{
+		var message = result.FormatErrors();
+		panel.ReportError(context is null ? message : $"{context}: {message}");
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs
@@ -103,7 +103,7 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportError($"Failed to save recipe: {result.Errors[0].Message}");
+			_messagePanel.ReportFailure(result, "Failed to save recipe");
 
 			return;
 		}
@@ -123,7 +123,7 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 		var result = await _coordinator.LoadRecipeAsync(filePath);
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportError(result.Errors[0].Message);
+			_messagePanel.ReportFailure(result);
 
 			return;
 		}
@@ -138,7 +138,7 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportError(result.Errors[0].Message);
+			_messagePanel.ReportFailure(result);
 
 			return;
 		}

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
@@ -201,7 +201,7 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportError($"Step {stepIndex + 1}: {result.Errors[0].Message}");
+			_messagePanel.ReportFailure(result, $"Step {stepIndex + 1}");
 		}
 	}
 
@@ -223,7 +223,7 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 		if (result.IsFailed)
 		{
 			_messagePanel.ReportError(
-				$"Step {stepIndex + 1}: Failed to change action - {result.Errors[0].Message}");
+				$"Step {stepIndex + 1}: Failed to change action - {result.FormatErrors()}");
 			return;
 		}
 
@@ -441,7 +441,7 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 				"Unknown action key {ActionKey} in step {StepNumber}: {Errors}",
 				step.ActionKey,
 				stepNumber,
-				string.Join("; ", actionResult.Errors.Select(e => e.Message)));
+				actionResult.FormatErrors());
 			_messagePanel.ReportError($"Step {stepNumber}: unknown action (key={step.ActionKey})");
 			return null;
 		}


### PR DESCRIPTION
## Problem

A failed FluentResults `Result` reached the user through two duplicated idioms, with an asymmetry: the user-facing MessagePanel showed only the FIRST error (`result.Errors[0].Message`, ~8 sites) while logging showed ALL of them (`string.Join("; ", Errors.Select(e => e.Message))`, ~9 sites). The user saw less than the log.

## Change

Introduce one reporting seam in `SemiStep.UI/MessageService/ResultReportingExtensions.cs`:

- `FormatErrors(this IResultBase)` — joins every error message with `"; "`.
- `ReportFailure(this MessagePanelViewModel, IResultBase, string? context = null)` — surfaces `FormatErrors()` on the transient operation channel, optionally prefixed by `context`.

All `Result`-based panel sites now route through `ReportFailure` (existing prefixes preserved via `context`); the duplicated `"; "` logging joins route through `FormatErrors`. A failed operation now surfaces ALL its error messages, matching the log. No other behavior change.

`RecipeGridViewModel` change-action message text is preserved verbatim (`"Step {n}: Failed to change action - {...}"`) via manual composition with `FormatErrors()` — same wording, now all errors.

## Sites migrated

- 8 panel sites → `ReportFailure` (RecipeFile x3, Clipboard x2, MainWindow x2, RecipeGrid:204) + 1 embedded-literal preserved (RecipeGrid:226).
- 8 logging `"; "` join-sites → `FormatErrors` (RecipeCoordinator x6, App.axaml.cs, RecipeGrid:444).
- Exception-based handlers and the NewLine-joined paste site left untouched (not `Result.Errors[0]` / not `"; "`).

Adds `Docs/error-reporting.md` documenting the two MessagePanel channels and the seam contract, plus unit tests for `FormatErrors`/`ReportFailure`.

Full suite: 756 passed.

PR 1 of 2; PR 2 (PLC fault channel) stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)