### PR TITLE
Remove gate columns from Откачка and Напуск actions

### DIFF
--- a/ConfigFiles/RIE/actions/process.yaml
+++ b/ConfigFiles/RIE/actions/process.yaml
@@ -3,12 +3,6 @@
   ui_name: "Откачка"
   deploy_duration: longlasting
   columns:
-    - key: gate_mode
-      group_name: gate_mode
-      property_type_id: enum
-    - key: gate_setpoint
-      default_value: "0"
-      property_type_id: gate_setpoint
     - key: step_duration
       default_value: "10"
       property_type_id: time
@@ -158,12 +152,6 @@
   ui_name: "Напуск"
   deploy_duration: longlasting
   columns:
-    - key: gate_mode
-      group_name: gate_mode
-      property_type_id: enum
-    - key: gate_setpoint
-      default_value: "0"
-      property_type_id: gate_setpoint
     - key: step_duration
       default_value: "10"
       property_type_id: time


### PR DESCRIPTION
Closes #70.

The gate (Шибер режим/задание) value is not used by the PLC for pump-down and vent steps. Drops `gate_mode` and `gate_setpoint` from actions `100` (Откачка) and `500` (Напуск) in the RIE config.

- Columns stay greyed and non-editable for these steps via the existing inapplicable-cell mechanism (no code change).
- They remain intact for actions that legitimately use the gate (Стабилизация газа, Травление, Продувка).
- Global `columns`/`groups`/`properties` definitions untouched; no formula references these columns.

Config-component tests pass (169/169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)