### PR TITLE
Give dialogs a native title bar so they can be moved

### DIFF
--- a/SemiStep/SemiStep.UI/Dialogs/ErrorWindow.axaml
+++ b/SemiStep/SemiStep.UI/Dialogs/ErrorWindow.axaml
@@ -6,8 +6,7 @@
         Height="400"
         CanResize="False"
         ShowInTaskbar="True"
-        WindowStartupLocation="CenterScreen"
-        WindowDecorations="BorderOnly">
+        WindowStartupLocation="CenterScreen">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/SemiStep/SemiStep.UI/Dialogs/MessageDialog.axaml
+++ b/SemiStep/SemiStep.UI/Dialogs/MessageDialog.axaml
@@ -9,8 +9,7 @@
         SizeToContent="Height"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
-        ShowInTaskbar="False"
-        WindowDecorations="BorderOnly">
+        ShowInTaskbar="False">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/SemiStep/SemiStep.UI/Plc/PlcConflictDialog.axaml
+++ b/SemiStep/SemiStep.UI/Plc/PlcConflictDialog.axaml
@@ -11,8 +11,7 @@
         Height="200"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
-        ShowInTaskbar="False"
-        WindowDecorations="BorderOnly">
+        ShowInTaskbar="False">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/SemiStep/SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml
+++ b/SemiStep/SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml
@@ -9,8 +9,7 @@
         Height="150"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
-        ShowInTaskbar="False"
-        WindowDecorations="BorderOnly">
+        ShowInTaskbar="False">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>


### PR DESCRIPTION
Part of #74 (Phase A — dialog chrome).

All four dialog windows set `WindowDecorations="BorderOnly"`, which strips the caption (Title never shows, the window cannot be dragged) and leaves only a thin native border that is invisible against the white recipe grid.

Removes it from:
- `Dialogs/ErrorWindow.axaml`
- `Dialogs/MessageDialog.axaml`
- `Plc/PlcConflictDialog.axaml`
- `ShutdownService/ExitConfirmationDialog.axaml`

They now default to `Full` decorations: native title bar, drag, border, shadow, close button. `CanResize="False"` stays for these fixed-content dialogs.

Owners are already passed where centering needs them: `ExitConfirmationDialog` and `PlcConflictDialog` call `ShowDialog(owner)` with `CenterOwner`; `ErrorWindow` is the ownerless startup window and keeps `CenterScreen`.

UI project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)