### PR TITLE
refactor: deliver PLC faults via a discrete channel; bare PlcState stream

### DIFF
--- a/Docs/error-reporting.md
+++ b/Docs/error-reporting.md
@@ -40,6 +40,10 @@ read `Errors[0]` directly.
   operation channel via `ReportFailure` (or `ReportError` when the message is composed mid-string).
 - **Persistent structural state** (the current recipe's validity) goes to the validation channel via
   `RefreshReasons`, and from there to the status-bar counts.
+- **PLC connection-loss / sync failures** arrive as a typed `IError` on `IPlcSyncService.Faults`, a
+  discrete one-shot channel. `RecipeCoordinator` bridges each fault to the operation channel via
+  `ReportError(error.Message)` — the message text is owned in Core. The persistent "disconnected"
+  label stays in the status bar.
 - **Exception handlers** (`ReportError($"... {ex.Message}")` on `ThrownExceptions`) are not
   `Result`-based and stay as-is.
 - **One deliberate exception** to the `"; "` idiom: the clipboard *paste* failure lists each error on

--- a/Docs/plans/completed/20260603-error-reporting-tidy.md
+++ b/Docs/plans/completed/20260603-error-reporting-tidy.md
@@ -95,56 +95,56 @@ Benefit: errors become consistently visible, event and state are separated, the 
 
 ### Task 4 (PR B): Branch off PR A (stacked)
 
-- [ ] From the worktree on `error-report-seam`, `git switch -c plc-fault-channel`.
+- [x] From the worktree on `error-report-seam`, `git switch -c plc-fault-channel`.
 
 ### Task 5 (PR B): Bare PlcState + Faults channel in Core
 
 **Files:**
 - Modify: `SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs`, `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs`, `SemiStep/SemiStep.Core/Plc/Sync/PlcSyncExecutor.cs`, `SemiStep/SemiStep.Core/Plc/State/PlcSessionSnapshot.cs`, `SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs`
 
-- [ ] `IPlcSyncService`: change `PlcState` to `IObservable<PlcSessionSnapshot>`; add `IObservable<IError> Faults`.
-- [ ] `PlcSessionSnapshot.InitialState`: bare `PlcSessionSnapshot` (drop the `Result.Ok` wrapper).
-- [ ] `PlcSyncCoordinator`: `BehaviorSubject<PlcSessionSnapshot>` + `Subject<IError> _faults` (expose as `Faults`); `PublishSnapshot` always publishes the snapshot (remove both `Fail` branches); `HandleConnectionLost` emits `_faults.OnNext(new Error("PLC connection lost"))`; remove `_connectionLost` and its clear-sites (see deviation note); dispose `_faults` in `Dispose`.
-- [ ] `PlcSyncExecutor`: add `Action<IError> reportFault` ctor callback; emit `reportFault(new Error(message))` at the four `setStatus(Failed)` sites enumerated in Technical Details; keep the `!IsConnected` early-return SILENT (no fault — avoids duplicating the connection-lost message); remove `_pendingErrorMessage`/`PendingErrorMessage` (now unused).
-- [ ] `PlcLifecycleManager`: change the `PlcState` pass-through property type to `IObservable<PlcSessionSnapshot>`; add `public IObservable<IError> Faults => _syncService.Faults;`.
-- [ ] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — resolve all references to the removed `Result` wrapper / fields.
+- [x] `IPlcSyncService`: change `PlcState` to `IObservable<PlcSessionSnapshot>`; add `IObservable<IError> Faults`.
+- [x] `PlcSessionSnapshot.InitialState`: bare `PlcSessionSnapshot` (drop the `Result.Ok` wrapper).
+- [x] `PlcSyncCoordinator`: `BehaviorSubject<PlcSessionSnapshot>` + `Subject<IError> _faults` (expose as `Faults`); `PublishSnapshot` always publishes the snapshot (remove both `Fail` branches); `HandleConnectionLost` emits `_faults.OnNext(new Error("PLC connection lost"))`; remove `_connectionLost` and its clear-sites (see deviation note); dispose `_faults` in `Dispose`.
+- [x] `PlcSyncExecutor`: add `Action<IError> reportFault` ctor callback; emit `reportFault(new Error(message))` at the four `setStatus(Failed)` sites enumerated in Technical Details; keep the `!IsConnected` early-return SILENT (no fault — avoids duplicating the connection-lost message); remove `_pendingErrorMessage`/`PendingErrorMessage` (now unused).
+- [x] `PlcLifecycleManager`: change the `PlcState` pass-through property type to `IObservable<PlcSessionSnapshot>`; add `public IObservable<IError> Faults => _syncService.Faults;`.
+- [x] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — resolve all references to the removed `Result` wrapper / fields.
 
 ### Task 6 (PR B): Bridge faults to the MessagePanel in the UI
 
 **Files:**
 - Modify: `SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs`, `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs`
 
-- [ ] `RecipeCoordinator`: subscribe `_plc.Faults`, `ObserveOn(MainThreadScheduler)`, route each `IError` to the MessagePanel via the PR A seam (`ReportFailure`/`ReportError(error.Message)`); dispose the subscription with the others. Single-consumer channel → a plain `ObserveOn` subscription, NOT `Publish().RefCount()`.
-- [ ] Change `PlcState`/`PlcStateChanged` and `OnPlcStateChanged`/`LogPlcStateChange` to carry bare `PlcSessionSnapshot` (drop `Result`/`IsFailed` handling). `MainWindowViewModel` already discards the payload — adjust the type only.
-- [ ] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
+- [x] `RecipeCoordinator`: subscribe `_plc.Faults`, `ObserveOn(MainThreadScheduler)`, route each `IError` to the MessagePanel via the PR A seam (`ReportFailure`/`ReportError(error.Message)`); dispose the subscription with the others. Single-consumer channel → a plain `ObserveOn` subscription, NOT `Publish().RefCount()`.
+- [x] Change `PlcState`/`PlcStateChanged` and `OnPlcStateChanged`/`LogPlcStateChange` to carry bare `PlcSessionSnapshot` (drop `Result`/`IsFailed` handling). `MainWindowViewModel` already discards the payload — adjust the type only.
+- [x] `dotnet build SemiStep/SemiStep.slnx -clp:ErrorsOnly` — 0 errors.
 
 ### Task 7 (PR B): Update stub + tests
 
 **Files:**
 - Modify: `SemiStep/SemiStep.Tests/Helpers/StubPlcSyncService.cs`, `SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs`, `SemiStep/SemiStep.Tests/UI/RecipeCoordinatorTests.cs`, `SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs`, any other test asserting `IsFailed` on `PlcState`
 
-- [ ] `StubPlcSyncService`: `PlcState` -> bare snapshot subject; add a `Faults` subject + push helpers. Update `PushPlcState(Result.Ok(...))` signature to bare snapshot and fix its callers — incl. `UIFixture.cs` (`PushPlcState(Result.Ok(...))`) and `RecipeCoordinatorTests.cs` (`PushPlcState(Result.Fail(...))`).
-- [ ] **Replace the now-contradicting UI test** `RecipeCoordinatorTests.PlcStateChange_Failure_DoesNotAddEntriesToMessagePanel` (it asserted a `Result.Fail` on `PlcState` adds NO panel entry — the opposite of the new contract). Replace with a positive test: a `Faults` emission routes to the MessagePanel operation channel (entry appears with the fault message).
-- [ ] **Rewrite, don't re-point, the `_connectionLost`-clearing regression tests** in `PlcSyncCoordinatorTests` (the re-enable-clears-flag / reconnect-clears-flag tests). With one-shot faults there is nothing lingering to clear; replace with: connection-loss emits exactly ONE fault on `Faults`, and a subsequent reconnect/re-enable emits NO further fault.
-- [ ] Re-point remaining assertions that checked `IsFailed`/`Errors` on `PlcState` to assert on `Faults`; `PlcState` now always carries a snapshot.
-- [ ] Add: sync-write failure emits a fault carrying the message; the `!IsConnected` debounce-abort emits NO fault (no duplicate of the connection-lost fault).
-- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green.
+- [x] `StubPlcSyncService`: `PlcState` -> bare snapshot subject; add a `Faults` subject + push helpers. Update `PushPlcState(Result.Ok(...))` signature to bare snapshot and fix its callers — incl. `UIFixture.cs` (`PushPlcState(Result.Ok(...))`) and `RecipeCoordinatorTests.cs` (`PushPlcState(Result.Fail(...))`).
+- [x] **Replace the now-contradicting UI test** `RecipeCoordinatorTests.PlcStateChange_Failure_DoesNotAddEntriesToMessagePanel` (it asserted a `Result.Fail` on `PlcState` adds NO panel entry — the opposite of the new contract). Replace with a positive test: a `Faults` emission routes to the MessagePanel operation channel (entry appears with the fault message).
+- [x] **Rewrite, don't re-point, the `_connectionLost`-clearing regression tests** in `PlcSyncCoordinatorTests` (the re-enable-clears-flag / reconnect-clears-flag tests). With one-shot faults there is nothing lingering to clear; replace with: connection-loss emits exactly ONE fault on `Faults`, and a subsequent reconnect/re-enable emits NO further fault.
+- [x] Re-point remaining assertions that checked `IsFailed`/`Errors` on `PlcState` to assert on `Faults`; `PlcState` now always carries a snapshot.
+- [x] Add: sync-write failure emits a fault carrying the message; the `!IsConnected` debounce-abort emits NO fault (no duplicate of the connection-lost fault).
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green.
 
 ### Task 8 (PR B): Format, commit, push, stacked PR
 
-- [ ] `dotnet format SemiStep/SemiStep.slnx`.
-- [ ] Commit on `plc-fault-channel` (`refactor: deliver PLC faults via a discrete channel; bare PlcState snapshot stream`); push; `gh pr create --base error-report-seam` (stacked; note dependency on PR A).
+- [x] `dotnet format SemiStep/SemiStep.slnx`.
+- [x] Commit on `plc-fault-channel` (`refactor: deliver PLC faults via a discrete channel; bare PlcState snapshot stream`); push; `gh pr create --base error-report-seam` (stacked; note dependency on PR A).
 
 ### Task 9: Verify acceptance criteria
 
-- [ ] PR A: failed operations surface all error messages. Grep acceptance: `Errors[0]` and `string.Join("; "` across `SemiStep/SemiStep.UI` return only intentionally-excluded sites (exception-based handlers), nothing Result-based.
-- [ ] PR B: `PlcState` is bare; `Faults` channel delivers connection-loss/sync-failure once; `_connectionLost`/`_pendingErrorMessage` removed; preserved subsystems untouched (`git diff origin/master...HEAD --stat`).
-- [ ] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green on the PR B branch.
+- [x] PR A: failed operations surface all error messages. Grep acceptance: `Errors[0]` and `string.Join("; "` across `SemiStep/SemiStep.UI` return only intentionally-excluded sites (exception-based handlers), nothing Result-based.
+- [x] PR B: `PlcState` is bare; `Faults` channel delivers connection-loss/sync-failure once; `_connectionLost`/`_pendingErrorMessage` removed; preserved subsystems untouched (`git diff origin/master...HEAD --stat`).
+- [x] `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — full suite green on the PR B branch.
 
 ### Task 10: [Final] Plan housekeeping
 
-- [ ] Mark all checkboxes; note deviations.
-- [ ] Move this plan to `Docs/plans/completed/` (commit on the PR B branch).
+- [x] Mark all checkboxes; note deviations.
+- [x] Move this plan to `Docs/plans/completed/` (commit on the PR B branch).
 
 ## Post-Completion
 

--- a/SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs
+++ b/SemiStep/SemiStep.Core/Plc/IPlcSyncService.cs
@@ -23,5 +23,7 @@ public interface IPlcSyncService
 
 	DateTimeOffset? LastSyncTime { get; }
 
-	IObservable<Result<PlcSessionSnapshot>> PlcState { get; }
+	IObservable<PlcSessionSnapshot> PlcState { get; }
+
+	IObservable<IError> Faults { get; }
 }

--- a/SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs
+++ b/SemiStep/SemiStep.Core/Plc/PlcLifecycleManager.cs
@@ -58,7 +58,9 @@ public sealed class PlcLifecycleManager : IDisposable
 	public PlcSyncStatus SyncStatus => _syncService.Status;
 	public DateTimeOffset? LastSyncTime => _syncService.LastSyncTime;
 
-	public IObservable<Result<PlcSessionSnapshot>> PlcState => _syncService.PlcState;
+	public IObservable<PlcSessionSnapshot> PlcState => _syncService.PlcState;
+
+	public IObservable<IError> Faults => _syncService.Faults;
 
 	public event Action<Recipe, Recipe>? PlcRecipeConflictDetected;
 

--- a/SemiStep/SemiStep.Core/Plc/State/PlcSessionSnapshot.cs
+++ b/SemiStep/SemiStep.Core/Plc/State/PlcSessionSnapshot.cs
@@ -1,9 +1,7 @@
-﻿using FluentResults;
-
-namespace SemiStep.Core.Plc.State;
+﻿namespace SemiStep.Core.Plc.State;
 
 public sealed record PlcSessionSnapshot(PlcConnectionState ConnectionState, PlcSyncStatus SyncStatus, bool IsSyncEnabled)
 {
-	public static readonly Result<PlcSessionSnapshot> InitialState = Result.Ok(
-		new PlcSessionSnapshot(PlcConnectionState.Disconnected, PlcSyncStatus.Idle, false));
+	public static readonly PlcSessionSnapshot InitialState =
+		new(PlcConnectionState.Disconnected, PlcSyncStatus.Idle, false);
 }

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
@@ -12,12 +12,12 @@ namespace SemiStep.Core.Plc.Sync;
 internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 {
 	private readonly Lock _lock = new();
-	private readonly BehaviorSubject<Result<PlcSessionSnapshot>> _subject = new(
+	private readonly BehaviorSubject<PlcSessionSnapshot> _subject = new(
 		PlcSessionSnapshot.InitialState);
+	private readonly Subject<IError> _faults = new();
 	private readonly PlcSyncExecutor _executor;
 
 	private PlcConnectionState _connectionState = PlcConnectionState.Disconnected;
-	private bool _connectionLost;
 	private volatile bool _disposed;
 	private bool _isSyncEnabled;
 	private DateTimeOffset? _lastSyncTime;
@@ -34,6 +34,7 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 			_lock,
 			status => Status = status,
 			time => LastSyncTime = time,
+			fault => _faults.OnNext(fault),
 			loggerFactory.CreateLogger<PlcSyncExecutor>());
 	}
 
@@ -93,7 +94,9 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 		}
 	}
 
-	public IObservable<Result<PlcSessionSnapshot>> PlcState => _subject;
+	public IObservable<PlcSessionSnapshot> PlcState => _subject;
+
+	public IObservable<IError> Faults => _faults;
 
 	public void NotifyRecipeChanged(Recipe recipe, bool isValid)
 	{
@@ -118,10 +121,6 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 		lock (_lock)
 		{
 			_isSyncEnabled = value;
-			if (value)
-			{
-				_connectionLost = false;
-			}
 			connectionStateSnapshot = _connectionState;
 		}
 		PublishSnapshot(connectionStateSnapshot);
@@ -132,10 +131,6 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 		lock (_lock)
 		{
 			_connectionState = state;
-			if (state == PlcConnectionState.Connected)
-			{
-				_connectionLost = false;
-			}
 		}
 		PublishSnapshot(state);
 	}
@@ -155,28 +150,20 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 		_executor.Dispose();
 		_subject.OnCompleted();
 		_subject.Dispose();
+		_faults.OnCompleted();
+		_faults.Dispose();
 	}
 
 	public void ResetForDisable()
 	{
 		_executor.Reset();
-		lock (_lock)
-		{
-			_connectionLost = false;
-		}
 		Status = PlcSyncStatus.Idle;
 	}
 
 	public void HandleConnectionLost()
 	{
 		_executor.Reset();
-		PlcConnectionState connectionStateSnapshot;
-		lock (_lock)
-		{
-			_connectionLost = true;
-			connectionStateSnapshot = _connectionState;
-		}
-		PublishSnapshot(connectionStateSnapshot);
+		_faults.OnNext(new Error("PLC connection lost"));
 	}
 
 	public async Task WaitForPendingSyncAsync(CancellationToken ct = default)
@@ -188,8 +175,6 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 	{
 		PlcSyncStatus status;
 		bool isSyncEnabled;
-		bool connectionLost;
-		string? errorMessage;
 		bool disposed;
 
 		lock (_lock)
@@ -197,8 +182,6 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 			disposed = _disposed;
 			status = _status;
 			isSyncEnabled = _isSyncEnabled;
-			connectionLost = _connectionLost;
-			errorMessage = _executor.PendingErrorMessage;
 		}
 
 		if (disposed)
@@ -207,27 +190,9 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 		}
 
 		var snapshot = new PlcSessionSnapshot(connectionState, status, isSyncEnabled);
-
-		if (status == PlcSyncStatus.Failed)
-		{
-			TryPublish(Result.Fail<PlcSessionSnapshot>(new Error(errorMessage ?? "Sync failed")));
-			return;
-		}
-
-		if (connectionLost && isSyncEnabled)
-		{
-			TryPublish(Result.Fail<PlcSessionSnapshot>(new Error("PLC connection lost")));
-			return;
-		}
-
-		TryPublish(Result.Ok(snapshot));
-	}
-
-	private void TryPublish(Result<PlcSessionSnapshot> result)
-	{
 		if (!_disposed)
 		{
-			_subject.OnNext(result);
+			_subject.OnNext(snapshot);
 		}
 	}
 }

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
@@ -34,7 +34,7 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 			_lock,
 			status => Status = status,
 			time => LastSyncTime = time,
-			fault => _faults.OnNext(fault),
+			EmitFault,
 			loggerFactory.CreateLogger<PlcSyncExecutor>());
 	}
 
@@ -163,12 +163,24 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 	public void HandleConnectionLost()
 	{
 		_executor.Reset();
-		_faults.OnNext(new Error("PLC connection lost"));
+		EmitFault(new Error("PLC connection lost"));
 	}
 
 	public async Task WaitForPendingSyncAsync(CancellationToken ct = default)
 	{
 		await _executor.WaitForPendingSyncAsync(ct);
+	}
+
+	private void EmitFault(IError fault)
+	{
+		lock (_lock)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+			_faults.OnNext(fault);
+		}
 	}
 
 	private void PublishSnapshot(PlcConnectionState connectionState)

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncCoordinator.cs
@@ -185,25 +185,14 @@ internal sealed class PlcSyncCoordinator : IPlcSyncService, IDisposable
 
 	private void PublishSnapshot(PlcConnectionState connectionState)
 	{
-		PlcSyncStatus status;
-		bool isSyncEnabled;
-		bool disposed;
-
 		lock (_lock)
 		{
-			disposed = _disposed;
-			status = _status;
-			isSyncEnabled = _isSyncEnabled;
-		}
+			if (_disposed)
+			{
+				return;
+			}
 
-		if (disposed)
-		{
-			return;
-		}
-
-		var snapshot = new PlcSessionSnapshot(connectionState, status, isSyncEnabled);
-		if (!_disposed)
-		{
+			var snapshot = new PlcSessionSnapshot(connectionState, _status, _isSyncEnabled);
 			_subject.OnNext(snapshot);
 		}
 	}

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncExecutor.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcSyncExecutor.cs
@@ -17,6 +17,7 @@ internal sealed class PlcSyncExecutor(
 	Lock stateLock,
 	Action<PlcSyncStatus> setStatus,
 	Action<DateTimeOffset> setLastSyncTime,
+	Action<IError> reportFault,
 	ILogger<PlcSyncExecutor> logger)
 {
 	internal const int DebounceDelayMilliseconds = 1000;
@@ -25,19 +26,7 @@ internal sealed class PlcSyncExecutor(
 	private Task? _syncTask;
 	private CancellationTokenSource? _debounceCts;
 	private Recipe? _pendingSnapshot;
-	private string? _pendingErrorMessage;
 	private volatile bool _disposed;
-
-	public string? PendingErrorMessage
-	{
-		get
-		{
-			lock (stateLock)
-			{
-				return _pendingErrorMessage;
-			}
-		}
-	}
 
 	public void OnRecipeChanged(Recipe recipe)
 	{
@@ -77,7 +66,6 @@ internal sealed class PlcSyncExecutor(
 			_debounceCts?.Dispose();
 			_debounceCts = null;
 			_pendingSnapshot = null;
-			_pendingErrorMessage = null;
 		}
 	}
 
@@ -163,11 +151,8 @@ internal sealed class PlcSyncExecutor(
 			catch (Exception ex)
 			{
 				_logger.LogError(ex, "Unhandled exception in sync task");
-				lock (stateLock)
-				{
-					_pendingErrorMessage = ex.Message;
-				}
 				setStatus(PlcSyncStatus.Failed);
+				reportFault(new Error(ex.Message));
 			}
 		}, ct);
 	}
@@ -213,13 +198,11 @@ internal sealed class PlcSyncExecutor(
 		if (activeResult.IsFailed)
 		{
 			var isDisconnected = activeResult.Errors.OfType<NotConnectedError>().Any();
-			lock (stateLock)
-			{
-				_pendingErrorMessage = isDisconnected
-					? "Not connected to PLC"
-					: activeResult.Errors[0].Message;
-			}
+			var faultMessage = isDisconnected
+				? "Not connected to PLC"
+				: activeResult.Errors[0].Message;
 			setStatus(PlcSyncStatus.Failed);
+			reportFault(new Error(faultMessage));
 
 			if (isDisconnected)
 			{
@@ -231,11 +214,8 @@ internal sealed class PlcSyncExecutor(
 
 		if (activeResult.Value)
 		{
-			lock (stateLock)
-			{
-				_pendingErrorMessage = "Recipe is being executed on PLC";
-			}
 			setStatus(PlcSyncStatus.Failed);
+			reportFault(new Error("Recipe is being executed on PLC"));
 			_logger.LogWarning("Sync blocked: recipe is being executed on PLC");
 
 			return Result.Fail("Recipe active");
@@ -246,20 +226,13 @@ internal sealed class PlcSyncExecutor(
 
 	private async Task WriteSyncAsync(Recipe recipe, CancellationToken ct)
 	{
-		lock (stateLock)
-		{
-			_pendingErrorMessage = null;
-		}
 		setStatus(PlcSyncStatus.Syncing);
 
 		var writeResult = await transactionExecutor.WriteRecipeWithRetryAsync(recipe, ct);
 		if (writeResult.IsFailed)
 		{
-			lock (stateLock)
-			{
-				_pendingErrorMessage = writeResult.Errors[0].Message;
-			}
 			setStatus(PlcSyncStatus.Failed);
+			reportFault(new Error(writeResult.Errors[0].Message));
 			if (!writeResult.Errors.OfType<NotConnectedError>().Any())
 			{
 				_logger.LogError("Sync failed: {Message}", writeResult.Errors[0].Message);
@@ -269,10 +242,6 @@ internal sealed class PlcSyncExecutor(
 		}
 
 		setLastSyncTime(DateTimeOffset.UtcNow);
-		lock (stateLock)
-		{
-			_pendingErrorMessage = null;
-		}
 		setStatus(PlcSyncStatus.Synced);
 
 		bool hasPending;

--- a/SemiStep/SemiStep.Tests/Helpers/StubPlcSyncService.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/StubPlcSyncService.cs
@@ -10,8 +10,9 @@ namespace SemiStep.Tests.Helpers;
 
 public sealed class StubPlcSyncService : IPlcSyncService
 {
-	private readonly BehaviorSubject<Result<PlcSessionSnapshot>> _plcStateSubject = new(
+	private readonly BehaviorSubject<PlcSessionSnapshot> _plcStateSubject = new(
 		PlcSessionSnapshot.InitialState);
+	private readonly Subject<IError> _faultsSubject = new();
 
 	public bool IsSyncEnabled { get; private set; }
 
@@ -19,7 +20,9 @@ public sealed class StubPlcSyncService : IPlcSyncService
 
 	public DateTimeOffset? LastSyncTime => null;
 
-	public IObservable<Result<PlcSessionSnapshot>> PlcState => _plcStateSubject;
+	public IObservable<PlcSessionSnapshot> PlcState => _plcStateSubject;
+
+	public IObservable<IError> Faults => _faultsSubject;
 
 	/// <summary>True if <see cref="ResetForDisable"/> was called at least once.</summary>
 	public bool WasResetForDisableCalled { get; private set; }
@@ -34,9 +37,15 @@ public sealed class StubPlcSyncService : IPlcSyncService
 	public List<(Recipe Recipe, bool IsValid)> NotifyRecipeChangedCalls { get; } = new();
 
 	/// <summary>Pushes a new PLC state snapshot to subscribers of <see cref="PlcState"/>.</summary>
-	public void PushPlcState(Result<PlcSessionSnapshot> state)
+	public void PushPlcState(PlcSessionSnapshot state)
 	{
 		_plcStateSubject.OnNext(state);
+	}
+
+	/// <summary>Pushes a fault to subscribers of <see cref="Faults"/>.</summary>
+	public void PushFault(IError fault)
+	{
+		_faultsSubject.OnNext(fault);
 	}
 
 	public void NotifyRecipeChanged(Recipe recipe, bool isValid)

--- a/SemiStep/SemiStep.Tests/S7/Helpers/FakeS7Transport.cs
+++ b/SemiStep/SemiStep.Tests/S7/Helpers/FakeS7Transport.cs
@@ -12,6 +12,9 @@ internal sealed class FakeS7Transport : IS7Transport
 	private readonly Dictionary<int, Func<int, int, byte[]>> _dbReadFactories = new();
 	private bool _connected = true;
 
+	/// <summary>When set, every write throws this exception, simulating a transport-level write failure.</summary>
+	public Exception? WriteException { get; set; }
+
 	/// <summary>Ordered log of every write call received.</summary>
 	public List<(int DbNumber, int StartByte, byte[] Data)> WriteLog { get; } = new();
 
@@ -65,6 +68,12 @@ internal sealed class FakeS7Transport : IS7Transport
 	public Task WriteBytesAsync(int dbNumber, int startByte, byte[] data, CancellationToken ct = default)
 	{
 		ct.ThrowIfCancellationRequested();
+
+		if (WriteException is not null)
+		{
+			throw WriteException;
+		}
+
 		WriteLog.Add((dbNumber, startByte, (byte[])data.Clone()));
 		return Task.CompletedTask;
 	}

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -247,13 +247,15 @@ public sealed class PlcSyncCoordinatorTests
 		var (coordinator, _, _) = Build(connected: false);
 		coordinator.SetSyncEnabled(true);
 
-		PlcSessionSnapshot? latest = null;
-		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
+		var snapshotsAfterSubscription = new List<PlcSessionSnapshot>();
+		using var subscription = coordinator.PlcState
+			.Skip(1)
+			.Subscribe(snapshotsAfterSubscription.Add);
 
 		coordinator.HandleConnectionLost();
 
-		latest.Should().NotBeNull(
-			"PlcState now always carries a bare snapshot; faults travel on the Faults channel");
+		snapshotsAfterSubscription.Should().BeEmpty(
+			"connection loss must not push a new snapshot on PlcState; the fault travels on the Faults channel");
 	}
 
 	[Fact]

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -98,20 +98,20 @@ public sealed class PlcSyncCoordinatorTests
 	public void NotifyRecipeChanged_IsValidFalse_EmitsOutOfSyncSnapshot()
 	{
 		var (coordinator, _, _) = Build();
-		Result<PlcSessionSnapshot>? received = null;
+		PlcSessionSnapshot? received = null;
 		using var sub = coordinator.PlcState.Skip(1).Take(1).Subscribe(s => received = s);
 
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: false);
 
 		received.Should().NotBeNull();
-		received!.Value.SyncStatus.Should().Be(PlcSyncStatus.OutOfSync);
+		received!.SyncStatus.Should().Be(PlcSyncStatus.OutOfSync);
 	}
 
 	[Fact]
 	public void NotifyRecipeChanged_IsValidFalse_StatusChangedMultipleTimes_OnlyEmitsWhenValueChanges()
 	{
 		var (coordinator, _, _) = Build();
-		var snapshots = new List<Result<PlcSessionSnapshot>>();
+		var snapshots = new List<PlcSessionSnapshot>();
 
 		// Skip the initial state emitted on subscription.
 		using var sub = coordinator.PlcState.Skip(1).Subscribe(snapshots.Add);
@@ -226,103 +226,82 @@ public sealed class PlcSyncCoordinatorTests
 	}
 
 	[Fact]
-	public void ReEnableAfterCleanDisable_DoesNotEmitConnectionLostFailure()
+	public void HandleConnectionLost_EmitsExactlyOneFault()
 	{
 		var (coordinator, _, _) = Build(connected: false);
-		Result<PlcSessionSnapshot>? latest = null;
-		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
-
-		coordinator.SetSyncEnabled(true);
-		coordinator.SetSyncEnabled(false);
-		coordinator.ResetForDisable();
 		coordinator.SetSyncEnabled(true);
 
-		latest.Should().NotBeNull();
-		latest!.IsFailed.Should().BeFalse(
-			"re-enabling sync after a clean disable must not emit a spurious connection-lost failure");
-	}
+		var faults = new List<IError>();
+		using var subscription = coordinator.Faults.Subscribe(faults.Add);
 
-	[Fact]
-	public void ReEnableAfterConnectionLostThenCleanDisable_DoesNotEmitConnectionLostFailure()
-	{
-		var (coordinator, _, _) = Build(connected: false);
-		Result<PlcSessionSnapshot>? latest = null;
-		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
-
-		// Drive the coordinator into the stale state that produced the field bug: a genuine
-		// connection loss leaves Status = Disconnected. The user then toggles Sync off (clean
-		// disable) and back on. ResetForDisable must clear the stale status to Idle so the
-		// re-enable does not republish the connection-lost failure.
-		coordinator.SetSyncEnabled(true);
 		coordinator.HandleConnectionLost();
-		coordinator.SetSyncEnabled(false);
-		coordinator.ResetForDisable();
-		coordinator.SetSyncEnabled(true);
 
-		latest.Should().NotBeNull();
-		latest!.IsFailed.Should().BeFalse(
-			"after a genuine loss is cleared by a clean disable, re-enabling sync must not "
-			+ "republish the stale connection-lost failure");
+		faults.Should().ContainSingle(
+			"a runtime connection loss must emit exactly one fault on the Faults channel");
+		faults[0].Message.Should().Be("PLC connection lost");
 	}
 
 	[Fact]
-	public void HandleConnectionLost_WhileSyncEnabled_EmitsConnectionLostFailure()
+	public void HandleConnectionLost_DoesNotEmitFailureOnStateStream()
 	{
 		var (coordinator, _, _) = Build(connected: false);
 		coordinator.SetSyncEnabled(true);
 
-		Result<PlcSessionSnapshot>? latest = null;
+		PlcSessionSnapshot? latest = null;
 		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
 
 		coordinator.HandleConnectionLost();
 
-		latest.Should().NotBeNull();
-		latest!.IsFailed.Should().BeTrue(
-			"a runtime connection loss while sync is enabled must surface as a failed snapshot");
+		latest.Should().NotBeNull(
+			"PlcState now always carries a bare snapshot; faults travel on the Faults channel");
 	}
 
 	[Fact]
-	public void ReEnableAfterConnectionLost_ClearsLostFlag_DoesNotEmitFailure()
+	public void ReconnectAfterConnectionLost_EmitsNoFurtherFault()
 	{
 		var (coordinator, _, _) = Build(connected: false);
 		coordinator.SetSyncEnabled(true);
 
-		Result<PlcSessionSnapshot>? latest = null;
-		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
+		var faults = new List<IError>();
+		using var subscription = coordinator.Faults.Subscribe(faults.Add);
 
 		coordinator.HandleConnectionLost();
-		latest!.IsFailed.Should().BeTrue("a connection loss while enabled must surface as a failure first");
+		faults.Should().ContainSingle("the connection loss emits one fault");
 
-		coordinator.SetSyncEnabled(true);
-
-		latest.Should().NotBeNull();
-		latest!.IsFailed.Should().BeFalse(
-			"re-enabling sync must clear the connection-lost flag so no stale failure lingers");
-	}
-
-	[Fact]
-	public void ConnectedAfterConnectionLost_ClearsLostFlag_DoesNotEmitFailure()
-	{
-		var (coordinator, _, _) = Build(connected: false);
-		coordinator.SetSyncEnabled(true);
-
-		Result<PlcSessionSnapshot>? latest = null;
-		using var subscription = coordinator.PlcState.Subscribe(snapshot => latest = snapshot);
-
-		coordinator.HandleConnectionLost();
-		latest!.IsFailed.Should().BeTrue("a connection loss while enabled must surface as a failure first");
-
+		// One-shot faults do not linger: reconnecting must not re-emit the connection-lost fault.
 		coordinator.UpdateConnectionState(PlcConnectionState.Connected);
 
-		latest.Should().NotBeNull();
-		latest!.IsFailed.Should().BeFalse(
-			"the auto-reconnect recovery path must clear the connection-lost flag without the user toggling sync");
+		faults.Should().ContainSingle(
+			"a reconnect must not re-emit the one-shot connection-lost fault");
+	}
+
+	[Fact]
+	public void ReEnableAfterConnectionLostThenCleanDisable_EmitsNoFurtherFault()
+	{
+		var (coordinator, _, _) = Build(connected: false);
+
+		var faults = new List<IError>();
+		using var subscription = coordinator.Faults.Subscribe(faults.Add);
+
+		coordinator.SetSyncEnabled(true);
+		coordinator.HandleConnectionLost();
+		faults.Should().ContainSingle("the connection loss emits one fault");
+
+		// A clean disable followed by a re-enable must not republish the (one-shot) fault.
+		coordinator.SetSyncEnabled(false);
+		coordinator.ResetForDisable();
+		coordinator.SetSyncEnabled(true);
+
+		faults.Should().ContainSingle(
+			"re-enabling sync after a clean disable must not republish the connection-lost fault");
 	}
 
 	[Fact]
 	public async Task NotifyRecipeChanged_IsValidTrue_Disconnected_DebounceAbortLeavesStatusUnchanged()
 	{
 		var (coordinator, transport, _) = Build(connected: false);
+		var faults = new List<IError>();
+		using var subscription = coordinator.Faults.Subscribe(faults.Add);
 
 		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: true);
 
@@ -333,5 +312,37 @@ public sealed class PlcSyncCoordinatorTests
 			"a debounce that fires while disconnected must abort cleanly without transitioning to Failed");
 		transport.WriteLog.Should().BeEmpty(
 			"no write may reach the PLC while disconnected");
+		faults.Should().BeEmpty(
+			"the !IsConnected debounce-abort must stay silent; HandleConnectionLost already owns the connection-lost fault");
+	}
+
+	[Fact]
+	public async Task SyncWriteFailure_EmitsFaultCarryingMessage()
+	{
+		var (coordinator, transport, _) = Build(connected: true);
+		const string FailureMessage = "transport write blew up";
+		transport.WriteException = new InvalidOperationException(FailureMessage);
+
+		var layout = BuildTestConfiguration().Layout;
+		transport.SetReadResponseForDb(layout.IntDb.DbNumber, (_, count) => new byte[count]);
+		transport.SetReadResponseForDb(layout.FloatDb.DbNumber, (_, count) => new byte[count]);
+		transport.SetReadResponseForDb(layout.StringDb.DbNumber, (_, count) => new byte[count]);
+
+		var faults = new List<IError>();
+		using var subscription = coordinator.Faults.Subscribe(faults.Add);
+
+		coordinator.NotifyRecipeChanged(Recipe.Empty, isValid: true);
+		await coordinator.WaitForPendingSyncAsync(TestContext.Current.CancellationToken);
+
+		await TestHelpers.WaitUntilAsync(
+			() => faults.Count > 0,
+			timeout: TimeSpan.FromMilliseconds(2500),
+			pollInterval: TimeSpan.FromMilliseconds(20),
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		faults.Should().ContainSingle("a sync-write failure must emit exactly one fault");
+		faults[0].Message.Should().Be(FailureMessage,
+			"the fault must carry the write-failure message so the user sees the cause");
+		coordinator.Status.Should().Be(PlcSyncStatus.Failed);
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
@@ -1,6 +1,4 @@
-﻿using FluentResults;
-
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
 using SemiStep.Core.Configuration;
@@ -66,8 +64,8 @@ public sealed class UIFixture : IAsyncLifetime
 	public void SetSyncEnabled(bool isSyncEnabled)
 	{
 		PlcSyncService.SetSyncEnabled(isSyncEnabled);
-		PlcSyncService.PushPlcState(Result.Ok(
-			new PlcSessionSnapshot(PlcConnectionState.Disconnected, PlcSyncStatus.Idle, isSyncEnabled)));
+		PlcSyncService.PushPlcState(
+			new PlcSessionSnapshot(PlcConnectionState.Disconnected, PlcSyncStatus.Idle, isSyncEnabled));
 	}
 
 	public void SetRecipeActive(bool active)

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorTests.cs
@@ -368,16 +368,19 @@ public sealed class RecipeCoordinatorTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void PlcStateChange_Failure_DoesNotAddEntriesToMessagePanel()
+	public void PlcFault_RoutesToMessagePanelOperationChannel()
 	{
 		_fixture.Session.Reset();
-		var entryCountBeforePlcChange = _fixture.MessagePanel.Entries.Count;
+		_fixture.MessagePanel.Entries.Should().BeEmpty("a fresh empty recipe has no structural defects");
 
-		_fixture.PlcSyncService.PushPlcState(
-			Result.Fail<PlcSessionSnapshot>("PLC connection lost"));
+		_fixture.PlcSyncService.PushFault(new Error("PLC connection lost"));
 
-		_fixture.MessagePanel.Entries.Count.Should().Be(entryCountBeforePlcChange);
-		_fixture.MessagePanel.Entries.Should().NotContain(e => e.Message == "PLC connection lost");
+		_fixture.MessagePanel.Entries.Should().ContainSingle(
+			"a PLC fault must surface as a transient operation message in the panel");
+		_fixture.MessagePanel.Entries[0].Message.Should().Be("PLC connection lost");
+		_fixture.MessagePanel.Entries[0].Severity.Should().Be(MessageSeverity.Error);
+		_fixture.MessagePanel.ErrorCount.Should().Be(0,
+			"a PLC fault is an operation outcome, not a structural defect, so it must not inflate the validation count");
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -38,13 +38,14 @@ public sealed class RecipeCoordinator : IDisposable
 	private readonly PlcLifecycleManager _plc;
 	private readonly Subject<(Recipe Local, Recipe Plc)> _plcRecipeConflictDetected = new();
 	private readonly IObservable<(Recipe Local, Recipe Plc)> _plcRecipeConflictDetectedShared;
-	private readonly Subject<Result<PlcSessionSnapshot>> _plcStateChanged = new();
-	private readonly IObservable<Result<PlcSessionSnapshot>> _plcStateChangedShared;
+	private readonly Subject<PlcSessionSnapshot> _plcStateChanged = new();
+	private readonly IObservable<PlcSessionSnapshot> _plcStateChangedShared;
 	private readonly RecipeMetadataRegistry _recipeMetadataRegistry;
 	private readonly RecipeSession _session;
 	private bool _disposed;
 	private bool _initialized;
 	private IDisposable? _plcStateSubscription;
+	private IDisposable? _plcFaultsSubscription;
 
 	public RecipeCoordinator(
 		RecipeSession session,
@@ -88,7 +89,7 @@ public sealed class RecipeCoordinator : IDisposable
 	}
 
 	public IObservable<(Recipe Local, Recipe Plc)> PlcRecipeConflictDetected => _plcRecipeConflictDetectedShared;
-	public IObservable<Result<PlcSessionSnapshot>> PlcStateChanged => _plcStateChangedShared;
+	public IObservable<PlcSessionSnapshot> PlcStateChanged => _plcStateChangedShared;
 	public IObservable<bool> CanEditRecipe => _canEditRecipe;
 
 	public event Action<MutationSignal>? Mutated;
@@ -127,6 +128,10 @@ public sealed class RecipeCoordinator : IDisposable
 			_plcStateSubscription = _plc.PlcState
 				.ObserveOn(RxSchedulers.MainThreadScheduler)
 				.Subscribe(OnPlcStateChanged);
+
+			_plcFaultsSubscription = _plc.Faults
+				.ObserveOn(RxSchedulers.MainThreadScheduler)
+				.Subscribe(OnPlcFault);
 		}
 		catch
 		{
@@ -153,6 +158,7 @@ public sealed class RecipeCoordinator : IDisposable
 			_plc.PlcRecipeConflictDetected -= OnPlcRecipeConflictDetected;
 
 			_plcStateSubscription?.Dispose();
+			_plcFaultsSubscription?.Dispose();
 			_canEditRecipeConnection.Dispose();
 
 			_plcRecipeConflictDetected.Dispose();
@@ -480,7 +486,7 @@ public sealed class RecipeCoordinator : IDisposable
 		}
 	}
 
-	private void OnPlcStateChanged(Result<PlcSessionSnapshot> result)
+	private void OnPlcStateChanged(PlcSessionSnapshot snapshot)
 	{
 		lock (_disposeLock)
 		{
@@ -489,23 +495,28 @@ public sealed class RecipeCoordinator : IDisposable
 				return;
 			}
 
-			LogPlcStateChange(result);
+			LogPlcStateChange(snapshot);
 
-			_plcStateChanged.OnNext(result);
+			_plcStateChanged.OnNext(snapshot);
 		}
 	}
 
-	private void LogPlcStateChange(Result<PlcSessionSnapshot> result)
+	private void OnPlcFault(IError error)
 	{
-		if (result.IsFailed)
+		lock (_disposeLock)
 		{
-			_logger.LogWarning(
-				"PLC state change: failure {Errors}",
-				result.FormatErrors());
-			return;
-		}
+			if (_disposed)
+			{
+				return;
+			}
 
-		var snapshot = result.Value;
+			_logger.LogWarning("PLC fault: {Message}", error.Message);
+			_messagePanel.ReportError(error.Message);
+		}
+	}
+
+	private void LogPlcStateChange(PlcSessionSnapshot snapshot)
+	{
 		_logger.LogInformation(
 			"PLC state change: Connection={ConnectionState}, SyncStatus={SyncStatus}, SyncEnabled={IsSyncEnabled}",
 			snapshot.ConnectionState,

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -44,8 +44,8 @@ public sealed class RecipeCoordinator : IDisposable
 	private readonly RecipeSession _session;
 	private bool _disposed;
 	private bool _initialized;
-	private IDisposable? _plcStateSubscription;
 	private IDisposable? _plcFaultsSubscription;
+	private IDisposable? _plcStateSubscription;
 
 	public RecipeCoordinator(
 		RecipeSession session,


### PR DESCRIPTION
PlcState now bare `IObservable<PlcSessionSnapshot>`; new `IObservable<IError> Faults` routed to MessagePanel via PR A seam; `_connectionLost`/`_pendingErrorMessage` removed; PLC connection-loss/sync-failure now user-visible; stacked on PR #59 (error-report-seam) — review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)