### PR TITLE
Nested actions (generations): depth-N recipe-row composition

### DIFF
--- a/ConfigFiles/RIE/actions/process.yaml
+++ b/ConfigFiles/RIE/actions/process.yaml
@@ -85,29 +85,45 @@
     - key: icp_match
       group_name: match_mode
       property_type_id: enum
-    - key: icp_load
-      default_value: "50"
-      property_type_id: percent
-    - key: icp_tune
-      default_value: "50"
-      property_type_id: percent
+      targets: { 2: 3002 }
     - key: rie_power
       default_value: "0"
       property_type_id: power_rie
     - key: rie_match
       group_name: match_mode
       property_type_id: enum
+      targets: { 2: 3003 }
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: comment
+      property_type_id: string
+
+# ICP capacitor (manual match) — subaction of Травление (icp_match = Ручной)
+3002:
+  ui_name: "ICP ручной"
+  role: subaction
+  deploy_duration: longlasting
+  columns:
+    - key: icp_load
+      default_value: "50"
+      property_type_id: percent
+    - key: icp_tune
+      default_value: "50"
+      property_type_id: percent
+
+# RIE capacitor (manual match) — subaction of Травление (rie_match = Ручной)
+3003:
+  ui_name: "RIE ручной"
+  role: subaction
+  deploy_duration: longlasting
+  columns:
     - key: rie_load
       default_value: "50"
       property_type_id: percent
     - key: rie_tune
       default_value: "50"
       property_type_id: percent
-    - key: step_duration
-      default_value: "10"
-      property_type_id: time
-    - key: comment
-      property_type_id: string
 
 # Purge
 400:

--- a/Docs/architecture/nested-actions.md
+++ b/Docs/architecture/nested-actions.md
@@ -1,0 +1,234 @@
+# Nested Actions (Subactions) — Reference-Based Depth-N Row Composition
+
+## Overview
+
+A recipe row was composed depth-1: the primary action fully determined which columns
+applied to the step, and the **value** chosen in a selector column could not change the
+row's composition. Nested actions generalize this to depth-N: a selector column's chosen
+value pulls in a referenced **subaction** that contributes more columns, which may itself
+carry a further selector, recursively. Inactive columns reuse the existing greyed
+"inapplicable" state.
+
+The data model stays flat and cheap. `Step` is unchanged
+(`Step(int ActionKey, ImmutableDictionary<PropertyId, PropertyValue>)`), the grid keeps one
+global flat column set, and the PLC write path is untouched. The tree lives only in
+metadata and is collapsed at config load into two derived facts per primary action:
+
+- **Column union** — every column reachable through `targets`, materialized into
+  `ActionDefinition.Properties` in a deterministic order. This is the storage/serialization
+  view that PLC write, CSV, clipboard, and import validation iterate.
+- **Per-column activation condition** — which selector value(s) up the chain make a column
+  active. This is the runtime UI view, feeding dynamic greying.
+
+Problem it solves: operator-set values on subaction columns were silently lost on PLC
+write/import if those columns were not on the primary action, and selectors could not change
+row composition. Concretely, RIE `Травление` with `icp_match = Авто` must hide the ICP
+capacitor columns (`icp_load`, `icp_tune`); with `Ручной` they appear with defaults.
+
+## Data model: the tree is metadata, the row stays flat
+
+- **`Step` is flat.** No action path, no per-generation buckets, no nested sub-steps.
+- **Grid columns are global and flat.** An Avalonia `DataGrid` cannot have per-row columns;
+  one global set is built from the registry once. Unchanged.
+- **The tree lives in configuration/metadata only.** A selector column references a subaction
+  by id; the subaction is a named, reusable column bundle.
+- **At runtime the tree manifests as dynamic applicability.** Which of the global columns are
+  active for a row is a function of the resolved action plus the current selector values,
+  recomputed when a selector changes. Inactive columns are the existing greyed inapplicable
+  state — non-editable, serialized as default.
+
+## Configuration shape
+
+A selector column carries `targets: {selectorValue → actionId}`. The referenced action is a
+subaction. Actions and subactions are distinguished by an explicit `role`:
+
+- `role: action` (the default; may be omitted) — a primary action. Appears in the operator
+  dropdown. Existing configs carry no `role`, so they default to `action` with zero migration.
+- `role: subaction` — reachable only through some column's `targets`. Never appears in the
+  dropdown and never enters the registry's runtime action collections.
+
+Targets are stated per column entry within an action, not on the global group. The same group
+(`match_mode`) can therefore branch differently per selector (`icp_match` and `rie_match`
+target different subactions). Only the value(s) that change composition carry a target; an
+unlisted value (e.g. `Авто`) simply pulls in nothing.
+
+```yaml
+# actions/process.yaml — primary action (role omitted = action)
+300:
+  ui_name: "Травление"
+  columns:
+    # ... gas flows, gate columns ...
+    - { key: icp_power, default_value: "0", property_type_id: power_icp }
+    - key: icp_match
+      group_name: match_mode            # 1 = Авто, 2 = Ручной
+      property_type_id: enum
+      targets: { 2: 3002 }              # value 2 (Ручной) -> subaction 3002
+    - { key: rie_power, default_value: "0", property_type_id: power_rie }
+    - key: rie_match
+      group_name: match_mode
+      property_type_id: enum
+      targets: { 2: 3003 }
+    - { key: step_duration, default_value: "10", property_type_id: time }
+    - { key: comment, property_type_id: string }
+
+3002:
+  ui_name: "ICP ручной"
+  role: subaction
+  columns:
+    - { key: icp_load, default_value: "50", property_type_id: percent }
+    - { key: icp_tune, default_value: "50", property_type_id: percent }
+3003:
+  ui_name: "RIE ручной"
+  role: subaction
+  columns:
+    - { key: rie_load, default_value: "50", property_type_id: percent }
+    - { key: rie_tune, default_value: "50", property_type_id: percent }
+```
+
+Sharing is allowed **across distinct roots**: a subaction may be referenced by more than one
+primary action, so the reference structure is a DAG, not a strict tree. Each root resolves the
+shared subaction independently with its own activation path. Sharing a subaction across two
+branches of the **same** root is rejected at load (see Validation rules) — its columns can carry
+only one activation path, so the second branch would be greyed wrongly.
+
+## Load-time resolver
+
+`ActionTreeResolver` (`SemiStep.Core/Recipes/ActionTreeResolver.cs`) runs once at registry
+construction over the raw mapped actions. For every `role: action` root it walks each selector
+column's `targets` transitively and produces a resolved primary `ActionDefinition`. Subactions
+are consumed during the walk and are not part of the output, so they never reach the registry's
+`_actionsById` / `_allActions` / `_actionsByName`, the dropdown, or `GetDefaultActionId()`.
+
+The walk produces two structures in a single pass:
+
+### Column union (deterministic order)
+
+Columns are spliced in declaration order, depth-first at the selector site: a selector's
+subaction columns are inserted immediately after the selector column. Keys are deduped — the
+first occurrence wins; a later reachable occurrence of the same key with the **same** property
+type **and the same activation path** is accepted, a **conflicting** property type or a
+**different activation path within one root** fails the load.
+
+For action `300` above the union is, in order:
+
+```
+... gas flows, gate columns ...,
+icp_power, icp_match, icp_load, icp_tune,
+rie_power, rie_match, rie_load, rie_tune,
+step_duration, comment
+```
+
+The union becomes `ActionDefinition.Properties`. The resolved `Targets`/`Activation` are written
+back onto each column: `Targets` is cleared on the materialized column, and `Activation` is set
+to the chain of conditions on its path (`null` for always-active columns).
+
+### Per-column activation condition
+
+Each column carries a list of `ActivationCondition(SelectorKey, EnablingValue)` — one entry per
+selector on its path from the root. `icp_load`/`icp_tune` carry `(icp_match, 2)`;
+`rie_load`/`rie_tune` carry `(rie_match, 2)`; everything else carries none. A column is active iff
+**every** condition on it is met, which gives depth>1 chains for free.
+
+### PLC byte-order invariant
+
+The PLC writes values into fixed slots by `Properties` order. The union after splicing must
+reproduce the prior column order byte-for-byte so the slot layout is unchanged: for RIE `300`,
+`rie_power` stays between the icp-manual splice and `rie_match`, and the gate/flow columns keep
+their positions. This is a hard invariant, regression-tested by serializing a fixed `Травление`
+step and asserting an identical `PlcRecipeData` slot layout. Inactive branch columns write
+`0`/empty into their reserved slots; the layout never shifts.
+
+## Correction to the original design note
+
+The original note (now superseded) claimed PLC write, CSV, and clipboard were "already
+generation-tolerant, no change". That was only true **once the column union is materialized into
+`Properties`**. Those consumers iterate `action.Properties`; a subaction column absent from it has
+its value silently dropped on PLC write / CSV export / clipboard / import validation. Union
+materialization is the load-bearing step that makes them tolerant — name it explicitly. With the
+union in place those consumers need no code change; without it they are broken for subaction
+columns.
+
+The original note also modeled role membership by inference ("roots = actions referenced by
+nobody") and showed an explicit auto-child (`3001`). The implemented model uses an explicit
+`role` enum and lets unlisted selector values pull in nothing, so no empty auto-subaction exists.
+
+## Validation rules (config load, hard errors)
+
+`CrossReferenceValidator` (`SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs`)
+enforces, at load, with a clear message each:
+
+- every `targets` id resolves to a defined action (dangling target fails);
+- every `targets` id points at a `role: subaction` (a target on a `role: action` fails — catches
+  a mis-tagged fragment);
+- every `role: subaction` is referenced by at least one `targets` (orphan subaction fails);
+- no cycle in the reference graph (a cycle reachable from any action fails);
+- action ids are unique (enforced earlier by the loader across files; uniqueness across files
+  and for subaction ids is checked by `ActionsSectionLoader`, not `ValidateReferenceGraph`).
+
+The `role: action`/`role: subaction` rule fires regardless of depth — a subaction whose own
+selector targets a `role: action` also fails. The resolver additionally guards against cycles
+(defense-in-depth alongside the validator) and rejects a column key reachable with conflicting
+property types or, within one root, with different activation paths.
+
+### Known gaps
+
+- A `targets` selector **value** is not cross-checked against the column's group at config load.
+  A target keyed on a value the group does not define (or a typo) is accepted; that branch is
+  simply never reachable, so it silently contributes nothing rather than failing.
+- `role` accepts only `null`/`"action"`/`"subaction"`. Any other string fails mapping at config
+  load.
+
+## Runtime: dynamic applicability
+
+`ActiveColumnSetResolver` (`SemiStep.Core/Recipes/Helpers/ActiveColumnSetResolver.cs`) computes a
+step's active column set from the resolved action's per-column activation conditions and the
+step's current selector values. A column with no conditions is always active; a column with
+conditions is active iff every selector named in its conditions currently holds the enabling value.
+
+`CellStateResolver.IsInapplicable` (`SemiStep.Core/Recipes/Helpers/CellStateResolver.cs`) consults
+this active set: a cell is inapplicable iff it is not the action column, not read-only, and its key
+is not in the active set. Inactive columns reuse the greyed inapplicable palette; no new style.
+
+In the UI, `RecipeRowViewModel.InapplicableColumns` is an observable property. On recompute it is
+assigned a **new** `IReadOnlySet<string>` instance so the one-way cell binding re-fires; mutating
+in place would not notify. Selector edits route through the grid view-model into the batched core
+mutation; ordinary (non-selector) edits do not trigger an applicability recompute.
+
+## One-undo-unit selector edit
+
+The undo boundary is `RecipeSession.Apply` — one call, one undo snapshot.
+`RecipeSession.UpdateStepForSelectorChange` (`SemiStep.Core/Recipes/RecipeSession.cs`) builds a
+single updated step that sets the selector value, drops the keys that became inactive, seeds
+defaults for the keys that became active, runs any formula recalc, and calls `Apply` exactly once.
+Switching `icp_match` to `Авто` and back is therefore a single undo unit: `Ctrl+Z` restores both
+the prior selector value and the prior dropped load/tune values in one step.
+
+## Formula guard
+
+`FormulaEvaluator` (`SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs`) takes the row's active
+column set. In `BuildVariableMap`, when a `recalc_order` variable is not in the active set, the
+recalc is skipped and the step is returned unchanged, rather than throwing. An active variable that
+is absent or non-numeric is still a genuine error and throws. The speculative config-time
+cross-branch formula ban from the original design was dropped (YAGNI).
+
+## What stays untouched
+
+- `Step` is flat; the grid keeps one global flat column set.
+- The PLC write path is unchanged; it iterates `Properties` (now the union) and writes defaults
+  for absent values, as before.
+- CSV, clipboard, and import validation iterate `Properties` and benefit from the union with no
+  code change.
+- The greyed inapplicable palette is reused; no new visual style.
+
+## Acceptance criteria (met)
+
+- RIE `Травление`: `icp_match = Авто` greys `icp_load`/`icp_tune` and drops their values;
+  `Ручной` makes them applicable with defaults; `rie_match` is independent.
+- `Ctrl+Z` after switching to `Авто` restores `Ручной` with the prior load/tune values in one step.
+- An inactive capacitor column writes `0`/empty into its fixed PLC slot; the slot layout is
+  unchanged byte-for-byte.
+- A depth-2 tree (a subaction carrying its own selector with `targets`) resolves and activates
+  along the full condition chain.
+- `GetDefaultActionId()` and the dropdown never surface a subaction.
+- Backward compatibility: actions without `targets`/`role` behave exactly as before; the dropdown
+  for existing configs is unchanged.

--- a/Docs/architecture/nested-actions.md
+++ b/Docs/architecture/nested-actions.md
@@ -162,8 +162,16 @@ enforces, at load, with a clear message each:
   a mis-tagged fragment);
 - every `role: subaction` is referenced by at least one `targets` (orphan subaction fails);
 - no cycle in the reference graph (a cycle reachable from any action fails);
+- no shared column across branches of one root — a column reachable within a single root via two
+  different selector conditions is rejected at config load (OR-activation is unsupported);
 - action ids are unique (enforced earlier by the loader across files; uniqueness across files
   and for subaction ids is checked by `ActionsSectionLoader`, not `ValidateReferenceGraph`).
+
+A column may carry only a **single** activation path. OR-activation is not supported, so a
+subaction reachable from two branches of the **same** root is rejected — this includes two
+selector values mapping to the same subaction (`targets: {2: X, 3: X}`), which is meaningless
+(both values would activate the same columns). Cross-**root** sharing (a subaction referenced by
+two different primary actions) is allowed; each root resolves it independently with its own path.
 
 The `role: action`/`role: subaction` rule fires regardless of depth — a subaction whose own
 selector targets a `role: action` also fails. The resolver additionally guards against cycles

--- a/Docs/plans/completed/20260623-nested-actions-depth-n.md
+++ b/Docs/plans/completed/20260623-nested-actions-depth-n.md
@@ -1,0 +1,367 @@
+# Nested Actions (Generations): Depth-1 → Depth-N Row Composition
+
+## Overview
+
+Today a recipe row's column composition is depth-1: the primary action fully
+determines which columns apply. This plan generalizes to depth-N "nested actions":
+a selector column's chosen value pulls in a referenced child action (a "subaction")
+that contributes more columns, which may itself carry a further selector, recursively.
+Inactive columns reuse the existing greyed "inapplicable" state.
+
+The data model stays flat and cheap: `Step` is unchanged, grid columns stay one global
+flat set. The tree lives only in metadata. Two derived facts are computed once at config
+load by walking the reference graph:
+
+- **Column union per primary action** — every column reachable through `targets`,
+  materialized into `ActionDefinition.Properties` in a deterministic order. This is the
+  storage/serialization view. It is the piece the original issue #71 design missed:
+  PLC write, CSV import, clipboard paste, and import validation all iterate
+  `action.Properties`, so a subaction column absent from it has its value silently
+  dropped. Materializing the union fixes this with zero change to those consumers.
+- **Per-column activation condition** — which selector value(s) up the chain make a
+  column active. This is the runtime UI view, feeding dynamic greying.
+
+Problem it solves: operator-set values on branch columns are silently lost on PLC
+write/import today if those columns are not on the primary action; and selectors cannot
+change row composition (e.g. RIE `Травление` with `icp_match = Авто` must hide the
+capacitor columns).
+
+## Context (from discovery)
+
+- Project: SemiStep, .NET 10 / C# 14, Avalonia + ReactiveUI. Recipe-table editor for S7 PLC.
+- Config pipeline: YAML → DTOs → loaders → mappers → validators → `RecipeMetadataRegistry`.
+- Files/areas involved:
+  - Config DTO/loader/mapper/validation: `ActionColumnDto`, `ActionDto`,
+    `ActionsSectionLoader`, `ActionMapper`, `CrossReferenceValidator`.
+  - Metadata: `ActionDefinition`, `ActionPropertyDefinition`, `RecipeMetadataRegistry`.
+  - Applicability/UI: `CellStateResolver`, `RecipeRowViewModel`, `RecipeGridViewModel`,
+    `CellApplicabilityBinding`, `InapplicableCellTheme`.
+  - Serialization/import (must NOT change behaviour, only benefit from the union):
+    `RecipeConverter`, `CsvRowConverter`, `ClipboardSerializer`, `ImportedRecipeValidator`.
+  - Formulas: `FormulaEvaluator`.
+- Patterns observed: `FluentResults` `Result<T>` everywhere in config mapping/validation;
+  immutable record/`sealed class` definitions; constructor injection; xUnit tests with
+  `[Trait("Component"|"Area"|"Category")]`; invalid-config tests use the overlay pattern
+  over `SemiStep.Tests/YamlConfigs/`.
+- Existing action count to consider for migration: 69 (`RIE` 9, `MOCVD` 38, `MBE` 22).
+
+## Development Approach
+
+- **testing approach**: Regular (code first, then unit tests) — matches the project.
+- Complete each task fully before the next. Small, focused changes.
+- **Every task includes new/updated tests** (success + error/edge), as separate checklist items.
+- **All tests pass before starting the next task.**
+- Build entry executable: `dotnet build SemiStep/SemiStep.UI/SemiStep.UI.csproj`.
+- Test: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` (filter by `Component`/`Area`).
+- Backward compatibility: existing actions without `targets` behave exactly as before;
+  `role` defaults to `action` so the 69 existing actions need no edit.
+
+## Testing Strategy
+
+- **unit tests**: required every task. Config-side via mapper/validator/registry over
+  small inline or overlay YAML; applicability via `CellStateResolver` and row VM.
+- **UI/headless**: applicability and selector-edit behaviour use `[AvaloniaFact]` where the
+  row view-model and bindings are exercised.
+- **no project e2e harness** beyond headless Avalonia tests; treat headless VM tests as the
+  integration layer.
+
+## Progress Tracking
+
+- mark completed `[x]` immediately; add discovered tasks with ➕; blockers with ⚠️.
+- keep this file in sync; update if scope shifts.
+
+## Solution Overview
+
+Decisions settled in design discussion:
+
+- **Reference-based subactions.** A selector column entry carries `targets: {selectorValue → actionId}`.
+  The referenced action is a "subaction" — a named, reusable column bundle. Sharing across
+  parents is allowed (reference DAG). Targets are action-scoped (the same group can branch
+  differently per selector).
+- **Explicit `role: action | subaction`**, defaulting to `action`. `action` = appears in the
+  operator dropdown; `subaction` = reachable only via `targets`. Default `action` means zero
+  migration on existing configs; `subaction` is stated only on fragments.
+- **Two derived structures, one load-time walk**: column union (→ `Properties`, deterministic
+  order) and per-column activation condition (→ dynamic applicability).
+- **Validator rules** (config-load, hard errors): every `targets` id resolves; targets point
+  only at `role: subaction`; every `role: subaction` is referenced ≥1; no cycles in the
+  reference graph; ids unique. Dropdown built from `role: action` roots only.
+- **PLC/serialization/import unchanged**: they keep iterating `Properties`, now the union.
+- **Formula guard**: skip recalc when a referenced variable is not in the row's active set
+  instead of throwing. The speculative config-time cross-branch ban is dropped (YAGNI).
+- **Core untouched**: flat `Step`, one global flat column set, reuse of the greyed
+  "inapplicable" palette (no new style).
+
+## Technical Details
+
+### Config shape
+
+```yaml
+300:
+  ui_name: "Травление"
+  role: action                # default; may be omitted
+  columns:
+    - { key: icp_power, property_type_id: power_icp, default_value: "0" }
+    - key: icp_match
+      group_name: match_mode
+      property_type_id: enum
+      targets: { 2: 3002 }    # value 2 (Ручной) -> subaction 3002
+    - key: rie_match
+      group_name: match_mode
+      property_type_id: enum
+      targets: { 2: 3003 }
+    - { key: step_duration, property_type_id: time, default_value: "10" }
+    - { key: comment, property_type_id: string }
+
+3002:
+  ui_name: "ICP ручной"
+  role: subaction
+  columns:
+    - { key: icp_load, property_type_id: percent, default_value: "50" }
+    - { key: icp_tune, property_type_id: percent, default_value: "50" }
+3003:
+  ui_name: "RIE ручной"
+  role: subaction
+  columns:
+    - { key: rie_load, property_type_id: percent, default_value: "50" }
+    - { key: rie_tune, property_type_id: percent, default_value: "50" }
+```
+
+### Derived data
+
+For primary action `300` after the load-time walk:
+
+- `Properties` (union, deterministic order — declaration order, depth-first splice at the
+  selector site). For the simplified example above:
+  `icp_power, icp_match, icp_load, icp_tune, rie_match, rie_load, rie_tune, step_duration, comment`.
+- Activation map: `icp_load`/`icp_tune` active iff `icp_match == 2`; `rie_load`/`rie_tune`
+  active iff `rie_match == 2`; the rest always active.
+
+**PLC byte-order invariant.** The PLC writes values into fixed slots by `Properties` order.
+For the real RIE action `300` (`process.yaml:88-111`, full order includes `rie_power`
+between the icp-manual splice and `rie_match`, plus the gate/flow columns), the union after
+splicing MUST reproduce the existing column order byte-for-byte, so the slot layout is
+unchanged. This is a hard invariant, regression-tested in Task 10 — not just the abstract
+"declaration order, depth-first" rule.
+
+### Processing flow
+
+1. Loader parses `targets` (on columns) and `role` (on actions) into DTOs.
+2. Mapper produces raw action definitions carrying own columns, role, and per-column targets.
+3. A resolver pass over all raw actions: validates the reference graph, computes per-root
+   union + activation map, and builds the final primary `ActionDefinition`s.
+4. Registry exposes roots (dropdown) and resolved primary actions (with union `Properties`).
+5. At runtime, the active column set for a row is `union minus columns whose activation
+   condition is unmet by the step's current selector values`. Inactive → greyed; on selector
+   edit, drop now-inactive values and seed defaults for now-active ones in one undo unit.
+
+### Activation representation
+
+`ActionPropertyDefinition` gains an optional activation condition
+(`(string SelectorKey, int EnablingValue)?` or a small list to support depth>1 chains —
+a column is active iff every condition on its path is met). Always-active columns carry none.
+
+## What Goes Where
+
+- **Implementation Steps** (checkboxes): all code, tests, the RIE config edit, the
+  architecture-note rewrite.
+- **Post-Completion** (no checkboxes): manual operator-facing QA of greying/undo in the
+  running app; review of whether MOCVD/MBE want any subaction usage (not in scope here).
+
+## Implementation Steps
+
+### Task 1: Parse `targets` and `role` from config
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Configuration/Dto/ActionColumnDto.cs`
+- Modify: `SemiStep/SemiStep.Core/Configuration/Dto/ActionDto.cs`
+- Modify: `SemiStep/SemiStep.Core/Configuration/Loaders/ActionsSectionLoader.cs`
+- Modify: `SemiStep/SemiStep.Tests/...` (loader tests)
+
+- [x] add `Dictionary<int,int>? Targets` to `ActionColumnDto`
+- [x] add `string? Role` to `ActionDto` (null → treated as `action` downstream)
+- [x] ensure the loader/deserializer maps `targets` and `role` (verify the YAML binding path used by `ActionsSectionLoader`)
+- [x] write tests: a column with `targets` and an action with `role: subaction` deserialize correctly
+- [x] write tests: absent `targets`/`role` deserialize as null (backward compat)
+- [x] run tests — must pass before next task
+
+### Task 2: Carry targets and role through mapping
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/ActionPropertiesDefinition.cs`
+- Modify: `SemiStep/SemiStep.Core/Configuration/Mapping/ActionMapper.cs`
+- Create: `SemiStep/SemiStep.Core/Recipes/ActionRole.cs` (enum `Action`, `Subaction`)
+- Modify: `SemiStep/SemiStep.Tests/...` (mapper tests)
+
+- [x] add `ActionRole` enum; map `dto.Role` (null/`"action"` → `Action`, `"subaction"` → `Subaction`, else fail)
+- [x] extend the mapped column/action shape to carry per-column `Targets` and the action `Role` (raw form, pre-union)
+- [x] keep `TryMapColumn` producing own-column data plus its targets
+- [x] write tests: role mapping (default, explicit, invalid string → failure)
+- [x] write tests: targets survive mapping; non-selector columns have none
+- [x] run tests — must pass before next task
+
+### Task 3: Reference-graph resolver — union, activation map, validation
+
+**Files:**
+- Create: `SemiStep/SemiStep.Core/Recipes/ActionTreeResolver.cs`
+- Modify: `SemiStep/SemiStep.Core/Recipes/ActionDefinition.cs` (carry activation map; `Properties` becomes the union for roots)
+- Modify: `SemiStep/SemiStep.Core/Recipes/ActionPropertiesDefinition.cs` (add optional activation condition to the record)
+- Create: `SemiStep/SemiStep.Tests/...` (resolver tests)
+
+- [x] add the optional activation condition (`(string SelectorKey, int EnablingValue)` list, empty = always active) to `ActionPropertyDefinition`
+- [x] implement a pass over all mapped actions that, per `role: action` root, walks `targets`
+      transitively and produces the column union in deterministic order (declaration order,
+      depth-first splice at the selector site), deduped by key
+- [x] produce the per-column activation condition during the same walk
+- [x] detect cycles in the reference graph → `Result.Fail`
+- [x] reject only a column key reachable under two branches with *conflicting* property types; the same key+type shared across parents (shared subaction) is allowed
+- [x] write tests: depth-1 union (RIE icp/rie), depth-2 union (pump-style chamber→criterion)
+- [x] write tests: shared subaction referenced by two parents resolves once per root, stable order
+- [x] write tests: cycle → failure; deterministic order is stable across loads
+- [x] run tests — must pass before next task
+
+### Task 4: Config-load validation rules for the reference graph
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs`
+- Modify: `SemiStep/SemiStep.Tests/...` (validation tests, overlay configs)
+
+- [x] every `targets` value resolves to a defined action id (dangling → fail)
+- [x] every `targets` target has `role: subaction` (pointing at a root/default-action → fail; this catches a mis-tagged fragment)
+- [x] every `role: subaction` is referenced by ≥1 `targets` (orphan → fail)
+- [x] ids unique across the registry (confirm existing rule still holds with subactions present)
+- [x] write tests (overlay configs): dangling target, target→action, orphan subaction, duplicate id — each fails with a clear message
+- [x] write tests: valid nested config passes
+- [x] run tests — must pass before next task
+
+### Task 5: Registry exposes roots for the dropdown, resolved primaries for metadata
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/RecipeMetadataRegistry.cs`
+- Modify: `SemiStep/SemiStep.Tests/...` (registry tests)
+
+- [x] subactions are consumed only by the Task 3 resolver at load and do NOT enter the registry's
+      runtime action collections (`_actionsById`/`_allActions`/`_actionsByName`); only resolved
+      primary `ActionDefinition`s are stored. This avoids regressing `GetDefaultActionId()`
+      (`RecipeCoordinator.cs:169`, returns the first action) and `ColumnWidthCalculator` (widens the
+      action column by action names)
+- [x] build `GetActionComboBoxItems()` from the resolved primaries (all are `role: action`)
+- [x] expose resolved primary `ActionDefinition`s (union `Properties` + activation map) to consumers
+- [x] write tests: dropdown excludes subactions; primary action `Properties` equals the union
+- [x] write tests: `GetDefaultActionId()` never returns a subaction id
+- [x] write tests: backward-compat config (no targets/role) yields the same dropdown as before
+- [x] run tests — must pass before next task
+
+### Task 6: Dynamic applicability resolver (step-value aware)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/Helpers/CellStateResolver.cs`
+- Create: `SemiStep/SemiStep.Core/Recipes/Helpers/ActiveColumnSetResolver.cs` (or fold into resolver)
+- Modify: `SemiStep/SemiStep.Tests/...`
+
+- [x] grep and enumerate all callers of `CellStateResolver.IsInapplicable` before changing its signature; migrate each to pass the step/active set
+- [x] add a function computing the active column set for a step from the action's activation map + the step's current selector values
+- [x] change `IsInapplicable` to consult the active set (column inactive ⇒ inapplicable), keeping the action-column and read-only exclusions
+- [x] remove the old single-action `IsPropertyPresentInAction` path once unused
+- [x] write tests: icp_match Авто ⇒ icp_load/icp_tune inactive; Ручной ⇒ active; rie independent
+- [x] write tests: depth-2 activation (chamber→criterion) and always-active columns
+- [x] run tests — must pass before next task
+
+### Task 7: Core batched selector mutation (one undo unit)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/RecipeSession.cs`
+- Modify: `SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs` (expose the batched mutation if mutations are routed through it)
+- Modify: `SemiStep/SemiStep.Tests/...`
+
+- [x] the undo boundary is `RecipeSession.Apply` (one call = one undo snapshot); `UpdateStepProperty` calls it once per property, so a selector edit that drops/seeds several columns via N calls would create N undo snapshots
+- [x] add a batched mutation, e.g. `UpdateStepForSelectorChange(stepIndex, selectorKey, value, columnsToDrop, columnsToSeed)`, that builds ONE `updatedStep` (set selector, remove dropped keys, add seeded defaults) and calls `Apply` exactly once
+- [x] route formula recalc (if any) within the same single `Apply`
+- [x] write tests: a batched selector change produces exactly one undo snapshot; `Undo` restores the prior selector value AND the prior dropped values in one step
+- [x] write tests: ordinary single-property edits are unchanged
+- [x] run tests — must pass before next task
+
+### Task 8: Observable `InapplicableColumns` + selector-edit recompute
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/CellApplicabilityBinding.cs` (verify it re-evaluates on `PropertyChanged`)
+- Modify: `SemiStep/SemiStep.Tests/...` (`[AvaloniaFact]`)
+
+- [x] change `InapplicableColumns` from ctor-fixed get-only to a `RaiseAndSetIfChanged` property; on recompute assign a NEW `IReadOnlySet<string>` instance (do NOT mutate in place — the `OneWay` binding only re-fires on `PropertyChanged` + reference change)
+- [x] on a selector-column edit: compute the new active set, then call the Task 7 batched mutation with the drop/seed sets so the value change + applicability shift is ONE undo unit
+- [x] verify `CellApplicabilityBinding`/`InapplicableCellTheme` flip on reassignment; note if neither needs code change beyond the property becoming observable
+- [x] write tests: switching icp_match to Авто drops icp_load value and greys it; back to Ручной seeds defaults
+- [x] write tests (headless): the cell theme flips when `InapplicableColumns` is reassigned
+- [x] run tests — must pass before next task
+
+### Task 9: Wire the recompute trigger in the grid view-model
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs`
+- Modify: `SemiStep/SemiStep.Tests/...`
+
+- [x] in `CreateRowViewModel`, seed the active set from the resolved action + step (done in Task 8: `BuildInapplicableColumns(action, step, ...)` at row creation)
+- [x] in the `PropertyUpdated` mutation path, when the edited column has targets, trigger the row recompute (Task 8: selector edits route through `OnSelectorValueChanged` → `UpdateStepForSelectorChange` → `row.RecomputeInapplicableColumns()`)
+- [x] confirm non-selector edits do not trigger applicability recompute (no regression in `UpdateSingleRowInPlace`: it only calls `UpdateStep`; ordinary edits go through `OnCellValueChanged` with no recompute)
+- [x] write tests: selector edit updates row applicability; ordinary edit does not (selector-positive cases existed from Task 8; added the non-selector negative test `OrdinaryEdit_DoesNotRecomputeApplicability_ReferenceUnchanged`)
+- [x] run tests — must pass before next task
+
+### Task 10: Formula guard for inactive variables
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs`
+- Modify: `SemiStep/SemiStep.Core/Recipes/RecipeSession.cs` (thread the active set into `Recalculate`/`BuildVariableMap`)
+- Modify: `SemiStep/SemiStep.Tests/...`
+
+- [x] thread the row's active column set (from the Task 6 resolver, which is Core) into `Recalculate`/`BuildVariableMap`
+- [x] in `BuildVariableMap`, when a referenced recalc variable is not in the active set, skip the recalc (return the step unchanged) instead of throwing
+- [x] write tests: a formula whose variable is currently inactive does not throw and leaves the step unchanged
+- [x] write tests: a fully-active formula still recalculates as before
+- [x] run tests — must pass before next task
+
+### Task 11: RIE config — Травление manual/auto branches
+
+**Files:**
+- Modify: `ConfigFiles/RIE/actions/process.yaml`
+- (verify) `ConfigFiles/RIE/groups/match_mode.yaml`, `ConfigFiles/RIE/columns/columns.yaml`
+
+- [x] add `targets` to `icp_match` (value Ручной → ICP-manual subaction) and `rie_match` (→ RIE-manual subaction)
+- [x] add the two `role: subaction` entries carrying `icp_load`/`icp_tune` and `rie_load`/`rie_tune`; remove those four from the primary `300` column list (now contributed by subactions)
+- [x] confirm config validation passes and the union for `300` reproduces the prior column ORDER byte-for-byte (`rie_power` stays between the icp splice and `rie_match`; gate/flow columns unchanged)
+- [x] write/extend tests: load RIE config; `300` union equals the expected column list AND order
+- [x] write a PLC regression test: serialize a fixed `Травление` step before/after this change and assert identical slot layout (`PlcRecipeData`) — backs the Post-Completion byte-layout item
+- [x] run tests — must pass before next task
+
+### Task 12: Verify acceptance criteria
+
+- [x] RIE `Травление`: `icp_match = Авто` ⇒ `icp_load`/`icp_tune` inapplicable (greyed, no value); `Ручной` ⇒ applicable with defaults; `rie_*` independent — `RieEtchManualBranchConfigTests.EtchAction_AutoMatch_DeactivatesCapacitorColumns` / `_ManualMatch_ActivatesCapacitorColumns` / `_MatchSelectorsAreIndependent`; UI end-to-end `RecipeRowSelectorEditTests.InitialAutoSelection_SubColumnInapplicable` / `SwitchToManual_SeedsSubValueDefault_AndMakesItApplicable` / `SwitchBackToAuto_DropsSubValue_AndGreysIt`
+- [x] `Ctrl+Z` after switching to `Авто` restores `Ручной` with prior load/tune values (single undo unit, Task 7) — `RecipeRowSelectorEditTests.SwitchToAutoThenUndo_RestoresManualSelectorAndDroppedValue_InOneStep` (asserts selector restored to 1 AND prior value 73 restored in one Undo)
+- [x] a step with an inactive capacitor column writes `0`/empty into its fixed PLC slot (value not lost for active columns) — added `RieEtchManualBranchSerializationTests.SerialiseEtchStep_AutoMatch_InactiveCapacitorColumnsWriteZeroIntoTheirSlots` (4 inactive capacitor floats serialise as 0 with no slot shift; active gas/power/duration keep positions)
+- [x] a depth-2 tree (a subaction that itself carries a selector with `targets`) resolves and activates correctly — `ActionTreeResolverTests.Resolve_Depth2_ChamberToCriterion_BuildsChainedActivation` (resolution + chained activation), `ActiveColumnSetResolverTests.Resolve_Depth2Chain_RequiresEveryConditionOnThePath` (activation gating)
+- [x] `GetDefaultActionId()` and the dropdown never surface a subaction — `RecipeMetadataRegistryTests.GetAllActions_FirstAction_IsNeverASubaction` (GetDefaultActionId returns GetAllActions().First().Id), `_GetActionComboBoxItems_ExcludesSubactions`, `_Subaction_DoesNotEnterRuntimeActionCollections`; config-level `RieEtchManualBranchConfigTests.RieConfig_DropdownExcludesSubactions`
+- [x] backward compatibility: actions without `targets`/`role` behave exactly as before; dropdown unchanged for existing configs — `RecipeMetadataRegistryTests.GetActionComboBoxItems_BackwardCompat_NoTargetsNoRole_MatchesPlainActions`; loader `ActionsSectionLoaderTargetsRoleTests` absent-targets/role cases; resolver `ActionTreeResolverTests` plain-action paths
+- [x] run full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — run SPLIT BY COMPONENT to avoid the known process-wide Avalonia/ReactiveUI `RxAppBuilder.EnsureInitialized` harness limitation (~195 UI failures only when all run in one process — pre-existing baseline, NOT a regression). Per-component all green: Core 229, Config 200, S7 102, Domain 34, Csv 17, UI 236; `Area=NestedActions` 46. Full UI build: 0 errors.
+
+### Task 13: [Final] Documentation
+
+**Files:**
+- Modify: `Docs/architecture/nested-actions.md`
+- Modify: `CLAUDE.md` (only if a new durable convention emerged)
+
+- [x] rewrite `nested-actions.md` to the final model: reference subactions, `role` (default `action`), column-union materialization + deterministic order, dynamic applicability, validator rules, formula guard, untouched core; correct the original "already generation-tolerant" claim to name the union step
+- [x] update `CLAUDE.md` only if warranted — no CLAUDE.md change warranted (project-overview file only; it states "do not add specifics here", and no cross-project convention emerged)
+- [x] move this plan to `Docs/plans/completed/`
+
+## Post-Completion
+*Manual / external — no checkboxes*
+
+**Manual verification**
+- Operator-facing QA in the running app: greying transitions, value-drop on switch to `Авто`,
+  undo restoring the manual branch, dropdown shows only top-level actions.
+- Confirm PLC byte layout for `Травление` is unchanged (union order matches the prior fixed slots).
+
+**External / follow-up**
+- Decide separately whether MOCVD/MBE configs adopt subactions (out of scope here).
+- The pump example (`Откачка` → камера/шлюз → по давлению/по времени) is a depth-2
+  validation case; wiring it into a real equipment config is a later config task.

--- a/SemiStep/SemiStep.Core/Configuration/Dto/ActionColumnDto.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Dto/ActionColumnDto.cs
@@ -6,4 +6,5 @@ internal sealed class ActionColumnDto
 	public string? GroupName { get; set; }
 	public string? PropertyTypeId { get; set; }
 	public string? DefaultValue { get; set; }
+	public Dictionary<int, int>? Targets { get; set; }
 }

--- a/SemiStep/SemiStep.Core/Configuration/Dto/ActionDto.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Dto/ActionDto.cs
@@ -4,6 +4,7 @@ internal sealed class ActionDto
 {
 	public int Id { get; set; }
 	public string? UiName { get; set; }
+	public string? Role { get; set; }
 	public string? DeployDuration { get; set; }
 	public List<ActionColumnDto>? Columns { get; set; }
 

--- a/SemiStep/SemiStep.Core/Configuration/Loaders/ActionsSectionLoader.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Loaders/ActionsSectionLoader.cs
@@ -117,6 +117,7 @@ internal static class ActionsSectionLoader
 		{
 			Id = id,
 			UiName = source.UiName,
+			Role = source.Role,
 			DeployDuration = source.DeployDuration,
 			Columns = source.Columns,
 			Formula = source.Formula

--- a/SemiStep/SemiStep.Core/Configuration/Mapping/ActionMapper.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Mapping/ActionMapper.cs
@@ -29,6 +29,12 @@ internal static class ActionMapper
 			return Result.Fail($"DeployDuration is required for action Id={dto.Id}");
 		}
 
+		var roleResult = MapRole(dto.Role, dto.Id);
+		if (roleResult.IsFailed)
+		{
+			return roleResult.ToResult<ActionDefinition>();
+		}
+
 		var columns = new List<ActionPropertyDefinition>();
 		if (dto.Columns is not null)
 		{
@@ -61,18 +67,8 @@ internal static class ActionMapper
 			uiName: dto.UiName,
 			deployDuration: deployDurationResult.Value,
 			properties: columns,
-			formula: formulaResult.Value));
-	}
-
-	private static Result<DeployDuration> MapDeployDuration(string? value, int actionId)
-	{
-		return value switch
-		{
-			"immediate" => Result.Ok(DeployDuration.Immediate),
-			"longlasting" => Result.Ok(DeployDuration.LongLasting),
-			_ => Result.Fail<DeployDuration>(
-				$"Unsupported DeployDuration '{value}' for action Id={actionId}")
-		};
+			formula: formulaResult.Value,
+			role: roleResult.Value));
 	}
 
 	public static Result<IReadOnlyList<ActionDefinition>> TryMapMany(
@@ -103,6 +99,29 @@ internal static class ActionMapper
 		return Result.Ok<IReadOnlyList<ActionDefinition>>(results);
 	}
 
+	private static Result<ActionRole> MapRole(string? value, int actionId)
+	{
+		return value switch
+		{
+			null => Result.Ok(ActionRole.Action),
+			"action" => Result.Ok(ActionRole.Action),
+			"subaction" => Result.Ok(ActionRole.Subaction),
+			_ => Result.Fail<ActionRole>(
+				$"Unsupported role '{value}' for action Id={actionId} (expected 'action' or 'subaction')")
+		};
+	}
+
+	private static Result<DeployDuration> MapDeployDuration(string? value, int actionId)
+	{
+		return value switch
+		{
+			"immediate" => Result.Ok(DeployDuration.Immediate),
+			"longlasting" => Result.Ok(DeployDuration.LongLasting),
+			_ => Result.Fail<DeployDuration>(
+				$"Unsupported DeployDuration '{value}' for action Id={actionId}")
+		};
+	}
+
 	private static Result<ActionPropertyDefinition> TryMapColumn(ActionColumnDto dto)
 	{
 		if (string.IsNullOrWhiteSpace(dto.Key))
@@ -120,7 +139,8 @@ internal static class ActionMapper
 			Key: dto.Key,
 			GroupName: dto.GroupName,
 			PropertyTypeId: dto.PropertyTypeId,
-			DefaultValue: dto.DefaultValue));
+			DefaultValue: dto.DefaultValue,
+			Targets: dto.Targets));
 	}
 
 	private static Result<FormulaDefinition?> MapFormula(

--- a/SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs
@@ -28,6 +28,7 @@ internal static class CrossReferenceValidator
 
 		ValidateColumnReferences(columns, propertyIds, validationResults);
 		ValidateActionReferences(actions, propertyIds, columnKeys, groupIds, validationResults);
+		ValidateReferenceGraph(actions, validationResults);
 
 		if (validationResults.Count == 0)
 		{
@@ -35,6 +36,155 @@ internal static class CrossReferenceValidator
 		}
 
 		return Result.Merge(validationResults.ToArray());
+	}
+
+	private static void ValidateReferenceGraph(
+		List<ActionDto> actions,
+		List<Result> validationResults)
+	{
+		// Duplicate action ids are rejected earlier by ActionsSectionLoader (across files) and
+		// by domain mapping; here the list is already unique. Last-write-wins keeps this robust
+		// if that ever changes without masking the dedicated duplicate-id error.
+		var actionsById = new Dictionary<int, ActionDto>();
+		foreach (var action in actions)
+		{
+			actionsById[action.Id] = action;
+		}
+
+		var subactionIds = actions
+			.Where(IsSubaction)
+			.Select(action => action.Id)
+			.ToHashSet();
+
+		var referencedTargetIds = new HashSet<int>();
+
+		foreach (var action in actions)
+		{
+			if (action.Columns == null)
+			{
+				continue;
+			}
+
+			var actionLocation = $"actions, Id={action.Id}, UiName='{action.UiName}'";
+
+			foreach (var column in action.Columns)
+			{
+				if (column.Targets == null || column.Targets.Count == 0)
+				{
+					continue;
+				}
+
+				foreach (var (selectorValue, targetId) in column.Targets)
+				{
+					referencedTargetIds.Add(targetId);
+
+					if (!actionsById.TryGetValue(targetId, out var target))
+					{
+						validationResults.Add(Result.Fail(
+							$"[{actionLocation}] Column '{column.Key}' targets undefined action id {targetId} "
+							+ $"(selector value {selectorValue})"));
+
+						continue;
+					}
+
+					if (!IsSubaction(target))
+					{
+						validationResults.Add(Result.Fail(
+							$"[{actionLocation}] Column '{column.Key}' targets action id {targetId} which is "
+							+ $"role 'action'; targets must point at a 'subaction'"));
+					}
+				}
+			}
+		}
+
+		foreach (var subactionId in subactionIds)
+		{
+			if (!referencedTargetIds.Contains(subactionId))
+			{
+				validationResults.Add(Result.Fail(
+					$"[actions, Id={subactionId}] Subaction id {subactionId} is not referenced by any "
+					+ $"column 'targets' (orphan subaction)"));
+			}
+		}
+
+		ValidateNoCycles(actions, actionsById, validationResults);
+	}
+
+	/// <summary>
+	/// Surfaces a reference-graph cycle as a clean config-load validation error, consistent with
+	/// the sibling dangling/orphan rules. The resolver also guards against cycles defensively, but
+	/// reporting it here means the config load fails with all reference errors together rather than
+	/// throwing later at registry construction.
+	/// </summary>
+	private static void ValidateNoCycles(
+		List<ActionDto> actions,
+		Dictionary<int, ActionDto> actionsById,
+		List<Result> validationResults)
+	{
+		var fullyExplored = new HashSet<int>();
+		var reported = false;
+
+		foreach (var action in actions)
+		{
+			if (reported)
+			{
+				break;
+			}
+
+			var onPath = new HashSet<int>();
+			if (HasCycle(action.Id, actionsById, fullyExplored, onPath))
+			{
+				validationResults.Add(Result.Fail(
+					$"[actions, Id={action.Id}] Cycle detected in the action reference graph reachable "
+					+ $"from action id {action.Id}"));
+				reported = true;
+			}
+		}
+	}
+
+	private static bool HasCycle(
+		int actionId,
+		Dictionary<int, ActionDto> actionsById,
+		HashSet<int> fullyExplored,
+		HashSet<int> onPath)
+	{
+		if (fullyExplored.Contains(actionId))
+		{
+			return false;
+		}
+
+		if (!onPath.Add(actionId))
+		{
+			return true;
+		}
+
+		if (actionsById.TryGetValue(actionId, out var action) && action.Columns != null)
+		{
+			foreach (var column in action.Columns)
+			{
+				if (column.Targets == null)
+				{
+					continue;
+				}
+
+				foreach (var targetId in column.Targets.Values)
+				{
+					if (HasCycle(targetId, actionsById, fullyExplored, onPath))
+					{
+						return true;
+					}
+				}
+			}
+		}
+
+		onPath.Remove(actionId);
+		fullyExplored.Add(actionId);
+		return false;
+	}
+
+	private static bool IsSubaction(ActionDto action)
+	{
+		return string.Equals(action.Role, "subaction", StringComparison.OrdinalIgnoreCase);
 	}
 
 	private static void ValidateColumnReferences(

--- a/SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs
@@ -42,9 +42,7 @@ internal static class CrossReferenceValidator
 		List<ActionDto> actions,
 		List<Result> validationResults)
 	{
-		// Duplicate action ids are rejected earlier by ActionsSectionLoader (across files) and
-		// by domain mapping; here the list is already unique. Last-write-wins keeps this robust
-		// if that ever changes without masking the dedicated duplicate-id error.
+		// Duplicate action ids are already rejected by ActionsSectionLoader; last-write-wins here.
 		var actionsById = new Dictionary<int, ActionDto>();
 		foreach (var action in actions)
 		{

--- a/SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs
@@ -108,6 +108,128 @@ internal static class CrossReferenceValidator
 		}
 
 		ValidateNoCycles(actions, actionsById, validationResults);
+		ValidateNoSharedColumnAcrossBranches(actions, actionsById, validationResults);
+	}
+
+	/// <summary>
+	/// Mirrors the resolver's rejection of a column reachable within a single root via more than
+	/// one selector condition (OR-activation is unsupported), so the config load fails with a clean
+	/// aggregated error instead of throwing later at registry construction. The resolver keeps its
+	/// own guard as defense-in-depth. For each root the column-key map is fresh, so the same column
+	/// shared across DIFFERENT roots is allowed and not flagged.
+	/// </summary>
+	private static void ValidateNoSharedColumnAcrossBranches(
+		List<ActionDto> actions,
+		Dictionary<int, ActionDto> actionsById,
+		List<Result> validationResults)
+	{
+		foreach (var root in actions)
+		{
+			if (IsSubaction(root))
+			{
+				continue;
+			}
+
+			var pathByColumnKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			var onPath = new HashSet<int>();
+
+			if (TryFindSharedColumn(
+					root.Id,
+					string.Empty,
+					actionsById,
+					pathByColumnKey,
+					onPath,
+					out var conflictingKey))
+			{
+				validationResults.Add(Result.Fail(
+					$"[actions, Id={root.Id}] Column key '{conflictingKey}' is reachable within action "
+					+ $"id {root.Id} via more than one selector condition (for example two selector "
+					+ $"values mapping to the same subaction, or two different selectors reaching it). "
+					+ $"A column may be activated by only a single condition path; OR-activation "
+					+ $"across branches is not supported"));
+			}
+		}
+	}
+
+	/// <summary>
+	/// Depth-first walk of the <c>targets</c> graph from one root, tracking per column key the
+	/// activation-path signature (the ordered selector edges taken to reach it; the root's own
+	/// columns have an empty signature = always-active). Returns <c>true</c> with the conflicting
+	/// key the first time a column key is reached with a path signature different from the one first
+	/// seen (OR-activation, which is unsupported), stopping the walk at most one finding per root.
+	/// Cycle-safe via <paramref name="onPath"/> (cycles are reported separately by
+	/// <see cref="ValidateNoCycles"/>).
+	/// </summary>
+	private static bool TryFindSharedColumn(
+		int actionId,
+		string pathSignature,
+		Dictionary<int, ActionDto> actionsById,
+		Dictionary<string, string> pathByColumnKey,
+		HashSet<int> onPath,
+		out string conflictingKey)
+	{
+		conflictingKey = string.Empty;
+
+		if (!onPath.Add(actionId))
+		{
+			return false;
+		}
+
+		try
+		{
+			if (!actionsById.TryGetValue(actionId, out var action) || action.Columns == null)
+			{
+				return false;
+			}
+
+			foreach (var column in action.Columns)
+			{
+				if (string.IsNullOrEmpty(column.Key))
+				{
+					continue;
+				}
+
+				if (pathByColumnKey.TryGetValue(column.Key, out var seenSignature))
+				{
+					if (!string.Equals(seenSignature, pathSignature, StringComparison.Ordinal))
+					{
+						conflictingKey = column.Key;
+						return true;
+					}
+				}
+				else
+				{
+					pathByColumnKey[column.Key] = pathSignature;
+				}
+
+				if (column.Targets == null || column.Targets.Count == 0)
+				{
+					continue;
+				}
+
+				foreach (var (selectorValue, targetId) in column.Targets)
+				{
+					var childSignature = $"{pathSignature}|{column.Key}={selectorValue}";
+
+					if (TryFindSharedColumn(
+							targetId,
+							childSignature,
+							actionsById,
+							pathByColumnKey,
+							onPath,
+							out conflictingKey))
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+		finally
+		{
+			onPath.Remove(actionId);
+		}
 	}
 
 	/// <summary>

--- a/SemiStep/SemiStep.Core/Recipes/ActionDefinition.cs
+++ b/SemiStep/SemiStep.Core/Recipes/ActionDefinition.cs
@@ -11,13 +11,15 @@ public sealed class ActionDefinition
 		string uiName,
 		DeployDuration deployDuration,
 		IReadOnlyList<ActionPropertyDefinition> properties,
-		FormulaDefinition? formula = null)
+		FormulaDefinition? formula = null,
+		ActionRole role = ActionRole.Action)
 	{
 		Id = id;
 		UiName = uiName;
 		DeployDuration = deployDuration;
 		Properties = properties;
 		Formula = formula;
+		Role = role;
 	}
 
 	public int Id { get; }
@@ -25,6 +27,8 @@ public sealed class ActionDefinition
 	public string UiName { get; }
 
 	public DeployDuration DeployDuration { get; }
+
+	public ActionRole Role { get; }
 
 	public IReadOnlyList<ActionPropertyDefinition> Properties { get; }
 

--- a/SemiStep/SemiStep.Core/Recipes/ActionPropertiesDefinition.cs
+++ b/SemiStep/SemiStep.Core/Recipes/ActionPropertiesDefinition.cs
@@ -4,4 +4,6 @@ public sealed record ActionPropertyDefinition(
 	string Key,
 	string? GroupName,
 	string PropertyTypeId,
-	string? DefaultValue);
+	string? DefaultValue,
+	IReadOnlyDictionary<int, int>? Targets = null,
+	IReadOnlyList<ActivationCondition>? Activation = null);

--- a/SemiStep/SemiStep.Core/Recipes/ActionRole.cs
+++ b/SemiStep/SemiStep.Core/Recipes/ActionRole.cs
@@ -1,0 +1,7 @@
+﻿namespace SemiStep.Core.Recipes;
+
+public enum ActionRole
+{
+	Action,
+	Subaction
+}

--- a/SemiStep/SemiStep.Core/Recipes/ActionTreeResolver.cs
+++ b/SemiStep/SemiStep.Core/Recipes/ActionTreeResolver.cs
@@ -1,0 +1,200 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes;
+
+/// <summary>
+/// Resolves the reference graph of mapped actions into the storage/serialization view.
+/// For every <see cref="ActionRole.Action"/> root it walks each selector column's
+/// <c>targets</c> transitively and materializes:
+/// <list type="bullet">
+/// <item>the column UNION in deterministic order (declaration order, depth-first splice at
+/// the selector site: a selector's child columns are inserted right after the selector
+/// column), deduped by key; and</item>
+/// <item>the per-column activation condition (the chain of selector values up the path that
+/// make the column active).</item>
+/// </list>
+/// The resolved primary <see cref="ActionDefinition"/>s (with the union as their
+/// <see cref="ActionDefinition.Properties"/>) are the product. Subactions are consumed only
+/// during the walk and are not part of the output.
+/// </summary>
+public static class ActionTreeResolver
+{
+	public static Result<IReadOnlyList<ActionDefinition>> Resolve(
+		IReadOnlyCollection<ActionDefinition> actions)
+	{
+		ArgumentNullException.ThrowIfNull(actions);
+
+		// Ids are unique upstream (the registry passes a dictionary's values; the loader rejects
+		// cross-file duplicates), so last-write-wins is safe and needs no dedicated duplicate guard.
+		var actionsById = new Dictionary<int, ActionDefinition>();
+		foreach (var action in actions)
+		{
+			actionsById[action.Id] = action;
+		}
+
+		var roots = actions
+			.Where(action => action.Role == ActionRole.Action)
+			.ToList();
+
+		var resolved = new List<ActionDefinition>(roots.Count);
+
+		foreach (var root in roots)
+		{
+			var rootResult = ResolveRoot(root, actionsById);
+			if (rootResult.IsFailed)
+			{
+				return rootResult.ToResult<IReadOnlyList<ActionDefinition>>();
+			}
+
+			resolved.Add(rootResult.Value);
+		}
+
+		return Result.Ok<IReadOnlyList<ActionDefinition>>(resolved);
+	}
+
+	private static Result<ActionDefinition> ResolveRoot(
+		ActionDefinition root,
+		IReadOnlyDictionary<int, ActionDefinition> actionsById)
+	{
+		var union = new List<ActionPropertyDefinition>();
+		var byKey = new Dictionary<string, ActionPropertyDefinition>(StringComparer.OrdinalIgnoreCase);
+		var onPath = new HashSet<int>();
+
+		var walkResult = Walk(
+			root,
+			root.Id,
+			Array.Empty<ActivationCondition>(),
+			actionsById,
+			union,
+			byKey,
+			onPath);
+
+		if (walkResult.IsFailed)
+		{
+			return walkResult.ToResult<ActionDefinition>();
+		}
+
+		return Result.Ok(new ActionDefinition(
+			id: root.Id,
+			uiName: root.UiName,
+			deployDuration: root.DeployDuration,
+			properties: union,
+			formula: root.Formula,
+			role: root.Role));
+	}
+
+	private static Result Walk(
+		ActionDefinition action,
+		int rootId,
+		IReadOnlyList<ActivationCondition> pathConditions,
+		IReadOnlyDictionary<int, ActionDefinition> actionsById,
+		List<ActionPropertyDefinition> union,
+		Dictionary<string, ActionPropertyDefinition> byKey,
+		HashSet<int> onPath)
+	{
+		if (!onPath.Add(action.Id))
+		{
+			return Result.Fail(
+				$"Cycle detected in action reference graph at action id {action.Id}");
+		}
+
+		try
+		{
+			foreach (var column in action.Properties)
+			{
+				var appendResult = AppendColumn(column, rootId, pathConditions, union, byKey);
+				if (appendResult.IsFailed)
+				{
+					return appendResult;
+				}
+
+				if (column.Targets is null || column.Targets.Count == 0)
+				{
+					continue;
+				}
+
+				foreach (var (selectorValue, targetId) in column.Targets.OrderBy(entry => entry.Key))
+				{
+					if (!actionsById.TryGetValue(targetId, out var subaction))
+					{
+						return Result.Fail(
+							$"Column '{column.Key}' targets undefined action id {targetId}");
+					}
+
+					var childConditions = new List<ActivationCondition>(pathConditions.Count + 1);
+					childConditions.AddRange(pathConditions);
+					childConditions.Add(new ActivationCondition(column.Key, selectorValue));
+
+					var childResult = Walk(
+						subaction,
+						rootId,
+						childConditions,
+						actionsById,
+						union,
+						byKey,
+						onPath);
+
+					if (childResult.IsFailed)
+					{
+						return childResult;
+					}
+				}
+			}
+
+			return Result.Ok();
+		}
+		finally
+		{
+			onPath.Remove(action.Id);
+		}
+	}
+
+	private static Result AppendColumn(
+		ActionPropertyDefinition column,
+		int rootId,
+		IReadOnlyList<ActivationCondition> pathConditions,
+		List<ActionPropertyDefinition> union,
+		Dictionary<string, ActionPropertyDefinition> byKey)
+	{
+		var activation = pathConditions.Count == 0
+			? null
+			: pathConditions.ToList();
+
+		if (byKey.TryGetValue(column.Key, out var existing))
+		{
+			if (!string.Equals(existing.PropertyTypeId, column.PropertyTypeId, StringComparison.Ordinal))
+			{
+				return Result.Fail(
+					$"Column key '{column.Key}' is reachable with conflicting property types "
+					+ $"'{existing.PropertyTypeId}' and '{column.PropertyTypeId}'");
+			}
+
+			// Reached a second time within the SAME root. If the two paths carry different
+			// activation conditions, only the first path's conditions would survive on the
+			// resolved column, silently greying the column wrongly under the second branch.
+			// Representing OR-of-paths is out of scope; reject the ambiguous authoring instead.
+			var existingActivation = existing.Activation ?? Enumerable.Empty<ActivationCondition>();
+			var candidateActivation = activation ?? Enumerable.Empty<ActivationCondition>();
+			if (!existingActivation.SequenceEqual(candidateActivation))
+			{
+				return Result.Fail(
+					$"Column key '{column.Key}' is reachable from two distinct branches of action "
+					+ $"id {rootId} with different activation conditions; a subaction may not be "
+					+ "shared across branches of the same root");
+			}
+
+			return Result.Ok();
+		}
+
+		var resolvedColumn = column with
+		{
+			Targets = null,
+			Activation = activation
+		};
+
+		union.Add(resolvedColumn);
+		byKey[column.Key] = resolvedColumn;
+
+		return Result.Ok();
+	}
+}

--- a/SemiStep/SemiStep.Core/Recipes/ActionTreeResolver.cs
+++ b/SemiStep/SemiStep.Core/Recipes/ActionTreeResolver.cs
@@ -24,8 +24,7 @@ public static class ActionTreeResolver
 	{
 		ArgumentNullException.ThrowIfNull(actions);
 
-		// Ids are unique upstream (the registry passes a dictionary's values; the loader rejects
-		// cross-file duplicates), so last-write-wins is safe and needs no dedicated duplicate guard.
+		// Ids are unique upstream (loader rejects duplicates), so last-write-wins is safe.
 		var actionsById = new Dictionary<int, ActionDefinition>();
 		foreach (var action in actions)
 		{
@@ -169,10 +168,8 @@ public static class ActionTreeResolver
 					+ $"'{existing.PropertyTypeId}' and '{column.PropertyTypeId}'");
 			}
 
-			// Reached a second time within the SAME root. If the two paths carry different
-			// activation conditions, only the first path's conditions would survive on the
-			// resolved column, silently greying the column wrongly under the second branch.
-			// Representing OR-of-paths is out of scope; reject the ambiguous authoring instead.
+			// Reached again within the same root via a different activation path: OR-of-paths is
+			// unsupported by design (only the first path would survive), so reject rather than mis-grey.
 			var existingActivation = existing.Activation ?? Enumerable.Empty<ActivationCondition>();
 			var candidateActivation = activation ?? Enumerable.Empty<ActivationCondition>();
 			if (!existingActivation.SequenceEqual(candidateActivation))

--- a/SemiStep/SemiStep.Core/Recipes/ActionTreeResolver.cs
+++ b/SemiStep/SemiStep.Core/Recipes/ActionTreeResolver.cs
@@ -178,9 +178,10 @@ public static class ActionTreeResolver
 			if (!existingActivation.SequenceEqual(candidateActivation))
 			{
 				return Result.Fail(
-					$"Column key '{column.Key}' is reachable from two distinct branches of action "
-					+ $"id {rootId} with different activation conditions; a subaction may not be "
-					+ "shared across branches of the same root");
+					$"Column key '{column.Key}' is reachable within action id {rootId} via more than "
+					+ $"one selector condition (for example two selector values mapping to the same "
+					+ $"subaction, or two different selectors reaching it). A column may be activated by "
+					+ $"only a single condition path; OR-activation across branches is not supported");
 			}
 
 			return Result.Ok();

--- a/SemiStep/SemiStep.Core/Recipes/ActivationCondition.cs
+++ b/SemiStep/SemiStep.Core/Recipes/ActivationCondition.cs
@@ -1,0 +1,9 @@
+﻿namespace SemiStep.Core.Recipes;
+
+/// <summary>
+/// A single condition on a column's activation path: the column is active only when the
+/// selector identified by <see cref="SelectorKey"/> currently holds <see cref="EnablingValue"/>.
+/// A column carries one condition per selector on its path from the primary action; it is
+/// active iff every condition is met. An empty/absent list means always active.
+/// </summary>
+public sealed record ActivationCondition(string SelectorKey, int EnablingValue);

--- a/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs
@@ -48,9 +48,7 @@ public sealed class FormulaEvaluator
 
 		var variableValues = BuildVariableMap(step, formula, action, activeColumns);
 
-		// A recalc-order variable that is currently inactive (its column is dropped from the
-		// row's active set) means the formula does not apply to this composition: skip the
-		// recalc and leave the step unchanged.
+		// Null map = a recalc variable is inactive for this composition; skip recalc, leave step as-is.
 		if (variableValues is null)
 		{
 			return Result.Ok(step);

--- a/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs
@@ -25,7 +25,8 @@ public sealed class FormulaEvaluator
 	public Result<Step> Recalculate(
 		Step step,
 		ActionDefinition action,
-		string changedColumnKey)
+		string changedColumnKey,
+		IReadOnlySet<string> activeColumns)
 	{
 		if (action.Formula is null)
 		{
@@ -45,7 +46,15 @@ public sealed class FormulaEvaluator
 				$"No compiled expression registered for target '{target}' in action '{action.UiName}'.");
 		}
 
-		var variableValues = BuildVariableMap(step, formula, action);
+		var variableValues = BuildVariableMap(step, formula, action, activeColumns);
+
+		// A recalc-order variable that is currently inactive (its column is dropped from the
+		// row's active set) means the formula does not apply to this composition: skip the
+		// recalc and leave the step unchanged.
+		if (variableValues is null)
+		{
+			return Result.Ok(step);
+		}
 
 		var evaluationResult = EvaluateExpression(compiled, variableValues, target, action.Id);
 		if (evaluationResult.IsFailed)
@@ -165,14 +174,26 @@ public sealed class FormulaEvaluator
 		return Result.Ok();
 	}
 
-	private static Dictionary<string, object> BuildVariableMap(
+	/// <summary>
+	/// Builds the variable map for the formula. Returns <c>null</c> when any recalc-order variable
+	/// is currently inactive (its column is not in the row's active set), signalling the caller to
+	/// skip the recalc. A variable that is active but absent from the step, or present with a
+	/// non-numeric value, is a genuine error and throws.
+	/// </summary>
+	private static Dictionary<string, object>? BuildVariableMap(
 		Step step,
 		FormulaDefinition formula,
-		ActionDefinition action)
+		ActionDefinition action,
+		IReadOnlySet<string> activeColumns)
 	{
 		var map = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 		foreach (var variableKey in formula.RecalcOrder)
 		{
+			if (!activeColumns.Contains(variableKey))
+			{
+				return null;
+			}
+
 			if (!step.Properties.TryGetValue(new PropertyId(variableKey), out var propertyValue))
 			{
 				throw new InvalidOperationException(

--- a/SemiStep/SemiStep.Core/Recipes/Helpers/ActiveColumnSetResolver.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Helpers/ActiveColumnSetResolver.cs
@@ -1,0 +1,59 @@
+﻿namespace SemiStep.Core.Recipes.Helpers;
+
+/// <summary>
+/// Computes the set of active column keys for a single step from the resolved action's
+/// per-column activation conditions and the step's current selector values.
+/// A column is active iff every <see cref="ActivationCondition"/> on it is met by the step's
+/// value for that selector. A column with no activation conditions is always active.
+/// Columns absent from the action's <see cref="ActionDefinition.Properties"/> are not part of
+/// the action and never appear in the active set.
+/// </summary>
+public static class ActiveColumnSetResolver
+{
+	public static IReadOnlySet<string> Resolve(ActionDefinition action, Step step)
+	{
+		ArgumentNullException.ThrowIfNull(action);
+		ArgumentNullException.ThrowIfNull(step);
+
+		var active = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var property in action.Properties)
+		{
+			if (IsColumnActive(property, step))
+			{
+				active.Add(property.Key);
+			}
+		}
+
+		return active;
+	}
+
+	private static bool IsColumnActive(ActionPropertyDefinition property, Step step)
+	{
+		if (property.Activation is null || property.Activation.Count == 0)
+		{
+			return true;
+		}
+
+		foreach (var condition in property.Activation)
+		{
+			if (!IsConditionMet(condition, step))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static bool IsConditionMet(ActivationCondition condition, Step step)
+	{
+		var selectorId = new PropertyId(condition.SelectorKey);
+		if (!step.Properties.TryGetValue(selectorId, out var value))
+		{
+			return false;
+		}
+
+		return value.Type == PropertyType.Int && value.AsInt() == condition.EnablingValue;
+	}
+}

--- a/SemiStep/SemiStep.Core/Recipes/Helpers/CellStateResolver.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Helpers/CellStateResolver.cs
@@ -5,20 +5,19 @@ public static class CellStateResolver
 	/// <summary>
 	/// Reports whether this cell should be painted as row-level inapplicable.
 	/// False for the action column and for columns whose <see cref="GridColumnDefinition.ReadOnly"/> flag is set —
-	/// those are handled separately. Otherwise, true iff the action does not define this column's property.
+	/// those are handled separately. Otherwise, true iff the column is not in the step's active set:
+	/// either the action does not define this column, or its activation conditions are unmet by the
+	/// step's current selector values.
 	/// </summary>
 	/// <remarks>
 	/// Invariant: the "read-only column" and "inapplicable" signals are disjoint by design — never both true for the same cell.
 	/// </remarks>
-	public static bool IsInapplicable(GridColumnDefinition column, ActionDefinition action)
+	public static bool IsInapplicable(GridColumnDefinition column, IReadOnlySet<string> activeColumnKeys)
 	{
+		ArgumentNullException.ThrowIfNull(activeColumnKeys);
+
 		return column.Key != StepValueParser.ActionColumnKey
 			&& !column.ReadOnly
-			&& !IsPropertyPresentInAction(column.Key, action);
-	}
-
-	private static bool IsPropertyPresentInAction(string columnKey, ActionDefinition action)
-	{
-		return action.Properties.Any(col => col.Key == columnKey);
+			&& !activeColumnKeys.Contains(column.Key);
 	}
 }

--- a/SemiStep/SemiStep.Core/Recipes/RecipeMetadataRegistry.cs
+++ b/SemiStep/SemiStep.Core/Recipes/RecipeMetadataRegistry.cs
@@ -27,15 +27,17 @@ public sealed class RecipeMetadataRegistry
 
 	public RecipeMetadataRegistry(AppConfiguration config)
 	{
-		_actionsById = new Dictionary<int, ActionDefinition>(config.Actions);
+		var resolvedActions = ResolvePrimaryActions(config.Actions.Values.ToList());
 
+		_actionsById = new Dictionary<int, ActionDefinition>();
 		_actionsByName = new Dictionary<string, ActionDefinition>(StringComparer.OrdinalIgnoreCase);
-		foreach (var action in config.Actions.Values)
+		foreach (var action in resolvedActions)
 		{
+			_actionsById[action.Id] = action;
 			_actionsByName[action.UiName] = action;
 		}
 
-		_allActions = config.Actions.Values.ToList();
+		_allActions = resolvedActions;
 
 		_properties = new Dictionary<string, PropertyTypeDefinition>(StringComparer.OrdinalIgnoreCase);
 		foreach (var (key, property) in config.Properties)
@@ -60,6 +62,28 @@ public sealed class RecipeMetadataRegistry
 		_stringMaxLength = ResolveStringMaxLength(_properties.Values);
 
 		EnsureColumnPropertyReferencesResolve(_columns.Values, _properties);
+	}
+
+	/// <summary>
+	/// Runs the reference-graph resolver over the raw mapped actions so the registry holds only
+	/// resolved primary actions. Subactions (<see cref="ActionRole.Subaction"/>) are consumed by
+	/// the resolver and never enter the runtime action collections; each surviving primary carries
+	/// the union of its own and its subactions' columns (deterministic order) as its
+	/// <see cref="ActionDefinition.Properties"/>. Resolver failures (cycles, dangling targets,
+	/// conflicting column types) fail fast at construction.
+	/// </summary>
+	private static IReadOnlyList<ActionDefinition> ResolvePrimaryActions(
+		IReadOnlyCollection<ActionDefinition> rawActions)
+	{
+		var resolveResult = ActionTreeResolver.Resolve(rawActions);
+		if (resolveResult.IsFailed)
+		{
+			throw new InvalidOperationException(
+				"RecipeMetadataRegistry: failed to resolve the action reference graph: "
+				+ string.Join("; ", resolveResult.Errors.Select(error => error.Message)));
+		}
+
+		return resolveResult.Value;
 	}
 
 	private static void EnsureColumnPropertyReferencesResolve(

--- a/SemiStep/SemiStep.Core/Recipes/RecipeSession.cs
+++ b/SemiStep/SemiStep.Core/Recipes/RecipeSession.cs
@@ -409,41 +409,13 @@ public sealed class RecipeSession
 
 		var action = actionResult.Value;
 
-		var actionPropertyResult = action.FindProperty(columnKey);
-		if (actionPropertyResult.IsFailed)
+		var valueResult = ParseAndValidateColumnValue(action, columnKey, value);
+		if (valueResult.IsFailed)
 		{
-			return actionPropertyResult.ToResult();
+			return valueResult.ToResult();
 		}
 
-		var actionProperty = actionPropertyResult.Value;
-
-		var propertyDefinitionResult = _recipeMetadataRegistry.GetProperty(actionProperty.PropertyTypeId);
-		if (propertyDefinitionResult.IsFailed)
-		{
-			return propertyDefinitionResult.ToResult();
-		}
-
-		var parseResult = PropertyParser.Parse(value, propertyDefinitionResult.Value);
-		if (parseResult.IsFailed)
-		{
-			return parseResult.ToResult();
-		}
-
-		var parsedValue = parseResult.Value;
-
-		var typeCheck = PropertyValidator.Validate(propertyDefinitionResult.Value, parsedValue.Value);
-		if (typeCheck.IsFailed)
-		{
-			return typeCheck;
-		}
-
-		var groupCheck = PropertyValidator.ValidateGroupValue(actionProperty, parsedValue, _recipeMetadataRegistry);
-		if (groupCheck.IsFailed)
-		{
-			return groupCheck;
-		}
-
-		var updatedStep = step.WithProperty(columnKey, parsedValue);
+		var updatedStep = step.WithProperty(columnKey, valueResult.Value);
 
 		var recalcResult = TryApplyFormulaRecalc(updatedStep, action, columnKey, stepIndex);
 		if (recalcResult.IsFailed)
@@ -458,6 +430,131 @@ public sealed class RecipeSession
 		return Apply(newRecipe);
 	}
 
+	/// <summary>
+	/// Applies a selector-column edit as a single undo unit: sets the selector value, drops the
+	/// values of columns that the new selection deactivates, and seeds default values for columns
+	/// the new selection activates. The whole composition change is committed through a single
+	/// <see cref="Apply"/> call, so one <see cref="Undo"/> restores both the prior selector value
+	/// and the prior dropped values together.
+	/// </summary>
+	public Result UpdateStepForSelectorChange(
+		int stepIndex,
+		string selectorKey,
+		string value,
+		IReadOnlyCollection<string> columnsToDrop,
+		IReadOnlyCollection<string> columnsToSeed)
+	{
+		_logger.LogInformation(
+			"Mutation entry: UpdateStepForSelectorChange StepIndex={StepIndex}, SelectorKey={SelectorKey}, "
+			+ "DropCount={DropCount}, SeedCount={SeedCount}, StepCount={StepCount}",
+			stepIndex,
+			selectorKey,
+			columnsToDrop.Count,
+			columnsToSeed.Count,
+			Current.StepCount);
+
+		var indexCheck = ValidateStepIndex(Current, stepIndex);
+		if (indexCheck.IsFailed)
+		{
+			return indexCheck;
+		}
+
+		var current = Current;
+		var step = current.Steps[stepIndex];
+
+		var actionResult = _recipeMetadataRegistry.GetAction(step.ActionKey);
+		if (actionResult.IsFailed)
+		{
+			return actionResult.ToResult();
+		}
+
+		var action = actionResult.Value;
+
+		var selectorResult = ParseAndValidateColumnValue(action, selectorKey, value);
+		if (selectorResult.IsFailed)
+		{
+			return selectorResult.ToResult();
+		}
+
+		var properties = step.Properties.SetItem(new PropertyId(selectorKey), selectorResult.Value);
+
+		foreach (var dropKey in columnsToDrop)
+		{
+			properties = properties.Remove(new PropertyId(dropKey));
+		}
+
+		// Seed defaults through the same resolver StepInitializer uses, so a newly-activated column
+		// with no default_value (numeric, enum/group) gets its proper default instead of an empty
+		// string that would fail validation.
+		foreach (var seedKey in columnsToSeed)
+		{
+			var seedPropertyResult = action.FindProperty(seedKey);
+			if (seedPropertyResult.IsFailed)
+			{
+				return seedPropertyResult.ToResult();
+			}
+
+			var seedValue = StepInitializer.ResolveDefaultValue(seedPropertyResult.Value, _recipeMetadataRegistry);
+			properties = properties.SetItem(new PropertyId(seedKey), seedValue);
+		}
+
+		var updatedStep = step with { Properties = properties };
+
+		var recalcResult = TryApplyFormulaRecalc(updatedStep, action, selectorKey, stepIndex);
+		if (recalcResult.IsFailed)
+		{
+			return recalcResult.ToResult();
+		}
+
+		updatedStep = recalcResult.Value;
+
+		var newRecipe = current.ReplaceStep(stepIndex, updatedStep);
+
+		return Apply(newRecipe);
+	}
+
+	private Result<PropertyValue> ParseAndValidateColumnValue(
+		ActionDefinition action,
+		string columnKey,
+		string value)
+	{
+		var actionPropertyResult = action.FindProperty(columnKey);
+		if (actionPropertyResult.IsFailed)
+		{
+			return actionPropertyResult.ToResult<PropertyValue>();
+		}
+
+		var actionProperty = actionPropertyResult.Value;
+
+		var propertyDefinitionResult = _recipeMetadataRegistry.GetProperty(actionProperty.PropertyTypeId);
+		if (propertyDefinitionResult.IsFailed)
+		{
+			return propertyDefinitionResult.ToResult<PropertyValue>();
+		}
+
+		var parseResult = PropertyParser.Parse(value, propertyDefinitionResult.Value);
+		if (parseResult.IsFailed)
+		{
+			return parseResult;
+		}
+
+		var parsedValue = parseResult.Value;
+
+		var typeCheck = PropertyValidator.Validate(propertyDefinitionResult.Value, parsedValue.Value);
+		if (typeCheck.IsFailed)
+		{
+			return typeCheck.ToResult<PropertyValue>();
+		}
+
+		var groupCheck = PropertyValidator.ValidateGroupValue(actionProperty, parsedValue, _recipeMetadataRegistry);
+		if (groupCheck.IsFailed)
+		{
+			return groupCheck.ToResult<PropertyValue>();
+		}
+
+		return Result.Ok(parsedValue);
+	}
+
 	private Result<Step> TryApplyFormulaRecalc(Step step, ActionDefinition action, string columnKey, int stepIndex)
 	{
 		if (action.Formula is null
@@ -466,7 +563,8 @@ public sealed class RecipeSession
 			return Result.Ok(step);
 		}
 
-		var recalcResult = _formulaEvaluator.Recalculate(step, action, columnKey);
+		var activeColumns = ActiveColumnSetResolver.Resolve(action, step);
+		var recalcResult = _formulaEvaluator.Recalculate(step, action, columnKey, activeColumns);
 		if (recalcResult.IsFailed)
 		{
 			_logger.LogInformation(

--- a/SemiStep/SemiStep.Core/Recipes/RecipeSession.cs
+++ b/SemiStep/SemiStep.Core/Recipes/RecipeSession.cs
@@ -483,9 +483,8 @@ public sealed class RecipeSession
 			properties = properties.Remove(new PropertyId(dropKey));
 		}
 
-		// Seed defaults through the same resolver StepInitializer uses, so a newly-activated column
-		// with no default_value (numeric, enum/group) gets its proper default instead of an empty
-		// string that would fail validation.
+		// Resolve seed defaults through StepInitializer so a newly-activated column with no
+		// default_value still gets a valid default instead of an empty string that fails validation.
 		foreach (var seedKey in columnsToSeed)
 		{
 			var seedPropertyResult = action.FindProperty(seedKey);

--- a/SemiStep/SemiStep.Core/Recipes/StepInitializer.cs
+++ b/SemiStep/SemiStep.Core/Recipes/StepInitializer.cs
@@ -29,9 +29,11 @@ public static class StepInitializer
 				ResolveDefaultValue(column, recipeMetadataRegistry));
 		}
 
-		// Active set grows monotonically (seeding a selector can only add columns), so it reaches
-		// a fixpoint in at most one iteration per tree level. Cap iterations by column count as a
-		// hard termination guard.
+		// Active set grows monotonically (seeding a selector can only add columns). The loop
+		// terminates when a pass seeds nothing (seededThisPass == false) — that is the real
+		// termination mechanism, reached once the active set stops growing. The Properties.Count
+		// bound is only a defensive upper limit against an unforeseen non-convergence; it can never
+		// actually be hit first, because the active set can grow at most Properties.Count times.
 		for (var iteration = 0; iteration <= action.Properties.Count; iteration++)
 		{
 			var partialStep = new Step(action.Id, properties);

--- a/SemiStep/SemiStep.Core/Recipes/StepInitializer.cs
+++ b/SemiStep/SemiStep.Core/Recipes/StepInitializer.cs
@@ -1,24 +1,67 @@
 ﻿using System.Collections.Immutable;
 using System.Globalization;
 
+using SemiStep.Core.Recipes.Helpers;
+
 namespace SemiStep.Core.Recipes;
 
-internal static class StepInitializer
+public static class StepInitializer
 {
 	internal static Step Create(
 		ActionDefinition action,
 		RecipeMetadataRegistry recipeMetadataRegistry)
 	{
-		var propertyValues = action.Properties
-			.ToImmutableDictionary(
-				col => new PropertyId(col.Key),
-				col => ResolveDefaultValue(col, recipeMetadataRegistry));
+		// Seed to a fixpoint. Always-active columns (no activation conditions — this includes
+		// every top-level selector) are seeded first so the active set can be computed; each
+		// newly-seeded selector can in turn activate deeper columns, so we recompute the active
+		// set and seed again until it stops growing. For a flat (non-nested) action every column
+		// is always-active, so this converges in a single pass and behaves exactly as before.
+		// Inactive columns (e.g. capacitor columns under an Авто selector) are deliberately left
+		// out so serialization writes their PLC slot as 0/empty instead of a stale default.
+		var properties = ImmutableDictionary<PropertyId, PropertyValue>.Empty;
 
-		return new Step(action.Id, propertyValues);
+		var alwaysActive = action.Properties
+			.Where(column => column.Activation is null || column.Activation.Count == 0);
+		foreach (var column in alwaysActive)
+		{
+			properties = properties.SetItem(
+				new PropertyId(column.Key),
+				ResolveDefaultValue(column, recipeMetadataRegistry));
+		}
+
+		// Active set grows monotonically (seeding a selector can only add columns), so it reaches
+		// a fixpoint in at most one iteration per tree level. Cap iterations by column count as a
+		// hard termination guard.
+		for (var iteration = 0; iteration <= action.Properties.Count; iteration++)
+		{
+			var partialStep = new Step(action.Id, properties);
+			var activeColumnKeys = ActiveColumnSetResolver.Resolve(action, partialStep);
+
+			var seededThisPass = false;
+			foreach (var column in action.Properties)
+			{
+				if (properties.ContainsKey(new PropertyId(column.Key)) || !activeColumnKeys.Contains(column.Key))
+				{
+					continue;
+				}
+
+				properties = properties.SetItem(
+					new PropertyId(column.Key),
+					ResolveDefaultValue(column, recipeMetadataRegistry));
+				seededThisPass = true;
+			}
+
+			if (!seededThisPass)
+			{
+				break;
+			}
+		}
+
+		return new Step(action.Id, properties);
 	}
 
 	// Config registries are pre-validated at startup; .Value access is safe here.
-	private static PropertyValue ResolveDefaultValue(
+	internal static PropertyValue ResolveDefaultValue(
 		ActionPropertyDefinition property,
 		RecipeMetadataRegistry recipeMetadataRegistry)
 	{

--- a/SemiStep/SemiStep.Core/Recipes/StepInitializer.cs
+++ b/SemiStep/SemiStep.Core/Recipes/StepInitializer.cs
@@ -11,13 +11,9 @@ public static class StepInitializer
 		ActionDefinition action,
 		RecipeMetadataRegistry recipeMetadataRegistry)
 	{
-		// Seed to a fixpoint. Always-active columns (no activation conditions — this includes
-		// every top-level selector) are seeded first so the active set can be computed; each
-		// newly-seeded selector can in turn activate deeper columns, so we recompute the active
-		// set and seed again until it stops growing. For a flat (non-nested) action every column
-		// is always-active, so this converges in a single pass and behaves exactly as before.
-		// Inactive columns (e.g. capacitor columns under an Авто selector) are deliberately left
-		// out so serialization writes their PLC slot as 0/empty instead of a stale default.
+		// Seed only active columns, to a fixpoint: a seeded selector can activate deeper columns,
+		// so recompute the active set and seed until it stops growing. Inactive columns are left
+		// out deliberately so serialization writes their PLC slot as 0/empty, not a stale default.
 		var properties = ImmutableDictionary<PropertyId, PropertyValue>.Empty;
 
 		var alwaysActive = action.Properties
@@ -29,11 +25,8 @@ public static class StepInitializer
 				ResolveDefaultValue(column, recipeMetadataRegistry));
 		}
 
-		// Active set grows monotonically (seeding a selector can only add columns). The loop
-		// terminates when a pass seeds nothing (seededThisPass == false) — that is the real
-		// termination mechanism, reached once the active set stops growing. The Properties.Count
-		// bound is only a defensive upper limit against an unforeseen non-convergence; it can never
-		// actually be hit first, because the active set can grow at most Properties.Count times.
+		// Real termination is the seededThisPass guard below; the Properties.Count bound is only a
+		// defensive cap (the active set can grow at most Properties.Count times).
 		for (var iteration = 0; iteration <= action.Properties.Count; iteration++)
 		{
 			var partialStep = new Step(action.Id, properties);
@@ -62,7 +55,6 @@ public static class StepInitializer
 		return new Step(action.Id, properties);
 	}
 
-	// Config registries are pre-validated at startup; .Value access is safe here.
 	internal static PropertyValue ResolveDefaultValue(
 		ActionPropertyDefinition property,
 		RecipeMetadataRegistry recipeMetadataRegistry)

--- a/SemiStep/SemiStep.Tests/Config/Integration/Loaders/ActionsSectionLoaderTargetsRoleTests.cs
+++ b/SemiStep/SemiStep.Tests/Config/Integration/Loaders/ActionsSectionLoaderTargetsRoleTests.cs
@@ -1,0 +1,87 @@
+﻿using FluentAssertions;
+
+using SemiStep.Core.Configuration.Loaders;
+using SemiStep.Tests.Config.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Config.Integration.Loaders;
+
+[Trait("Category", "Integration")]
+[Trait("Component", "Config")]
+[Trait("Area", "NestedActions")]
+public sealed class ActionsSectionLoaderTargetsRoleTests
+{
+	private const string NestedActionsYaml = """
+		300:
+		  ui_name: "Etching"
+		  role: action
+		  deploy_duration: "immediate"
+		  columns:
+		    - key: icp_power
+		      property_type_id: power_icp
+		      default_value: "0"
+		    - key: icp_match
+		      group_name: match_mode
+		      property_type_id: enum
+		      targets: { 2: 3002 }
+		3002:
+		  ui_name: "ICP manual"
+		  role: subaction
+		  deploy_duration: "immediate"
+		  columns:
+		    - key: icp_load
+		      property_type_id: percent
+		      default_value: "50"
+		""";
+
+	private const string BackwardCompatYaml = """
+		100:
+		  ui_name: "Simple"
+		  deploy_duration: "immediate"
+		  columns:
+		    - key: power
+		      property_type_id: power
+		      default_value: "0"
+		""";
+
+	[Fact]
+	public async Task ActionsLoader_DeserializesTargetsAndSubactionRole()
+	{
+		using var tempDir = TestDataCopier.CreateEmptyTempDirectory();
+		TestDataCopier.WriteYaml(tempDir, Path.Combine("actions", "process.yaml"), NestedActionsYaml);
+
+		var result = await ActionsSectionLoader.LoadAsync(tempDir.Path);
+
+		result.IsSuccess.Should().BeTrue(result.IsFailed
+			? string.Join("; ", result.Errors.Select(e => e.Message))
+			: string.Empty);
+
+		var primary = result.Value.Single(action => action.Id == 300);
+		primary.Role.Should().Be("action");
+
+		var selectorColumn = primary.Columns!.Single(column => column.Key == "icp_match");
+		selectorColumn.Targets.Should().NotBeNull();
+		selectorColumn.Targets!.Should().ContainKey(2).WhoseValue.Should().Be(3002);
+
+		var subaction = result.Value.Single(action => action.Id == 3002);
+		subaction.Role.Should().Be("subaction");
+	}
+
+	[Fact]
+	public async Task ActionsLoader_AbsentTargetsAndRoleDeserializeAsNull()
+	{
+		using var tempDir = TestDataCopier.CreateEmptyTempDirectory();
+		TestDataCopier.WriteYaml(tempDir, Path.Combine("actions", "process.yaml"), BackwardCompatYaml);
+
+		var result = await ActionsSectionLoader.LoadAsync(tempDir.Path);
+
+		result.IsSuccess.Should().BeTrue(result.IsFailed
+			? string.Join("; ", result.Errors.Select(e => e.Message))
+			: string.Empty);
+
+		var action = result.Value.Single(definition => definition.Id == 100);
+		action.Role.Should().BeNull();
+		action.Columns!.Single().Targets.Should().BeNull();
+	}
+}

--- a/SemiStep/SemiStep.Tests/Config/Integration/NestedActions/RieEtchManualBranchConfigTests.cs
+++ b/SemiStep/SemiStep.Tests/Config/Integration/NestedActions/RieEtchManualBranchConfigTests.cs
@@ -1,0 +1,186 @@
+﻿using FluentAssertions;
+
+using SemiStep.Core.Configuration;
+using SemiStep.Core.Configuration.Facade;
+using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Helpers;
+using SemiStep.Tests.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Config.Integration.NestedActions;
+
+/// <summary>
+/// Verifies the real shipped RIE config (<c>ConfigFiles/RIE</c>): the etch action 300
+/// ("Травление") resolves its capacitor columns through the icp_match / rie_match manual
+/// branches, the resolved column union reproduces the pre-change order byte-for-byte, and
+/// the capacitor columns are active only when their match selector is Ручной (value 2).
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Component", "Config")]
+[Trait("Area", "NestedActions")]
+public sealed class RieEtchManualBranchConfigTests
+{
+	private const int EtchActionId = 300;
+	private const int MatchModeAuto = 1;
+	private const int MatchModeManual = 2;
+
+	// The exact column order action 300 produced before capacitor columns became subactions.
+	// The PLC writes values into fixed slots by this order, so the resolved union must match
+	// it byte-for-byte (rie_power stays between the icp splice and rie_match).
+	private static string[] ExpectedEtchColumnOrder()
+	{
+		return
+		[
+			"ar", "o2", "n2", "sf6", "cf4", "cl2", "he",
+			"gate_mode", "gate_setpoint",
+			"icp_power", "icp_match", "icp_load", "icp_tune",
+			"rie_power", "rie_match", "rie_load", "rie_tune",
+			"step_duration", "comment"
+		];
+	}
+
+	[Fact]
+	public async Task RieConfig_LoadsAndValidatesSuccessfully()
+	{
+		var result = await ConfigFacade.LoadAndValidateAsync(RieConfigPath());
+
+		result.IsSuccess.Should().BeTrue(result.IsFailed
+			? string.Join("; ", result.Errors.Select(error => error.Message))
+			: string.Empty);
+	}
+
+	[Fact]
+	public async Task EtchAction_ResolvedUnion_MatchesPriorColumnOrderExactly()
+	{
+		var registry = await BuildRieRegistryAsync();
+
+		var etch = registry.GetAction(EtchActionId);
+		etch.IsSuccess.Should().BeTrue();
+
+		etch.Value.Properties.Select(property => property.Key)
+			.Should().Equal(ExpectedEtchColumnOrder());
+	}
+
+	[Fact]
+	public async Task EtchAction_DropsTargetsFromResolvedColumns()
+	{
+		var registry = await BuildRieRegistryAsync();
+
+		var etch = registry.GetAction(EtchActionId).Value;
+
+		etch.Properties.Should().OnlyContain(property => property.Targets == null);
+	}
+
+	[Fact]
+	public async Task EtchAction_CapacitorColumns_CarryManualBranchActivation()
+	{
+		var registry = await BuildRieRegistryAsync();
+		var etch = registry.GetAction(EtchActionId).Value;
+
+		Activation(etch, "icp_load").Should().ContainSingle()
+			.Which.Should().Be(new ActivationCondition("icp_match", MatchModeManual));
+		Activation(etch, "icp_tune").Should().ContainSingle()
+			.Which.Should().Be(new ActivationCondition("icp_match", MatchModeManual));
+		Activation(etch, "rie_load").Should().ContainSingle()
+			.Which.Should().Be(new ActivationCondition("rie_match", MatchModeManual));
+		Activation(etch, "rie_tune").Should().ContainSingle()
+			.Which.Should().Be(new ActivationCondition("rie_match", MatchModeManual));
+
+		Property(etch, "icp_power").Activation.Should().BeNull();
+		Property(etch, "rie_power").Activation.Should().BeNull();
+		Property(etch, "icp_match").Activation.Should().BeNull();
+		Property(etch, "rie_match").Activation.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task EtchAction_AutoMatch_DeactivatesCapacitorColumns()
+	{
+		var registry = await BuildRieRegistryAsync();
+		var etch = registry.GetAction(EtchActionId).Value;
+
+		var step = StepWithMatchModes(icpMatch: MatchModeAuto, rieMatch: MatchModeAuto);
+		var active = ActiveColumnSetResolver.Resolve(etch, step);
+
+		active.Should().NotContain("icp_load");
+		active.Should().NotContain("icp_tune");
+		active.Should().NotContain("rie_load");
+		active.Should().NotContain("rie_tune");
+		active.Should().Contain("icp_power");
+		active.Should().Contain("rie_power");
+	}
+
+	[Fact]
+	public async Task EtchAction_ManualMatch_ActivatesCapacitorColumns()
+	{
+		var registry = await BuildRieRegistryAsync();
+		var etch = registry.GetAction(EtchActionId).Value;
+
+		var step = StepWithMatchModes(icpMatch: MatchModeManual, rieMatch: MatchModeManual);
+		var active = ActiveColumnSetResolver.Resolve(etch, step);
+
+		active.Should().Contain("icp_load");
+		active.Should().Contain("icp_tune");
+		active.Should().Contain("rie_load");
+		active.Should().Contain("rie_tune");
+	}
+
+	[Fact]
+	public async Task EtchAction_MatchSelectorsAreIndependent()
+	{
+		var registry = await BuildRieRegistryAsync();
+		var etch = registry.GetAction(EtchActionId).Value;
+
+		var step = StepWithMatchModes(icpMatch: MatchModeManual, rieMatch: MatchModeAuto);
+		var active = ActiveColumnSetResolver.Resolve(etch, step);
+
+		active.Should().Contain("icp_load");
+		active.Should().Contain("icp_tune");
+		active.Should().NotContain("rie_load");
+		active.Should().NotContain("rie_tune");
+	}
+
+	[Fact]
+	public async Task RieConfig_DropdownExcludesSubactions()
+	{
+		var registry = await BuildRieRegistryAsync();
+
+		var dropdownIds = registry.GetActionComboBoxItems().Select(item => item.Id).ToList();
+
+		dropdownIds.Should().NotContain(3002);
+		dropdownIds.Should().NotContain(3003);
+		dropdownIds.Should().Contain(EtchActionId);
+	}
+
+	private static Step StepWithMatchModes(int icpMatch, int rieMatch)
+	{
+		return new Step(EtchActionId, System.Collections.Immutable.ImmutableDictionary<PropertyId, PropertyValue>.Empty)
+			.WithProperty("icp_match", PropertyValue.FromInt(icpMatch))
+			.WithProperty("rie_match", PropertyValue.FromInt(rieMatch));
+	}
+
+	private static IReadOnlyList<ActivationCondition>? Activation(ActionDefinition action, string key)
+	{
+		return Property(action, key).Activation;
+	}
+
+	private static ActionPropertyDefinition Property(ActionDefinition action, string key)
+	{
+		return action.Properties.Single(property => property.Key == key);
+	}
+
+	private static async Task<RecipeMetadataRegistry> BuildRieRegistryAsync()
+	{
+		var result = await ConfigFacade.LoadAndValidateAsync(RieConfigPath());
+		result.IsSuccess.Should().BeTrue(result.IsFailed
+			? string.Join("; ", result.Errors.Select(error => error.Message))
+			: string.Empty);
+
+		return new RecipeMetadataRegistry(result.Value);
+	}
+
+	private static string RieConfigPath()
+	{
+		return ShippedConfigLocator.GetConfigDirectory("RIE");
+	}
+}

--- a/SemiStep/SemiStep.Tests/Config/Integration/Validation/NestedActionReferenceTests.cs
+++ b/SemiStep/SemiStep.Tests/Config/Integration/Validation/NestedActionReferenceTests.cs
@@ -63,6 +63,17 @@ public sealed class NestedActionReferenceTests
 	}
 
 	[Fact]
+	public async Task SharedColumnWithinRoot_FailsWithClearMessage()
+	{
+		var result = await ConfigTestHelper.LoadInvalidCaseAsync("NestedSharedWithinRoot");
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("more than one selector condition", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("sub_value", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
 	public async Task ValidNestedConfig_Passes()
 	{
 		var config = await ConfigTestHelper.LoadStandaloneCaseAsync("NestedActionsValid");

--- a/SemiStep/SemiStep.Tests/Config/Integration/Validation/NestedActionReferenceTests.cs
+++ b/SemiStep/SemiStep.Tests/Config/Integration/Validation/NestedActionReferenceTests.cs
@@ -1,0 +1,73 @@
+﻿using FluentAssertions;
+
+using SemiStep.Tests.Config.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Config.Integration.Validation;
+
+[Trait("Category", "Integration")]
+[Trait("Component", "Config")]
+[Trait("Area", "NestedActions")]
+public sealed class NestedActionReferenceTests
+{
+	[Fact]
+	public async Task DanglingTarget_FailsWithClearMessage()
+	{
+		var result = await ConfigTestHelper.LoadInvalidCaseAsync("NestedDanglingTarget");
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("targets undefined action id 9999", StringComparison.OrdinalIgnoreCase));
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("branch_sel", StringComparison.OrdinalIgnoreCase),
+			"error should identify the selector column carrying the dangling target");
+	}
+
+	[Fact]
+	public async Task TargetPointingAtAction_FailsWithClearMessage()
+	{
+		var result = await ConfigTestHelper.LoadInvalidCaseAsync("NestedTargetIsAction");
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("which is role 'action'", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("must point at a 'subaction'", StringComparison.OrdinalIgnoreCase));
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("targets action id 10", StringComparison.OrdinalIgnoreCase),
+			"error should identify the mis-tagged target id");
+	}
+
+	[Fact]
+	public async Task OrphanSubaction_FailsWithClearMessage()
+	{
+		var result = await ConfigTestHelper.LoadInvalidCaseAsync("NestedOrphanSubaction");
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("orphan subaction", StringComparison.OrdinalIgnoreCase));
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("3001", StringComparison.OrdinalIgnoreCase),
+			"error should identify the unreferenced subaction id");
+	}
+
+	[Fact]
+	public async Task DuplicateSubactionId_FailsWithClearMessage()
+	{
+		var result = await ConfigTestHelper.LoadInvalidCaseAsync("NestedDuplicateId");
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("Duplicate action Id", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("3001", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task ValidNestedConfig_Passes()
+	{
+		var config = await ConfigTestHelper.LoadStandaloneCaseAsync("NestedActionsValid");
+
+		config.IsSuccess.Should().BeTrue(
+			"a nested config whose targets resolve to a referenced subaction must load");
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionSelectorSeedIntegrationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionSelectorSeedIntegrationTests.cs
@@ -1,0 +1,186 @@
+﻿using System.Collections.Immutable;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NCalc.Domain;
+
+using SemiStep.Core.Configuration;
+using SemiStep.Core.Plc.Configuration;
+using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Analysis;
+using SemiStep.Core.Recipes.Formulas;
+using SemiStep.Tests.Config.Helpers;
+using SemiStep.Tests.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Core.Integration.Recipes;
+
+/// <summary>
+/// Integration coverage for the selector-edit seed path through <see cref="RecipeSession"/>:
+/// a newly-activated subaction column with no <c>default_value</c> must be seeded with its
+/// resolved default (zero for a numeric column) rather than an empty string that would fail
+/// validation and reject the whole selector edit.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Component", "Core")]
+[Trait("Area", "NestedActions")]
+public sealed class RecipeSessionSelectorSeedIntegrationTests
+{
+	private const int BranchingActionId = 300;
+	private const string SelectorColumn = "branch_sel";
+	private const string SubValueColumn = "sub_value";
+	private const string SubNoDefaultColumn = "sub_nodefault";
+	private const int ManualValue = 1;
+
+	[Fact]
+	public async Task SelectorEdit_SeedsActivatedColumnWithNoDefault_AsZero_AndSucceeds()
+	{
+		var session = await BuildSessionAsync();
+
+		session.AppendStep(BranchingActionId).IsSuccess.Should().BeTrue();
+
+		// sub_value (default "50") and sub_nodefault (no default) are both inactive under Авто.
+		var step = session.Current.Steps[0];
+		step.Properties.ContainsKey(new PropertyId(SubNoDefaultColumn)).Should().BeFalse();
+
+		var result = session.UpdateStepForSelectorChange(
+			0,
+			SelectorColumn,
+			ManualValue.ToString(),
+			columnsToDrop: System.Array.Empty<string>(),
+			columnsToSeed: new[] { SubValueColumn, SubNoDefaultColumn });
+
+		result.IsSuccess.Should().BeTrue(
+			"a column with no default_value must seed its resolved zero default, not an empty string");
+
+		var updated = session.Current.Steps[0];
+		updated.Properties[new PropertyId(SubValueColumn)].AsFloat().Should().Be(50f);
+		updated.Properties[new PropertyId(SubNoDefaultColumn)].AsFloat().Should().Be(0f);
+	}
+
+	[Fact]
+	[Trait("Area", "Formulas")]
+	public void SelectorChange_DeactivatingRecalcVariable_SucceedsWithoutRecalcOrThrow()
+	{
+		// Action 444 has a formula (recalc order a -> b) where 'b' is active only when selector
+		// 'mode' == 2. Switching 'mode' to 1 deactivates 'b' and drops it. The shared
+		// TryApplyFormulaRecalc path must skip the recalc (instead of throwing on the missing
+		// inactive variable) and the edit must succeed in one undo unit.
+		var registry = BuildSelectorGatedRegistry();
+		var session = BuildSession(registry);
+
+		var step = new Step(
+			444,
+			ImmutableDictionary<PropertyId, PropertyValue>.Empty
+				.Add(new PropertyId("mode"), PropertyValue.FromInt(2))
+				.Add(new PropertyId("a"), PropertyValue.FromFloat(5f))
+				.Add(new PropertyId("b"), PropertyValue.FromFloat(10f)));
+		session.LoadAsCurrent(Recipe.Empty.AppendStep(step)).IsSuccess.Should().BeTrue();
+
+		var result = session.UpdateStepForSelectorChange(
+			0,
+			"mode",
+			"1",
+			columnsToDrop: new[] { "b" },
+			columnsToSeed: System.Array.Empty<string>());
+
+		result.IsSuccess.Should().BeTrue("deactivating a recalc variable must skip recalc, not throw");
+
+		var updated = session.Current.Steps[0];
+		updated.Properties[new PropertyId("mode")].AsInt().Should().Be(1);
+		updated.Properties.ContainsKey(new PropertyId("b")).Should().BeFalse("the deactivated column is dropped");
+		updated.Properties[new PropertyId("a")].AsFloat().Should().Be(5f, "the untouched active column is unchanged");
+	}
+
+	private static RecipeMetadataRegistry BuildSelectorGatedRegistry()
+	{
+		var properties = new Dictionary<string, PropertyTypeDefinition>
+		{
+			["intp"] = new PropertyTypeDefinition("intp", "int", "numeric", null, -1e9, 1e9, null),
+			["floatp"] = new PropertyTypeDefinition("floatp", "float", "decimal", null, -1e9, 1e9, null),
+			["string"] = new PropertyTypeDefinition("string", "string", "text", null, null, null, 64)
+		};
+
+		var sources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["a"] = "b / 2",
+			["b"] = "a * 2"
+		};
+
+		var compiled = new Dictionary<string, LogicalExpression>(StringComparer.OrdinalIgnoreCase);
+		foreach (var (key, source) in sources)
+		{
+			compiled[key] = FormulaIdentifierExtractor.Parse(source).Value.LogicalExpression;
+		}
+
+		var formula = new FormulaDefinition(
+			recalcOrder: new[] { "a", "b" },
+			compiledExpressions: compiled);
+
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[444] = new ActionDefinition(
+				id: 444,
+				uiName: "selector gated",
+				deployDuration: DeployDuration.Immediate,
+				properties: new[]
+				{
+					new ActionPropertyDefinition(
+						"mode",
+						null,
+						"intp",
+						"1",
+						Targets: new Dictionary<int, int> { [2] = 4444 }),
+					new ActionPropertyDefinition("a", null, "floatp", "0")
+				},
+				formula: formula),
+			[4444] = new ActionDefinition(
+				id: 4444,
+				uiName: "manual branch",
+				deployDuration: DeployDuration.Immediate,
+				properties: new[]
+				{
+					new ActionPropertyDefinition("b", null, "floatp", "0")
+				},
+				role: ActionRole.Subaction)
+		};
+
+		var configuration = new AppConfiguration(
+			Properties: properties,
+			Columns: new Dictionary<string, GridColumnDefinition>(),
+			Groups: new Dictionary<string, GroupDefinition>(),
+			Actions: actions,
+			GridStyle: GridStyleOptions.Default,
+			PlcConfiguration: PlcConfiguration.Default);
+
+		return new RecipeMetadataRegistry(configuration);
+	}
+
+	private static RecipeSession BuildSession(RecipeMetadataRegistry registry)
+	{
+		var analyzer = new RecipeAnalyzer(registry);
+		var evaluator = new FormulaEvaluator(registry, NullLogger<FormulaEvaluator>.Instance);
+		var sync = new StubPlcSyncService();
+
+		return new RecipeSession(
+			analyzer,
+			registry,
+			evaluator,
+			sync,
+			NullLogger<RecipeSession>.Instance);
+	}
+
+	private static async Task<RecipeSession> BuildSessionAsync()
+	{
+		var configResult = await ConfigTestHelper.LoadStandaloneCaseAsync("NestedActionsValid");
+		configResult.IsSuccess.Should().BeTrue(configResult.IsFailed
+			? string.Join("; ", configResult.Errors.Select(error => error.Message))
+			: string.Empty);
+
+		var registry = new RecipeMetadataRegistry(configResult.Value);
+		return BuildSession(registry);
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/RecipeSessionBehaviourCharacterizationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/RecipeSessionBehaviourCharacterizationTests.cs
@@ -24,9 +24,11 @@ public sealed class RecipeSessionBehaviourCharacterizationTests
 	private const int ForLoopActionId = RecipeTestDriver.ForLoopActionId;
 	private const int PauseActionId = RecipeTestDriver.PauseActionId;
 	private const int EndForLoopActionId = RecipeTestDriver.EndForLoopActionId;
+	private const int ValveActionId = RecipeTestDriver.WithGroupActionId;
 	private const int UnknownActionId = 9999;
 	private const string DurationColumn = RecipeTestDriver.StepDurationColumn;
 	private const string CommentColumn = RecipeTestDriver.CommentColumn;
+	private const string TargetColumn = RecipeTestDriver.TargetColumn;
 
 	#region Session.Apply
 
@@ -452,6 +454,120 @@ public sealed class RecipeSessionBehaviourCharacterizationTests
 		var result = harness.Session.UpdateStepProperty(0, DurationColumn, "not-a-number");
 
 		result.IsFailed.Should().BeTrue();
+	}
+
+	#endregion
+
+	#region Session.UpdateStepForSelectorChange
+
+	[Fact]
+	[Trait("Area", "NestedActions")]
+	public async Task UpdateStepForSelectorChange_DropsSeedsAndSetsSelector_InOneApply()
+	{
+		var harness = await BuildHarnessAsync();
+		harness.Session.AppendStep(ValveActionId).IsSuccess.Should().BeTrue();
+		harness.Session.UpdateStepProperty(0, CommentColumn, "keep-me").IsSuccess.Should().BeTrue();
+
+		var result = harness.Session.UpdateStepForSelectorChange(
+			0,
+			TargetColumn,
+			"2",
+			columnsToDrop: new[] { CommentColumn },
+			columnsToSeed: new[] { DurationColumn });
+
+		result.IsSuccess.Should().BeTrue();
+
+		var step = harness.Session.Current.Steps[0];
+		step.Properties[new PropertyId(TargetColumn)].AsInt().Should().Be(2, "selector value is applied");
+		step.Properties.ContainsKey(new PropertyId(CommentColumn))
+			.Should().BeFalse("dropped column is removed");
+		step.Properties[new PropertyId(DurationColumn)].AsFloat().Should().Be(10f, "seeded column gets its resolved default");
+	}
+
+	[Fact]
+	[Trait("Area", "NestedActions")]
+	public async Task UpdateStepForSelectorChange_ProducesExactlyOneUndoSnapshot()
+	{
+		var harness = await BuildHarnessAsync();
+		harness.Session.AppendStep(ValveActionId).IsSuccess.Should().BeTrue();
+
+		var undoCountBefore = harness.Session.UndoCount;
+
+		harness.Session.UpdateStepForSelectorChange(
+			0,
+			TargetColumn,
+			"2",
+			columnsToDrop: new[] { CommentColumn },
+			columnsToSeed: new[] { DurationColumn })
+			.IsSuccess.Should().BeTrue();
+
+		harness.Session.UndoCount.Should().Be(
+			undoCountBefore + 1,
+			"a batched selector change is a single undo unit regardless of how many columns it drops or seeds");
+	}
+
+	[Fact]
+	[Trait("Area", "NestedActions")]
+	public async Task UpdateStepForSelectorChange_SingleUndo_RestoresSelectorAndDroppedValues()
+	{
+		var harness = await BuildHarnessAsync();
+		harness.Session.AppendStep(ValveActionId).IsSuccess.Should().BeTrue();
+		harness.Session.UpdateStepProperty(0, TargetColumn, "1").IsSuccess.Should().BeTrue();
+		harness.Session.UpdateStepProperty(0, CommentColumn, "manual-branch").IsSuccess.Should().BeTrue();
+
+		harness.Session.UpdateStepForSelectorChange(
+			0,
+			TargetColumn,
+			"2",
+			columnsToDrop: new[] { CommentColumn },
+			columnsToSeed: new[] { DurationColumn })
+			.IsSuccess.Should().BeTrue();
+
+		harness.Session.Undo().IsSuccess.Should().BeTrue();
+
+		var step = harness.Session.Current.Steps[0];
+		step.Properties[new PropertyId(TargetColumn)].AsInt()
+			.Should().Be(1, "one Undo restores the prior selector value");
+		step.Properties[new PropertyId(CommentColumn)].AsString()
+			.Should().Be("manual-branch", "the same Undo restores the dropped value in one step");
+	}
+
+	[Fact]
+	[Trait("Area", "NestedActions")]
+	public async Task UpdateStepForSelectorChange_InvalidSelectorValue_FailsAndDoesNotMutate()
+	{
+		var harness = await BuildHarnessAsync();
+		harness.Session.AppendStep(ValveActionId).IsSuccess.Should().BeTrue();
+
+		var result = harness.Session.UpdateStepForSelectorChange(
+			0,
+			TargetColumn,
+			"not-a-number",
+			columnsToDrop: Array.Empty<string>(),
+			columnsToSeed: Array.Empty<string>());
+
+		result.IsFailed.Should().BeTrue();
+		harness.Session.Current.Steps[0].Properties.ContainsKey(new PropertyId(CommentColumn))
+			.Should().BeTrue("a rejected batched edit must not mutate the step");
+	}
+
+	[Fact]
+	[Trait("Area", "NestedActions")]
+	public async Task UpdateStepProperty_StillSingleUndoUnit_Unchanged()
+	{
+		var harness = await BuildHarnessAsync();
+		harness.Session.AppendStep(ValveActionId).IsSuccess.Should().BeTrue();
+		harness.Session.UpdateStepProperty(0, CommentColumn, "first").IsSuccess.Should().BeTrue();
+
+		var undoCountBefore = harness.Session.UndoCount;
+
+		harness.Session.UpdateStepProperty(0, CommentColumn, "second").IsSuccess.Should().BeTrue();
+
+		harness.Session.UndoCount.Should().Be(undoCountBefore + 1, "an ordinary single-property edit is one undo unit");
+
+		harness.Session.Undo().IsSuccess.Should().BeTrue();
+		harness.Session.Current.Steps[0].Properties[new PropertyId(CommentColumn)].AsString()
+			.Should().Be("first", "one Undo reverts a single-property edit");
 	}
 
 	#endregion

--- a/SemiStep/SemiStep.Tests/Core/Recipes/Helpers/ActiveColumnSetResolverTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Recipes/Helpers/ActiveColumnSetResolverTests.cs
@@ -1,0 +1,193 @@
+﻿using System.Collections.Immutable;
+
+using FluentAssertions;
+
+using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Core.Recipes.Helpers;
+
+[Trait("Component", "Core")]
+[Trait("Category", "Unit")]
+[Trait("Area", "NestedActions")]
+public sealed class ActiveColumnSetResolverTests
+{
+	private const int Auto = 1;
+	private const int Manual = 2;
+
+	[Fact]
+	public void Resolve_IcpMatchAuto_IcpManualColumnsInactive()
+	{
+		var action = BuildRieAction();
+		var step = BuildStep(icpMatch: Auto, rieMatch: Auto);
+
+		var active = ActiveColumnSetResolver.Resolve(action, step);
+
+		active.Should().NotContain("icp_load");
+		active.Should().NotContain("icp_tune");
+	}
+
+	[Fact]
+	public void Resolve_IcpMatchManual_IcpManualColumnsActive()
+	{
+		var action = BuildRieAction();
+		var step = BuildStep(icpMatch: Manual, rieMatch: Auto);
+
+		var active = ActiveColumnSetResolver.Resolve(action, step);
+
+		active.Should().Contain("icp_load");
+		active.Should().Contain("icp_tune");
+	}
+
+	[Fact]
+	public void Resolve_RieBranchIndependentOfIcpBranch()
+	{
+		var action = BuildRieAction();
+		var step = BuildStep(icpMatch: Auto, rieMatch: Manual);
+
+		var active = ActiveColumnSetResolver.Resolve(action, step);
+
+		active.Should().NotContain("icp_load");
+		active.Should().NotContain("icp_tune");
+		active.Should().Contain("rie_load");
+		active.Should().Contain("rie_tune");
+	}
+
+	[Fact]
+	public void Resolve_AlwaysActiveColumns_StayActiveRegardlessOfSelectors()
+	{
+		var action = BuildRieAction();
+		var step = BuildStep(icpMatch: Auto, rieMatch: Auto);
+
+		var active = ActiveColumnSetResolver.Resolve(action, step);
+
+		active.Should().Contain("icp_match");
+		active.Should().Contain("rie_match");
+		active.Should().Contain("step_duration");
+	}
+
+	[Fact]
+	public void Resolve_SelectorValueMissing_DependentColumnsInactive()
+	{
+		var action = BuildRieAction();
+		var step = new Step(300, ImmutableDictionary<PropertyId, PropertyValue>.Empty);
+
+		var active = ActiveColumnSetResolver.Resolve(action, step);
+
+		active.Should().NotContain("icp_load");
+		active.Should().NotContain("rie_load");
+		active.Should().Contain("step_duration");
+	}
+
+	[Fact]
+	public void Resolve_Depth2Chain_RequiresEveryConditionOnThePath()
+	{
+		// chamber selector value 5 -> branch, then criterion selector value 7 -> leaf column.
+		var action = BuildDepth2Action();
+
+		var both = ActiveColumnSetResolver.Resolve(
+			action,
+			BuildDepth2Step(chamber: 5, criterion: 7));
+		both.Should().Contain("leaf_value");
+
+		var chamberOnly = ActiveColumnSetResolver.Resolve(
+			action,
+			BuildDepth2Step(chamber: 5, criterion: 0));
+		chamberOnly.Should().NotContain("leaf_value");
+
+		var none = ActiveColumnSetResolver.Resolve(
+			action,
+			BuildDepth2Step(chamber: 0, criterion: 7));
+		none.Should().NotContain("leaf_value");
+	}
+
+	private static ActionDefinition BuildRieAction()
+	{
+		var properties = new List<ActionPropertyDefinition>
+		{
+			Enum("icp_match"),
+			Percent("icp_load", new ActivationCondition("icp_match", Manual)),
+			Percent("icp_tune", new ActivationCondition("icp_match", Manual)),
+			Enum("rie_match"),
+			Percent("rie_load", new ActivationCondition("rie_match", Manual)),
+			Percent("rie_tune", new ActivationCondition("rie_match", Manual)),
+			Time("step_duration")
+		};
+
+		return new ActionDefinition(
+			id: 300,
+			uiName: "Travlenie",
+			deployDuration: DeployDuration.LongLasting,
+			properties: properties);
+	}
+
+	private static ActionDefinition BuildDepth2Action()
+	{
+		var properties = new List<ActionPropertyDefinition>
+		{
+			Enum("chamber"),
+			Enum("criterion", new ActivationCondition("chamber", 5)),
+			Percent(
+				"leaf_value",
+				new ActivationCondition("chamber", 5),
+				new ActivationCondition("criterion", 7))
+		};
+
+		return new ActionDefinition(
+			id: 400,
+			uiName: "Pump",
+			deployDuration: DeployDuration.LongLasting,
+			properties: properties);
+	}
+
+	private static Step BuildStep(int icpMatch, int rieMatch)
+	{
+		var properties = ImmutableDictionary<PropertyId, PropertyValue>.Empty
+			.SetItem(new PropertyId("icp_match"), PropertyValue.FromInt(icpMatch))
+			.SetItem(new PropertyId("rie_match"), PropertyValue.FromInt(rieMatch));
+
+		return new Step(300, properties);
+	}
+
+	private static Step BuildDepth2Step(int chamber, int criterion)
+	{
+		var properties = ImmutableDictionary<PropertyId, PropertyValue>.Empty
+			.SetItem(new PropertyId("chamber"), PropertyValue.FromInt(chamber))
+			.SetItem(new PropertyId("criterion"), PropertyValue.FromInt(criterion));
+
+		return new Step(400, properties);
+	}
+
+	private static ActionPropertyDefinition Enum(string key, params ActivationCondition[] activation)
+	{
+		return new ActionPropertyDefinition(
+			Key: key,
+			GroupName: null,
+			PropertyTypeId: "enum",
+			DefaultValue: null,
+			Targets: null,
+			Activation: activation.Length == 0 ? null : activation);
+	}
+
+	private static ActionPropertyDefinition Percent(string key, params ActivationCondition[] activation)
+	{
+		return new ActionPropertyDefinition(
+			Key: key,
+			GroupName: null,
+			PropertyTypeId: "percent",
+			DefaultValue: "50",
+			Targets: null,
+			Activation: activation.Length == 0 ? null : activation);
+	}
+
+	private static ActionPropertyDefinition Time(string key)
+	{
+		return new ActionPropertyDefinition(
+			Key: key,
+			GroupName: null,
+			PropertyTypeId: "time",
+			DefaultValue: "10");
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Recipes/Helpers/CellStateResolverTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Recipes/Helpers/CellStateResolverTests.cs
@@ -16,9 +16,9 @@ public sealed class CellStateResolverTests
 	public void IsInapplicable_ReturnsFalse_WhenColumnIsReadOnly()
 	{
 		var column = BuildColumn(key: "duration", readOnly: true);
-		var action = BuildAction(propertyKeys: []);
+		IReadOnlySet<string> activeColumnKeys = new HashSet<string>();
 
-		var result = CellStateResolver.IsInapplicable(column, action);
+		var result = CellStateResolver.IsInapplicable(column, activeColumnKeys);
 
 		result.Should().BeFalse();
 	}
@@ -27,31 +27,31 @@ public sealed class CellStateResolverTests
 	public void IsInapplicable_ReturnsFalse_WhenColumnIsActionColumn()
 	{
 		var column = BuildColumn(key: StepValueParser.ActionColumnKey, readOnly: false);
-		var action = BuildAction(propertyKeys: []);
+		IReadOnlySet<string> activeColumnKeys = new HashSet<string>();
 
-		var result = CellStateResolver.IsInapplicable(column, action);
+		var result = CellStateResolver.IsInapplicable(column, activeColumnKeys);
 
 		result.Should().BeFalse();
 	}
 
 	[Fact]
-	public void IsInapplicable_ReturnsTrue_WhenActionMissesProperty()
+	public void IsInapplicable_ReturnsTrue_WhenColumnIsNotActive()
 	{
 		var column = BuildColumn(key: "temperature", readOnly: false);
-		var action = BuildAction(propertyKeys: ["duration"]);
+		IReadOnlySet<string> activeColumnKeys = new HashSet<string> { "duration" };
 
-		var result = CellStateResolver.IsInapplicable(column, action);
+		var result = CellStateResolver.IsInapplicable(column, activeColumnKeys);
 
 		result.Should().BeTrue();
 	}
 
 	[Fact]
-	public void IsInapplicable_ReturnsFalse_WhenActionHasProperty()
+	public void IsInapplicable_ReturnsFalse_WhenColumnIsActive()
 	{
 		var column = BuildColumn(key: "temperature", readOnly: false);
-		var action = BuildAction(propertyKeys: ["temperature"]);
+		IReadOnlySet<string> activeColumnKeys = new HashSet<string> { "temperature" };
 
-		var result = CellStateResolver.IsInapplicable(column, action);
+		var result = CellStateResolver.IsInapplicable(column, activeColumnKeys);
 
 		result.Should().BeFalse();
 	}
@@ -65,22 +65,5 @@ public sealed class CellStateResolverTests
 			PropertyTypeId: "string",
 			ReadOnly: readOnly,
 			SaveToCsv: true);
-	}
-
-	private static ActionDefinition BuildAction(string[] propertyKeys)
-	{
-		var properties = propertyKeys
-			.Select(key => new ActionPropertyDefinition(
-				Key: key,
-				GroupName: null,
-				PropertyTypeId: "string",
-				DefaultValue: null))
-			.ToArray();
-
-		return new ActionDefinition(
-			id: 1,
-			uiName: "TestAction",
-			deployDuration: DeployDuration.Immediate,
-			properties: properties);
 	}
 }

--- a/SemiStep/SemiStep.Tests/Core/Recipes/StepInitializerTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Recipes/StepInitializerTests.cs
@@ -1,0 +1,142 @@
+﻿using FluentAssertions;
+
+using SemiStep.Core.Recipes;
+using SemiStep.Tests.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Core.Recipes;
+
+[Trait("Category", "Unit")]
+[Trait("Component", "Core")]
+[Trait("Area", "NestedActions")]
+public sealed class StepInitializerTests
+{
+	private const int RootId = 900;
+	private const int IntermediateSubactionId = 901;
+	private const int LeafSubactionId = 902;
+	private const int SiblingSubactionId = 903;
+
+	// The intermediate selector's enabling value: choosing it pulls in the leaf subaction.
+	private const int IntermediateEnabling = 1;
+
+	// The leaf selector's enabling value: choosing it pulls in the depth-2 leaf column.
+	private const int LeafEnabling = 1;
+
+	[Fact]
+	public void Create_Depth2Chain_IntermediateSelectorDefaultsToEnabling_SeedsLeafColumn()
+	{
+		// The depth-1 selector defaults to its enabling value, which activates the intermediate
+		// selector; the intermediate selector ALSO defaults to its enabling value, which activates
+		// the depth-2 leaf column. A single-pass seeding computes the active set once from the
+		// always-active columns only, so the leaf column is never reached: the intermediate
+		// selector is not yet seeded when the active set is computed. The fixpoint seeding must
+		// reach the leaf column.
+		var registry = BuildRegistry();
+		var action = registry.GetAction(RootId).Value;
+
+		var step = StepInitializer.Create(action, registry);
+
+		step.Properties.Should().ContainKey(new PropertyId("root_sel"));
+		step.Properties.Should().ContainKey(new PropertyId("leaf_sel"));
+		step.Properties[new PropertyId("leaf_value")].AsFloat().Should().Be(50f);
+	}
+
+	[Fact]
+	public void Create_Depth2Chain_InactiveSiblingBranch_IsNotSeeded()
+	{
+		// The sibling branch activates only when the depth-1 selector holds value 2; it defaults to
+		// value 1, so the sibling column never activates and its slot must be left unseeded
+		// (serialises as 0 rather than a stale default).
+		var registry = BuildRegistry();
+		var action = registry.GetAction(RootId).Value;
+
+		var step = StepInitializer.Create(action, registry);
+
+		step.Properties.Should().NotContainKey(new PropertyId("sibling_value"));
+	}
+
+	private static RecipeMetadataRegistry BuildRegistry()
+	{
+		var properties = new[]
+		{
+			TestPropertyTypeDefinitionBuilder.CreateInt("enum"),
+			TestPropertyTypeDefinitionBuilder.CreateFloat("percent"),
+			TestPropertyTypeDefinitionBuilder.CreateString("comment", TestRecipeMetadataRegistryFactory.DefaultStringMaxLength)
+		};
+
+		// leaf subaction: a single percent column, pulled in by the intermediate selector.
+		var leaf = Subaction(LeafSubactionId, Percent("leaf_value"));
+
+		// intermediate subaction: itself carries a selector that defaults to its enabling value,
+		// so the leaf column should be active at creation.
+		var intermediate = Subaction(
+			IntermediateSubactionId,
+			SelectorWithDefault("leaf_sel", LeafEnabling, (LeafEnabling, LeafSubactionId)));
+
+		// sibling subaction: a percent column reached only when the root selector holds value 2.
+		var sibling = Subaction(SiblingSubactionId, Percent("sibling_value"));
+
+		// root: the depth-1 selector defaults to its enabling value (1 -> intermediate), so the
+		// whole chain should seed; value 2 would pull in the sibling branch instead.
+		var root = new ActionDefinition(
+			id: RootId,
+			uiName: "Depth2Root",
+			deployDuration: DeployDuration.LongLasting,
+			properties: new List<ActionPropertyDefinition>
+			{
+				SelectorWithDefault(
+					"root_sel",
+					IntermediateEnabling,
+					(IntermediateEnabling, IntermediateSubactionId),
+					(2, SiblingSubactionId)),
+				Column("comment", "comment")
+			},
+			role: ActionRole.Action);
+
+		return TestRecipeMetadataRegistryFactory.Build(
+			properties,
+			actions: new Dictionary<int, ActionDefinition>
+			{
+				[RootId] = root,
+				[IntermediateSubactionId] = intermediate,
+				[LeafSubactionId] = leaf,
+				[SiblingSubactionId] = sibling
+			});
+	}
+
+	private static ActionDefinition Subaction(int id, params ActionPropertyDefinition[] columns)
+	{
+		return new ActionDefinition(
+			id,
+			$"sub-{id}",
+			DeployDuration.LongLasting,
+			columns,
+			null,
+			ActionRole.Subaction);
+	}
+
+	private static ActionPropertyDefinition Column(string key, string propertyTypeId)
+	{
+		return new ActionPropertyDefinition(key, null, propertyTypeId, null);
+	}
+
+	private static ActionPropertyDefinition Percent(string key)
+	{
+		return new ActionPropertyDefinition(key, null, "percent", "50");
+	}
+
+	private static ActionPropertyDefinition SelectorWithDefault(
+		string key,
+		int defaultValue,
+		params (int Value, int TargetId)[] targets)
+	{
+		var map = targets.ToDictionary(t => t.Value, t => t.TargetId);
+		return new ActionPropertyDefinition(
+			Key: key,
+			GroupName: null,
+			PropertyTypeId: "enum",
+			DefaultValue: defaultValue.ToString(),
+			Targets: map);
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Configuration/Mapping/ActionMapperRoleTargetsTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Configuration/Mapping/ActionMapperRoleTargetsTests.cs
@@ -1,0 +1,121 @@
+﻿using FluentAssertions;
+
+using SemiStep.Core.Configuration.Dto;
+using SemiStep.Core.Configuration.Mapping;
+using SemiStep.Core.Recipes;
+
+using Xunit;
+
+namespace SemiStep.Tests.Core.Unit.Configuration.Mapping;
+
+[Trait("Category", "Unit")]
+[Trait("Component", "Config")]
+[Trait("Area", "Mapping")]
+public sealed class ActionMapperRoleTargetsTests
+{
+	[Fact]
+	public void TryMap_NullRole_DefaultsToAction()
+	{
+		var dto = BuildBaseActionDto();
+		dto.Role = null;
+
+		var result = ActionMapper.TryMap(dto, BuildDefaultProperties());
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Role.Should().Be(ActionRole.Action);
+	}
+
+	[Fact]
+	public void TryMap_ExplicitActionRole_MapsToAction()
+	{
+		var dto = BuildBaseActionDto();
+		dto.Role = "action";
+
+		var result = ActionMapper.TryMap(dto, BuildDefaultProperties());
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Role.Should().Be(ActionRole.Action);
+	}
+
+	[Fact]
+	public void TryMap_SubactionRole_MapsToSubaction()
+	{
+		var dto = BuildBaseActionDto();
+		dto.Role = "subaction";
+
+		var result = ActionMapper.TryMap(dto, BuildDefaultProperties());
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Role.Should().Be(ActionRole.Subaction);
+	}
+
+	[Fact]
+	public void TryMap_InvalidRoleString_Fails()
+	{
+		var dto = BuildBaseActionDto();
+		dto.Role = "primary";
+
+		var result = ActionMapper.TryMap(dto, BuildDefaultProperties());
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("Unsupported role 'primary'"));
+	}
+
+	[Fact]
+	public void TryMap_SelectorColumnTargets_SurviveMapping()
+	{
+		var dto = BuildBaseActionDto();
+		dto.Columns!.Add(new ActionColumnDto
+		{
+			Key = "icp_match",
+			GroupName = "match_mode",
+			PropertyTypeId = "temp",
+			Targets = new Dictionary<int, int> { [2] = 3002 }
+		});
+
+		var result = ActionMapper.TryMap(dto, BuildDefaultProperties());
+
+		result.IsSuccess.Should().BeTrue();
+		var selectorColumn = result.Value.Properties.Single(p => p.Key == "icp_match");
+		selectorColumn.Targets.Should().NotBeNull();
+		selectorColumn.Targets.Should().ContainKey(2).WhoseValue.Should().Be(3002);
+	}
+
+	[Fact]
+	public void TryMap_NonSelectorColumns_HaveNoTargets()
+	{
+		var dto = BuildBaseActionDto();
+
+		var result = ActionMapper.TryMap(dto, BuildDefaultProperties());
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Properties.Should().OnlyContain(p => p.Targets == null);
+	}
+
+	private static IReadOnlyDictionary<string, PropertyTypeDefinition> BuildDefaultProperties()
+	{
+		return new Dictionary<string, PropertyTypeDefinition>(StringComparer.OrdinalIgnoreCase)
+		{
+			["temp"] = new PropertyTypeDefinition("temp", "float", "decimal", null, null, null, null),
+			["speed"] = new PropertyTypeDefinition("speed", "float", "decimal", null, null, null, null),
+			["duration"] = new PropertyTypeDefinition("duration", "float", "decimal", null, null, null, null)
+		};
+	}
+
+	private static ActionDto BuildBaseActionDto()
+	{
+		return new ActionDto
+		{
+			Id = 300,
+			UiName = "process",
+			DeployDuration = "longlasting",
+			Columns = new List<ActionColumnDto>
+			{
+				new() { Key = "task", PropertyTypeId = "temp" },
+				new() { Key = "speed", PropertyTypeId = "speed" },
+				new() { Key = "step_duration", PropertyTypeId = "duration" }
+			}
+		};
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Configuration/Validation/CrossReferenceValidatorGraphTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Configuration/Validation/CrossReferenceValidatorGraphTests.cs
@@ -108,6 +108,41 @@ public sealed class CrossReferenceValidatorGraphTests
 	}
 
 	[Fact]
+	public void SameSelectorTwoValuesToSameSubaction_Fails_WithSpecificMessage()
+	{
+		// One selector maps two values to the same subaction: its columns are reachable within the
+		// root via two different activation paths. OR-activation is unsupported, so this fails.
+		var actions = new List<ActionDto>
+		{
+			Action(300, "Root", Selector("sel", new Dictionary<int, int> { [2] = 3002, [3] = 3002 })),
+			Subaction(3002, "Shared", new ActionColumnDto { Key = "x", PropertyTypeId = "percent" })
+		};
+
+		var result = Validate(actions);
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("more than one selector condition", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("'x'", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public void SharedSubactionAcrossDistinctRoots_Passes()
+	{
+		// Cross-root sharing is allowed: each root resolves the shared subaction with its own path.
+		var actions = new List<ActionDto>
+		{
+			Action(300, "RootOne", Selector("sel_one", 2, 3002)),
+			Action(301, "RootTwo", Selector("sel_two", 3, 3002)),
+			Subaction(3002, "Shared", new ActionColumnDto { Key = "x", PropertyTypeId = "percent" })
+		};
+
+		var result = Validate(actions);
+
+		result.IsSuccess.Should().BeTrue();
+	}
+
+	[Fact]
 	public void ValidNestedGraph_Passes()
 	{
 		var actions = new List<ActionDto>
@@ -177,12 +212,17 @@ public sealed class CrossReferenceValidatorGraphTests
 
 	private static ActionColumnDto Selector(string key, int selectorValue, int targetId)
 	{
+		return Selector(key, new Dictionary<int, int> { [selectorValue] = targetId });
+	}
+
+	private static ActionColumnDto Selector(string key, Dictionary<int, int> targets)
+	{
 		return new ActionColumnDto
 		{
 			Key = key,
 			PropertyTypeId = "enum",
 			GroupName = "match_mode",
-			Targets = new Dictionary<int, int> { [selectorValue] = targetId }
+			Targets = targets
 		};
 	}
 }

--- a/SemiStep/SemiStep.Tests/Core/Unit/Configuration/Validation/CrossReferenceValidatorGraphTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Configuration/Validation/CrossReferenceValidatorGraphTests.cs
@@ -1,0 +1,188 @@
+﻿using FluentAssertions;
+
+using FluentResults;
+
+using SemiStep.Core.Configuration.Dto;
+using SemiStep.Core.Configuration.Validation;
+
+using Xunit;
+
+namespace SemiStep.Tests.Core.Unit.Configuration.Validation;
+
+/// <summary>
+/// Direct unit coverage of the reference-graph rules in <see cref="CrossReferenceValidator"/>,
+/// driven by a hand-built <see cref="ActionDto"/> list. The integration tests exercise the same
+/// rules through the full config load, but that path also runs the resolver, which independently
+/// rejects dangling targets and cycles; these tests pin each validator rule and its specific
+/// message in isolation so a regression that removes a rule cannot hide behind the resolver.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Component", "Config")]
+[Trait("Area", "NestedActions")]
+public sealed class CrossReferenceValidatorGraphTests
+{
+	[Fact]
+	public void DanglingTarget_Fails_WithSpecificMessage()
+	{
+		var actions = new List<ActionDto>
+		{
+			Action(300, "Root", Selector("sel", 1, 9999))
+		};
+
+		var result = Validate(actions);
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("targets undefined action id 9999", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public void TargetIsAction_Fails_WithSpecificMessage()
+	{
+		var actions = new List<ActionDto>
+		{
+			Action(300, "Root", Selector("sel", 1, 400)),
+			Action(400, "OtherRoot")
+		};
+
+		var result = Validate(actions);
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("which is role 'action'", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("must point at a 'subaction'", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public void TargetIsAction_DeeperThanDepth1_StillFails()
+	{
+		// A subaction's OWN selector targets a role:action (a mis-tagged fragment deeper than
+		// depth-1). The rule iterates every action's columns, so it must fire at any depth.
+		var actions = new List<ActionDto>
+		{
+			Action(300, "Root", Selector("sel", 1, 3002)),
+			Subaction(3002, "Branch", Selector("deeper", 1, 400)),
+			Action(400, "AnotherRoot")
+		};
+
+		var result = Validate(actions);
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("targets action id 400", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("must point at a 'subaction'", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public void OrphanSubaction_Fails_WithSpecificMessage()
+	{
+		var actions = new List<ActionDto>
+		{
+			Action(300, "Root"),
+			Subaction(3001, "Unreferenced", new ActionColumnDto { Key = "x", PropertyTypeId = "percent" })
+		};
+
+		var result = Validate(actions);
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("orphan subaction", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("3001", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public void Cycle_Fails_WithSpecificMessage()
+	{
+		var actions = new List<ActionDto>
+		{
+			Action(300, "Root", Selector("enter", 1, 3002)),
+			Subaction(3002, "A", Selector("link", 1, 3003)),
+			Subaction(3003, "B", Selector("back", 1, 3002))
+		};
+
+		var result = Validate(actions);
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("Cycle detected", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public void ValidNestedGraph_Passes()
+	{
+		var actions = new List<ActionDto>
+		{
+			Action(300, "Root", Selector("sel", 1, 3002)),
+			Subaction(3002, "Manual", new ActionColumnDto { Key = "x", PropertyTypeId = "percent" })
+		};
+
+		var result = Validate(actions);
+
+		result.IsSuccess.Should().BeTrue();
+	}
+
+	private static Result Validate(List<ActionDto> actions)
+	{
+		// Supply the supporting properties/columns/groups every referenced key needs so that only
+		// the reference-graph rules under test can fail; the column/property/group existence rules
+		// (validated by sibling methods) stay green.
+		var properties = new List<PropertyDto>
+		{
+			new() { PropertyTypeId = "enum" },
+			new() { PropertyTypeId = "percent" },
+			new() { PropertyTypeId = "time" },
+			new() { PropertyTypeId = "string" }
+		};
+
+		var columnKeys = actions
+			.Where(action => action.Columns != null)
+			.SelectMany(action => action.Columns!)
+			.Select(column => column.Key!)
+			.Distinct()
+			.ToList();
+
+		var columns = columnKeys
+			.Select(key => new ColumnDto { Key = key })
+			.ToList();
+
+		var groups = new Dictionary<string, Dictionary<int, string>>(StringComparer.OrdinalIgnoreCase)
+		{
+			["match_mode"] = new() { [0] = "Auto", [1] = "Manual" }
+		};
+
+		return CrossReferenceValidator.Validate(properties, columns, groups, actions);
+	}
+
+	private static ActionDto Action(int id, string uiName, params ActionColumnDto[] columns)
+	{
+		return new ActionDto
+		{
+			Id = id,
+			UiName = uiName,
+			Role = "action",
+			Columns = columns.ToList()
+		};
+	}
+
+	private static ActionDto Subaction(int id, string uiName, params ActionColumnDto[] columns)
+	{
+		return new ActionDto
+		{
+			Id = id,
+			UiName = uiName,
+			Role = "subaction",
+			Columns = columns.ToList()
+		};
+	}
+
+	private static ActionColumnDto Selector(string key, int selectorValue, int targetId)
+	{
+		return new ActionColumnDto
+		{
+			Key = key,
+			PropertyTypeId = "enum",
+			GroupName = "match_mode",
+			Targets = new Dictionary<int, int> { [selectorValue] = targetId }
+		};
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Properties/CorePropertyStateTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Properties/CorePropertyStateTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Collections.Immutable;
+
+using FluentAssertions;
 
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Helpers;
@@ -51,7 +53,10 @@ public sealed class CorePropertyStateTests
 			ReadOnly: readOnly,
 			SaveToCsv: true);
 
-		var result = CellStateResolver.IsInapplicable(column, _waitAction);
+		var step = new Step(_waitAction.Id, ImmutableDictionary<PropertyId, PropertyValue>.Empty);
+		var activeColumnKeys = ActiveColumnSetResolver.Resolve(_waitAction, step);
+
+		var result = CellStateResolver.IsInapplicable(column, activeColumnKeys);
 
 		result.Should().Be(expectedInapplicable);
 	}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/ActionTreeResolverTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/ActionTreeResolverTests.cs
@@ -150,7 +150,33 @@ public sealed class ActionTreeResolverTests
 
 		result.IsFailed.Should().BeTrue();
 		result.Errors.Should().Contain(e =>
-			e.Message.Contains("two distinct branches", StringComparison.OrdinalIgnoreCase)
+			e.Message.Contains("more than one selector condition", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("shared_a", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public void Resolve_SameSelectorTwoValuesToSameSubaction_Fails()
+	{
+		// One selector maps two distinct values to the SAME subaction (targets: {2: X, 3: X}).
+		// The two values yield different activation paths reaching the same columns; representing
+		// OR-of-paths is unsupported, so the resolver rejects the meaningless authoring.
+		var shared = BuildSubaction(
+			5002,
+			"Shared",
+			Column("shared_a", "percent"),
+			Column("shared_b", "percent"));
+
+		var root = BuildAction(
+			500,
+			"Process",
+			Selector("mode", "enum", (2, 5002), (3, 5002)),
+			Column("tail", "string"));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, shared });
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("more than one selector condition", StringComparison.OrdinalIgnoreCase)
 			&& e.Message.Contains("shared_a", StringComparison.OrdinalIgnoreCase));
 	}
 

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/ActionTreeResolverTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/ActionTreeResolverTests.cs
@@ -1,0 +1,313 @@
+﻿using FluentAssertions;
+
+using SemiStep.Core.Recipes;
+
+using Xunit;
+
+namespace SemiStep.Tests.Core.Unit.Recipes;
+
+[Trait("Category", "Unit")]
+[Trait("Component", "Config")]
+[Trait("Area", "NestedActions")]
+public sealed class ActionTreeResolverTests
+{
+	[Fact]
+	public void Resolve_Depth1_SplicesSubactionColumnsAfterSelector()
+	{
+		var icpManual = BuildSubaction(
+			3002,
+			"ICP manual",
+			Column("icp_load", "percent"),
+			Column("icp_tune", "percent"));
+
+		var rieManual = BuildSubaction(
+			3003,
+			"RIE manual",
+			Column("rie_load", "percent"),
+			Column("rie_tune", "percent"));
+
+		var root = BuildAction(
+			300,
+			"Etch",
+			Column("icp_power", "power"),
+			Selector("icp_match", "enum", (2, 3002)),
+			Selector("rie_match", "enum", (2, 3003)),
+			Column("step_duration", "time"),
+			Column("comment", "string"));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, icpManual, rieManual });
+
+		result.IsSuccess.Should().BeTrue();
+		var resolved = result.Value.Single();
+		Keys(resolved).Should().Equal(
+			"icp_power", "icp_match", "icp_load", "icp_tune",
+			"rie_match", "rie_load", "rie_tune", "step_duration", "comment");
+	}
+
+	[Fact]
+	public void Resolve_Depth1_AssignsActivationConditionsToSubactionColumns()
+	{
+		var icpManual = BuildSubaction(3002, "ICP manual", Column("icp_load", "percent"));
+		var root = BuildAction(
+			300,
+			"Etch",
+			Column("icp_power", "power"),
+			Selector("icp_match", "enum", (2, 3002)));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, icpManual });
+
+		result.IsSuccess.Should().BeTrue();
+		var resolved = result.Value.Single();
+
+		Property(resolved, "icp_power").Activation.Should().BeNull();
+		Property(resolved, "icp_match").Activation.Should().BeNull();
+
+		var icpLoad = Property(resolved, "icp_load");
+		icpLoad.Activation.Should().ContainSingle()
+			.Which.Should().Be(new ActivationCondition("icp_match", 2));
+	}
+
+	[Fact]
+	public void Resolve_ResolvedColumns_DropTargets()
+	{
+		var icpManual = BuildSubaction(3002, "ICP manual", Column("icp_load", "percent"));
+		var root = BuildAction(300, "Etch", Selector("icp_match", "enum", (2, 3002)));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, icpManual });
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Single().Properties.Should().OnlyContain(p => p.Targets == null);
+	}
+
+	[Fact]
+	public void Resolve_Depth2_ChamberToCriterion_BuildsChainedActivation()
+	{
+		var byPressure = BuildSubaction(
+			4002,
+			"By pressure",
+			Column("target_pressure", "pressure"));
+
+		var byTime = BuildSubaction(
+			4003,
+			"By time",
+			Column("target_time", "time"));
+
+		var chamber = BuildSubaction(
+			4001,
+			"Chamber",
+			Column("chamber_id", "enum"),
+			Selector("criterion", "enum", (1, 4002), (2, 4003)));
+
+		var root = BuildAction(
+			400,
+			"Pump",
+			Selector("destination", "enum", (1, 4001)),
+			Column("comment", "string"));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, chamber, byPressure, byTime });
+
+		result.IsSuccess.Should().BeTrue();
+		var resolved = result.Value.Single();
+
+		Keys(resolved).Should().Equal(
+			"destination", "chamber_id", "criterion",
+			"target_pressure", "target_time", "comment");
+
+		Property(resolved, "chamber_id").Activation.Should().ContainSingle()
+			.Which.Should().Be(new ActivationCondition("destination", 1));
+
+		Property(resolved, "target_pressure").Activation.Should().Equal(
+			new ActivationCondition("destination", 1),
+			new ActivationCondition("criterion", 1));
+
+		Property(resolved, "target_time").Activation.Should().Equal(
+			new ActivationCondition("destination", 1),
+			new ActivationCondition("criterion", 2));
+
+		Property(resolved, "comment").Activation.Should().BeNull();
+	}
+
+	[Fact]
+	public void Resolve_SharedSubactionAcrossBranchesOfSameRoot_Fails()
+	{
+		// 5002 is reachable from two selectors of the SAME root with different activation
+		// conditions. Only the first path's conditions would survive on the resolved column,
+		// silently greying it wrongly under the second branch. The resolver rejects this.
+		var shared = BuildSubaction(
+			5002,
+			"Shared",
+			Column("shared_a", "percent"),
+			Column("shared_b", "percent"));
+
+		var root = BuildAction(
+			500,
+			"Process",
+			Selector("mode_one", "enum", (2, 5002)),
+			Selector("mode_two", "enum", (2, 5002)),
+			Column("tail", "string"));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, shared });
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e =>
+			e.Message.Contains("two distinct branches", StringComparison.OrdinalIgnoreCase)
+			&& e.Message.Contains("shared_a", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public void Resolve_SharedSubactionAcrossDistinctRoots_ResolvesOncePerRoot()
+	{
+		// The same subaction shared by two DIFFERENT roots is allowed: each root is resolved
+		// independently with its own activation path.
+		var shared = BuildSubaction(
+			5002,
+			"Shared",
+			Column("shared_a", "percent"));
+
+		var rootOne = BuildAction(
+			500,
+			"ProcessOne",
+			Selector("mode_one", "enum", (2, 5002)));
+
+		var rootTwo = BuildAction(
+			501,
+			"ProcessTwo",
+			Selector("mode_two", "enum", (3, 5002)));
+
+		var result = ActionTreeResolver.Resolve(new[] { rootOne, rootTwo, shared });
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Should().HaveCount(2);
+
+		var resolvedOne = result.Value.Single(a => a.Id == 500);
+		var resolvedTwo = result.Value.Single(a => a.Id == 501);
+
+		Property(resolvedOne, "shared_a").Activation.Should().ContainSingle()
+			.Which.Should().Be(new ActivationCondition("mode_one", 2));
+		Property(resolvedTwo, "shared_a").Activation.Should().ContainSingle()
+			.Which.Should().Be(new ActivationCondition("mode_two", 3));
+	}
+
+	[Fact]
+	public void Resolve_NoRoots_ReturnsEmpty()
+	{
+		var orphanSubaction = BuildSubaction(9001, "Lonely", Column("x", "percent"));
+
+		var result = ActionTreeResolver.Resolve(new[] { orphanSubaction });
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Resolve_DirectCycle_Fails()
+	{
+		var subA = BuildSubaction(6002, "A", Selector("link", "enum", (1, 6003)));
+		var subB = BuildSubaction(6003, "B", Selector("back", "enum", (1, 6002)));
+		var root = BuildAction(600, "Root", Selector("enter", "enum", (1, 6002)));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, subA, subB });
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e => e.Message.Contains("Cycle detected"));
+	}
+
+	[Fact]
+	public void Resolve_ConflictingPropertyTypes_Fails()
+	{
+		var subOne = BuildSubaction(7002, "One", Column("shared", "percent"));
+		var subTwo = BuildSubaction(7003, "Two", Column("shared", "time"));
+		var root = BuildAction(
+			700,
+			"Root",
+			Selector("a", "enum", (1, 7002)),
+			Selector("b", "enum", (1, 7003)));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, subOne, subTwo });
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e => e.Message.Contains("conflicting property types"));
+	}
+
+	[Fact]
+	public void Resolve_DanglingTarget_Fails()
+	{
+		var root = BuildAction(800, "Root", Selector("sel", "enum", (1, 9999)));
+
+		var result = ActionTreeResolver.Resolve(new[] { root });
+
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().Contain(e => e.Message.Contains("undefined action id 9999"));
+	}
+
+	[Fact]
+	public void Resolve_DeterministicOrder_StableAcrossLoads()
+	{
+		var icpManual = BuildSubaction(3002, "ICP manual", Column("icp_load", "percent"), Column("icp_tune", "percent"));
+		var rieManual = BuildSubaction(3003, "RIE manual", Column("rie_load", "percent"), Column("rie_tune", "percent"));
+
+		var first = ActionTreeResolver.Resolve(new[]
+		{
+			BuildAction(300, "Etch", Column("icp_power", "power"), Selector("icp_match", "enum", (2, 3002)), Selector("rie_match", "enum", (2, 3003))),
+			icpManual,
+			rieManual
+		});
+
+		var second = ActionTreeResolver.Resolve(new[]
+		{
+			rieManual,
+			icpManual,
+			BuildAction(300, "Etch", Column("icp_power", "power"), Selector("icp_match", "enum", (2, 3002)), Selector("rie_match", "enum", (2, 3003)))
+		});
+
+		first.IsSuccess.Should().BeTrue();
+		second.IsSuccess.Should().BeTrue();
+		Keys(first.Value.Single()).Should().Equal(Keys(second.Value.Single()));
+	}
+
+	[Fact]
+	public void Resolve_OnlyRootsAreReturned_SubactionsExcluded()
+	{
+		var sub = BuildSubaction(3002, "ICP manual", Column("icp_load", "percent"));
+		var root = BuildAction(300, "Etch", Selector("icp_match", "enum", (2, 3002)));
+
+		var result = ActionTreeResolver.Resolve(new[] { root, sub });
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Should().ContainSingle().Which.Id.Should().Be(300);
+	}
+
+	private static IReadOnlyList<string> Keys(ActionDefinition action)
+	{
+		return action.Properties.Select(p => p.Key).ToList();
+	}
+
+	private static ActionPropertyDefinition Property(ActionDefinition action, string key)
+	{
+		return action.Properties.Single(p => p.Key == key);
+	}
+
+	private static ActionPropertyDefinition Column(string key, string propertyTypeId)
+	{
+		return new ActionPropertyDefinition(key, null, propertyTypeId, null);
+	}
+
+	private static ActionPropertyDefinition Selector(
+		string key,
+		string propertyTypeId,
+		params (int Value, int TargetId)[] targets)
+	{
+		var map = targets.ToDictionary(t => t.Value, t => t.TargetId);
+		return new ActionPropertyDefinition(key, "match_mode", propertyTypeId, null, map);
+	}
+
+	private static ActionDefinition BuildAction(int id, string uiName, params ActionPropertyDefinition[] columns)
+	{
+		return new ActionDefinition(id, uiName, DeployDuration.LongLasting, columns, null, ActionRole.Action);
+	}
+
+	private static ActionDefinition BuildSubaction(int id, string uiName, params ActionPropertyDefinition[] columns)
+	{
+		return new ActionDefinition(id, uiName, DeployDuration.LongLasting, columns, null, ActionRole.Subaction);
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Formulas/FormulaEvaluatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Formulas/FormulaEvaluatorTests.cs
@@ -11,6 +11,7 @@ using SemiStep.Core.Plc.Configuration;
 using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Formulas;
 using SemiStep.Core.Recipes.Formulas.Errors;
+using SemiStep.Core.Recipes.Helpers;
 
 using Xunit;
 
@@ -40,7 +41,7 @@ public sealed class FormulaEvaluatorTests
 			speed: 10f,
 			stepDuration: 600f);
 
-		var result = evaluator.Recalculate(step, action, TaskColumnKey);
+		var result = evaluator.Recalculate(step, action, TaskColumnKey, ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsSuccess.Should().BeTrue();
 		var updated = result.Value;
@@ -56,7 +57,7 @@ public sealed class FormulaEvaluatorTests
 
 		var step = BuildRampStep(task: 700f, initialValue: 500f, speed: 20f, stepDuration: 600f);
 
-		var result = evaluator.Recalculate(step, action, Speed);
+		var result = evaluator.Recalculate(step, action, Speed, ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsSuccess.Should().BeTrue();
 		// recalc_order = [step_duration, speed, task, initial_value]
@@ -75,7 +76,7 @@ public sealed class FormulaEvaluatorTests
 		// speed=0 with changed=task -> target=step_duration -> (task-initial)/0 *60 = infinity
 		var step = BuildRampStep(task: 800f, initialValue: 500f, speed: 0f, stepDuration: 600f);
 
-		var result = evaluator.Recalculate(step, action, TaskColumnKey);
+		var result = evaluator.Recalculate(step, action, TaskColumnKey, ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsFailed.Should().BeTrue();
 		var error = result.Errors.OfType<FormulaComputationFailedError>().FirstOrDefault();
@@ -92,7 +93,7 @@ public sealed class FormulaEvaluatorTests
 
 		var step = BuildRampStep(task: 700f, initialValue: 500f, speed: 10f, stepDuration: 600f);
 
-		var result = evaluator.Recalculate(step, action, "TASK");
+		var result = evaluator.Recalculate(step, action, "TASK", ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.Properties[new PropertyId(StepDuration)].AsFloat().Should().BeApproximately(1200f, 0.001f);
@@ -107,7 +108,7 @@ public sealed class FormulaEvaluatorTests
 
 		var step = BuildRampStep(task: 700f, initialValue: 500f, speed: 20f, stepDuration: 600f);
 
-		var result = evaluator.Recalculate(step, action, Speed);
+		var result = evaluator.Recalculate(step, action, Speed, ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.Properties[new PropertyId(Speed)].AsFloat().Should().BeApproximately(20f, 0.001f,
@@ -123,7 +124,7 @@ public sealed class FormulaEvaluatorTests
 
 		var step = BuildRampStep(task: 100000f, initialValue: 500f, speed: 10f, stepDuration: 50f);
 
-		var result = evaluator.Recalculate(step, action, TaskColumnKey);
+		var result = evaluator.Recalculate(step, action, TaskColumnKey, ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsFailed.Should().BeTrue();
 		var error = result.Errors.OfType<FormulaComputationFailedError>().FirstOrDefault();
@@ -146,7 +147,7 @@ public sealed class FormulaEvaluatorTests
 				.Add(new PropertyId("a"), PropertyValue.FromFloat(0f))
 				.Add(new PropertyId("b"), PropertyValue.FromFloat(0f)));
 
-		var result = evaluator.Recalculate(step, action, "a");
+		var result = evaluator.Recalculate(step, action, "a", ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsFailed.Should().BeTrue();
 		var error = result.Errors.OfType<FormulaComputationFailedError>().FirstOrDefault();
@@ -169,7 +170,7 @@ public sealed class FormulaEvaluatorTests
 				.Add(new PropertyId("a"), PropertyValue.FromFloat(1f))
 				.Add(new PropertyId("b"), PropertyValue.FromFloat(0f)));
 
-		var result = evaluator.Recalculate(step, action, "a");
+		var result = evaluator.Recalculate(step, action, "a", ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsFailed.Should().BeTrue();
 		var error = result.Errors.OfType<FormulaComputationFailedError>().FirstOrDefault();
@@ -191,7 +192,7 @@ public sealed class FormulaEvaluatorTests
 				.Add(new PropertyId("target"), PropertyValue.FromInt(0))
 				.Add(new PropertyId("a"), PropertyValue.FromFloat(1e10f)));
 
-		var result = evaluator.Recalculate(step, action, "a");
+		var result = evaluator.Recalculate(step, action, "a", ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsFailed.Should().BeTrue();
 		result.Errors.Should().ContainItemsAssignableTo<FormulaComputationFailedError>();
@@ -212,7 +213,7 @@ public sealed class FormulaEvaluatorTests
 				.Add(new PropertyId(Speed), PropertyValue.FromString("not a number"))
 				.Add(new PropertyId(StepDuration), PropertyValue.FromFloat(600f)));
 
-		var act = () => evaluator.Recalculate(step, action, TaskColumnKey);
+		var act = () => evaluator.Recalculate(step, action, TaskColumnKey, ActiveColumnSetResolver.Resolve(action, step));
 
 		act.Should().Throw<InvalidOperationException>();
 	}
@@ -227,7 +228,7 @@ public sealed class FormulaEvaluatorTests
 
 		var step = BuildRampStep(task: 100000f, initialValue: 500f, speed: 10f, stepDuration: 50f);
 
-		var result = evaluator.Recalculate(step, action, TaskColumnKey);
+		var result = evaluator.Recalculate(step, action, TaskColumnKey, ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsFailed.Should().BeTrue();
 		result.Errors.Should().ContainItemsAssignableTo<FormulaComputationFailedError>();
@@ -250,7 +251,7 @@ public sealed class FormulaEvaluatorTests
 				.Add(new PropertyId("target"), PropertyValue.FromInt(0))
 				.Add(new PropertyId("a"), PropertyValue.FromFloat((float)targetSeed)));
 
-		var result = evaluator.Recalculate(step, action, "a");
+		var result = evaluator.Recalculate(step, action, "a", ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.Properties[new PropertyId("target")].AsInt().Should().Be(expected);
@@ -270,7 +271,7 @@ public sealed class FormulaEvaluatorTests
 				.Add(new PropertyId("target"), PropertyValue.FromInt(1))
 				.Add(new PropertyId("a"), PropertyValue.FromInt(99)));
 
-		var result = evaluator.Recalculate(step, action, "a");
+		var result = evaluator.Recalculate(step, action, "a", ActiveColumnSetResolver.Resolve(action, step));
 
 		result.IsFailed.Should().BeTrue();
 		var error = result.Errors.OfType<FormulaComputationFailedError>().FirstOrDefault();
@@ -289,7 +290,7 @@ public sealed class FormulaEvaluatorTests
 			ImmutableDictionary<PropertyId, PropertyValue>.Empty
 				.Add(new PropertyId("x"), PropertyValue.FromFloat(1f)));
 
-		var act = () => evaluator.Recalculate(step, action, "x");
+		var act = () => evaluator.Recalculate(step, action, "x", ActiveColumnSetResolver.Resolve(action, step));
 
 		act.Should().Throw<InvalidOperationException>();
 	}
@@ -309,9 +310,116 @@ public sealed class FormulaEvaluatorTests
 				.Add(new PropertyId(InitialValue), PropertyValue.FromFloat(500f))
 				.Add(new PropertyId(StepDuration), PropertyValue.FromFloat(600f)));
 
-		var act = () => evaluator.Recalculate(step, action, TaskColumnKey);
+		var act = () => evaluator.Recalculate(step, action, TaskColumnKey, ActiveColumnSetResolver.Resolve(action, step));
 
 		act.Should().Throw<InvalidOperationException>();
+	}
+
+	[Fact]
+	public void Recalculate_InactiveRecalcVariable_SkipsAndLeavesStepUnchanged()
+	{
+		// The 'b' column is active only when selector 'mode' == 2. With mode == 1 it is inactive,
+		// so the recalc references a column that is not in the active set and must be skipped.
+		var registry = BuildSelectorGatedRegistry();
+		var evaluator = BuildEvaluator(registry);
+		var action = registry.GetAction(444).Value;
+
+		var step = new Step(
+			444,
+			ImmutableDictionary<PropertyId, PropertyValue>.Empty
+				.Add(new PropertyId("mode"), PropertyValue.FromInt(1))
+				.Add(new PropertyId("a"), PropertyValue.FromFloat(5f)));
+
+		var activeColumns = ActiveColumnSetResolver.Resolve(action, step);
+		activeColumns.Should().NotContain("b");
+
+		var result = evaluator.Recalculate(step, action, "a", activeColumns);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Should().BeSameAs(step, "an inactive recalc variable must skip the recalc and leave the step untouched");
+	}
+
+	[Fact]
+	public void Recalculate_AllRecalcVariablesActive_RecomputesAsBefore()
+	{
+		// Same registry, but mode == 2 makes 'b' active, so the formula recalculates normally:
+		// changed = a -> target = b -> b = a * 2.
+		var registry = BuildSelectorGatedRegistry();
+		var evaluator = BuildEvaluator(registry);
+		var action = registry.GetAction(444).Value;
+
+		var step = new Step(
+			444,
+			ImmutableDictionary<PropertyId, PropertyValue>.Empty
+				.Add(new PropertyId("mode"), PropertyValue.FromInt(2))
+				.Add(new PropertyId("a"), PropertyValue.FromFloat(5f))
+				.Add(new PropertyId("b"), PropertyValue.FromFloat(0f)));
+
+		var activeColumns = ActiveColumnSetResolver.Resolve(action, step);
+		activeColumns.Should().Contain("b");
+
+		var result = evaluator.Recalculate(step, action, "a", activeColumns);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Properties[new PropertyId("b")].AsFloat().Should().BeApproximately(10f, 0.001f);
+	}
+
+	private static RecipeMetadataRegistry BuildSelectorGatedRegistry()
+	{
+		var properties = new Dictionary<string, PropertyTypeDefinition>
+		{
+			["intp"] = new PropertyTypeDefinition("intp", "int", "decimal", null, -1000d, 1000d, null),
+			["floatp"] = new PropertyTypeDefinition("floatp", "float", "decimal", null, -1000d, 1000d, null)
+		};
+
+		var sources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["a"] = "b / 2",
+			["b"] = "a * 2"
+		};
+
+		var compiled = new Dictionary<string, LogicalExpression>(StringComparer.OrdinalIgnoreCase);
+		foreach (var (key, source) in sources)
+		{
+			compiled[key] = FormulaIdentifierExtractor.Parse(source).Value.LogicalExpression;
+		}
+
+		var formula = new FormulaDefinition(
+			recalcOrder: new[] { "a", "b" },
+			compiledExpressions: compiled);
+
+		// The activation condition on 'b' is produced by the resolver from the selector's targets,
+		// not set directly: 'mode' targets subaction 4444 for value 2, which contributes 'b'.
+		// The resolved union for action 444 is [mode, b, a] with 'b' active iff mode == 2.
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[444] = new ActionDefinition(
+				id: 444,
+				uiName: "selector gated",
+				deployDuration: DeployDuration.Immediate,
+				properties: new[]
+				{
+					new ActionPropertyDefinition(
+						"mode",
+						null,
+						"intp",
+						"1",
+						Targets: new Dictionary<int, int> { [2] = 4444 }),
+					new ActionPropertyDefinition("a", null, "floatp", "0")
+				},
+				formula: formula),
+			[4444] = new ActionDefinition(
+				id: 4444,
+				uiName: "manual branch",
+				deployDuration: DeployDuration.Immediate,
+				properties: new[]
+				{
+					new ActionPropertyDefinition("b", null, "floatp", "0")
+				},
+				role: ActionRole.Subaction)
+		};
+
+		return new RecipeMetadataRegistry(BuildAppConfiguration(properties, actions));
 	}
 
 	private static FormulaEvaluator BuildEvaluator(RecipeMetadataRegistry registry)

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeMetadataRegistryTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeMetadataRegistryTests.cs
@@ -72,4 +72,212 @@ public sealed class RecipeMetadataRegistryTests
 
 		second.Should().BeSameAs(first);
 	}
+
+	[Fact]
+	public void GetActionComboBoxItems_ExcludesSubactions()
+	{
+		var registry = BuildNestedRegistry();
+
+		var items = registry.GetActionComboBoxItems();
+
+		items.Select(item => item.Id).Should().Equal(300);
+		items.Should().NotContain(item => item.Id == 3002);
+	}
+
+	[Fact]
+	public void GetAction_PrimaryProperties_EqualResolverUnion()
+	{
+		var registry = BuildNestedRegistry();
+
+		var action = registry.GetAction(300);
+
+		action.IsSuccess.Should().BeTrue();
+		action.Value.Properties.Select(property => property.Key).Should().Equal(
+			"icp_power", "icp_match", "icp_load", "icp_tune");
+	}
+
+	[Fact]
+	public void Subaction_DoesNotEnterRuntimeActionCollections()
+	{
+		var registry = BuildNestedRegistry();
+
+		registry.ActionExists(3002).IsFailed.Should().BeTrue();
+		registry.GetAllActions().Should().OnlyContain(action => action.Role == ActionRole.Action);
+	}
+
+	[Fact]
+	public void GetAllActions_FirstAction_IsNeverASubaction()
+	{
+		var registry = BuildNestedRegistry();
+
+		var first = registry.GetAllActions().FirstOrDefault();
+
+		first.Should().NotBeNull();
+		first!.Role.Should().Be(ActionRole.Action);
+		first.Id.Should().Be(300);
+	}
+
+	[Fact]
+	public void GetActionComboBoxItems_BackwardCompat_NoTargetsNoRole_MatchesPlainActions()
+	{
+		var plainActions = new Dictionary<int, ActionDefinition>
+		{
+			[10] = Action(10, "Open", Column("a", "int")),
+			[20] = Action(20, "Close", Column("b", "int"))
+		};
+
+		var registry = BuildRegistryWith(plainActions);
+
+		var items = registry.GetActionComboBoxItems();
+
+		items.Should().Equal(
+			new ComboBoxItemViewModel(10, "Open"),
+			new ComboBoxItemViewModel(20, "Close"));
+	}
+
+	private static RecipeMetadataRegistry BuildNestedRegistry()
+	{
+		var subaction = new ActionDefinition(
+			3002,
+			"ICP manual",
+			DeployDuration.LongLasting,
+			new[] { Column("icp_load", "percent"), Column("icp_tune", "percent") },
+			null,
+			ActionRole.Subaction);
+
+		var root = new ActionDefinition(
+			300,
+			"Etch",
+			DeployDuration.LongLasting,
+			new[] { Column("icp_power", "power"), Selector("icp_match", "enum", 2, 3002) },
+			null,
+			ActionRole.Action);
+
+		return BuildRegistryWith(new Dictionary<int, ActionDefinition>
+		{
+			[300] = root,
+			[3002] = subaction
+		});
+	}
+
+	[Fact]
+	[Trait("Area", "NestedActions")]
+	public void Constructor_CyclicReferenceGraph_Throws()
+	{
+		// 3002 -> 3003 -> 3002 forms a cycle reachable from root 300.
+		var subA = new ActionDefinition(
+			3002,
+			"A",
+			DeployDuration.LongLasting,
+			new[] { Selector("link", "enum", 1, 3003) },
+			null,
+			ActionRole.Subaction);
+
+		var subB = new ActionDefinition(
+			3003,
+			"B",
+			DeployDuration.LongLasting,
+			new[] { Selector("back", "enum", 1, 3002) },
+			null,
+			ActionRole.Subaction);
+
+		var root = new ActionDefinition(
+			300,
+			"Root",
+			DeployDuration.LongLasting,
+			new[] { Selector("enter", "enum", 1, 3002) },
+			null,
+			ActionRole.Action);
+
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[300] = root,
+			[3002] = subA,
+			[3003] = subB
+		};
+
+		var act = () => BuildRegistryWith(actions);
+
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*Cycle detected*");
+	}
+
+	[Fact]
+	[Trait("Area", "NestedActions")]
+	public void Constructor_ConflictingColumnTypesGraph_Throws()
+	{
+		// Both subactions contribute a 'shared' column with different property types into one root.
+		var subOne = new ActionDefinition(
+			7002,
+			"One",
+			DeployDuration.LongLasting,
+			new[] { Column("shared", "percent") },
+			null,
+			ActionRole.Subaction);
+
+		var subTwo = new ActionDefinition(
+			7003,
+			"Two",
+			DeployDuration.LongLasting,
+			new[] { Column("shared", "time") },
+			null,
+			ActionRole.Subaction);
+
+		var root = new ActionDefinition(
+			700,
+			"Root",
+			DeployDuration.LongLasting,
+			new[] { Selector("a", "enum", 1, 7002), Selector("b", "enum", 1, 7003) },
+			null,
+			ActionRole.Action);
+
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[700] = root,
+			[7002] = subOne,
+			[7003] = subTwo
+		};
+
+		var act = () => BuildRegistryWith(actions);
+
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*conflicting property types*");
+	}
+
+	private static RecipeMetadataRegistry BuildRegistryWith(Dictionary<int, ActionDefinition> actions)
+	{
+		var config = new AppConfiguration(
+			Properties: TestRecipeMetadataRegistryFactory.DefaultStringProperty(),
+			Columns: new Dictionary<string, GridColumnDefinition>(),
+			Groups: new Dictionary<string, GroupDefinition>(StringComparer.OrdinalIgnoreCase),
+			Actions: actions,
+			GridStyle: GridStyleOptions.Default,
+			PlcConfiguration: PlcConfiguration.Default);
+
+		return new RecipeMetadataRegistry(config);
+	}
+
+	private static ActionDefinition Action(int id, string uiName, params ActionPropertyDefinition[] columns)
+	{
+		return new ActionDefinition(id, uiName, DeployDuration.LongLasting, columns, null, ActionRole.Action);
+	}
+
+	private static ActionPropertyDefinition Column(string key, string propertyTypeId)
+	{
+		return new ActionPropertyDefinition(key, null, propertyTypeId, null);
+	}
+
+	private static ActionPropertyDefinition Selector(
+		string key,
+		string propertyTypeId,
+		int selectorValue,
+		int targetId)
+	{
+		return new ActionPropertyDefinition(
+			key,
+			"match_mode",
+			propertyTypeId,
+			null,
+			new Dictionary<int, int> { [selectorValue] = targetId });
+	}
 }

--- a/SemiStep/SemiStep.Tests/Helpers/ShippedConfigLocator.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/ShippedConfigLocator.cs
@@ -1,0 +1,31 @@
+﻿namespace SemiStep.Tests.Helpers;
+
+/// <summary>
+/// Locates a shipped equipment config under the repository's <c>ConfigFiles/&lt;name&gt;</c>
+/// directory (e.g. RIE, MOCVD, MBE) by walking up from the test output directory. Used by
+/// tests that must validate the real shipped config rather than a synthetic fixture.
+/// </summary>
+public static class ShippedConfigLocator
+{
+	public static string GetConfigDirectory(string equipmentName)
+	{
+		ArgumentException.ThrowIfNullOrEmpty(equipmentName);
+
+		var baseDir = AppContext.BaseDirectory;
+
+		for (var i = 0; i < 12 && !string.IsNullOrEmpty(baseDir); i++)
+		{
+			var probe = Path.Combine(baseDir, "ConfigFiles", equipmentName);
+			if (Directory.Exists(probe))
+			{
+				return probe;
+			}
+
+			baseDir = Directory.GetParent(baseDir)?.FullName ?? string.Empty;
+		}
+
+		throw new DirectoryNotFoundException(
+			$"Shipped config '{equipmentName}' not found. Expected 'ConfigFiles/{equipmentName}' "
+			+ "in or above the test output directory.");
+	}
+}

--- a/SemiStep/SemiStep.Tests/S7/RieEtchManualBranchSerializationTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/RieEtchManualBranchSerializationTests.cs
@@ -1,0 +1,224 @@
+﻿using System.Collections.Immutable;
+
+using FluentAssertions;
+
+using SemiStep.Core.Configuration.Facade;
+using SemiStep.Core.Plc.S7.Serialization;
+using SemiStep.Core.Recipes;
+using SemiStep.Tests.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.S7;
+
+/// <summary>
+/// PLC byte-layout regression for the RIE etch action 300 ("Травление") after the capacitor
+/// columns (icp_load/icp_tune, rie_load/rie_tune) moved into manual-branch subactions. The
+/// serializer iterates the resolved <c>Properties</c> order to fill fixed PLC slots, so the
+/// slot layout must equal the layout derived from the pre-change column order. A "before"
+/// baseline is impractical here (the old config is gone), so the expected slot order is
+/// stated explicitly from the pre-change order and asserted against the serializer output.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Component", "S7")]
+[Trait("Area", "NestedActions")]
+public sealed class RieEtchManualBranchSerializationTests
+{
+	private const int EtchActionId = 300;
+	private const int MatchModeAuto = 1;
+	private const int MatchModeManual = 2;
+	private const int GateModeDefault = 1;
+
+	[Fact]
+	public async Task SerialiseEtchStep_ManualMatch_ProducesPreChangeSlotLayout()
+	{
+		var registry = await BuildRieRegistryAsync();
+		var converter = new RecipeConverter(registry);
+
+		var step = BuildEtchStep();
+		var recipe = Recipe.Empty.AppendStep(step);
+
+		var result = converter.FromRecipe(recipe);
+
+		result.IsSuccess.Should().BeTrue(result.IsFailed
+			? string.Join("; ", result.Errors.Select(error => error.Message))
+			: string.Empty);
+
+		var data = result.Value;
+		data.StepCount.Should().Be(1);
+
+		// Int slots, in resolved-column order: ActionKey, then the enum columns
+		// gate_mode, icp_match, rie_match.
+		data.IntValues.Should().Equal(EtchActionId, 0, MatchModeManual, MatchModeManual);
+
+		// Float slots, in resolved-column order matching the pre-change layout:
+		// ar, o2, n2, sf6, cf4, cl2, he, gate_setpoint, icp_power,
+		// icp_load, icp_tune, rie_power, rie_load, rie_tune, step_duration.
+		data.FloatValues.Should().Equal(
+			11f, 12f, 13f, 14f, 15f, 16f, 17f,
+			20f,
+			100f,
+			51f, 52f,
+			200f,
+			61f, 62f,
+			30f);
+
+		// String slots: comment.
+		data.StringValues.Should().Equal("etch comment");
+	}
+
+	[Fact]
+	public async Task SerialiseEtchStep_AutoMatch_InactiveCapacitorColumnsWriteZeroIntoTheirSlots()
+	{
+		var registry = await BuildRieRegistryAsync();
+		var converter = new RecipeConverter(registry);
+
+		// Авто on both match selectors: the capacitor columns icp_load/icp_tune and
+		// rie_load/rie_tune are inactive and carry no value. They must still occupy their
+		// fixed float slots, written as 0, so the active columns keep their slot positions.
+		var step = BuildAutoEtchStep();
+		var recipe = Recipe.Empty.AppendStep(step);
+
+		var result = converter.FromRecipe(recipe);
+
+		result.IsSuccess.Should().BeTrue(result.IsFailed
+			? string.Join("; ", result.Errors.Select(error => error.Message))
+			: string.Empty);
+
+		var data = result.Value;
+
+		data.IntValues.Should().Equal(EtchActionId, 0, MatchModeAuto, MatchModeAuto);
+
+		// The four inactive capacitor slots serialise as 0; the active gas/power columns and
+		// step_duration keep their exact positions (no slot shift from the dropped values).
+		data.FloatValues.Should().Equal(
+			11f, 12f, 13f, 14f, 15f, 16f, 17f,
+			20f,
+			100f,
+			0f, 0f,
+			200f,
+			0f, 0f,
+			30f);
+
+		data.StringValues.Should().Equal("etch comment");
+	}
+
+	[Fact]
+	public async Task SerialiseFreshlyCreatedEtchStep_AutoMatch_InactiveCapacitorColumnsWriteZero()
+	{
+		// Exercises the REAL step-creation path (StepInitializer.Create), not a hand-built step.
+		// Action 300 defaults to icp_match/rie_match = Авто (the min group key), so the capacitor
+		// columns icp_load/icp_tune/rie_load/rie_tune are inactive and must NOT be seeded with
+		// their "50" default; their PLC slots must serialise as 0.
+		var registry = await BuildRieRegistryAsync();
+		var converter = new RecipeConverter(registry);
+
+		var action = registry.GetAction(EtchActionId).Value;
+		var step = StepInitializer.Create(action, registry);
+
+		// The four capacitor columns must be absent from the freshly-created step.
+		step.Properties.ContainsKey(new PropertyId("icp_load")).Should().BeFalse();
+		step.Properties.ContainsKey(new PropertyId("icp_tune")).Should().BeFalse();
+		step.Properties.ContainsKey(new PropertyId("rie_load")).Should().BeFalse();
+		step.Properties.ContainsKey(new PropertyId("rie_tune")).Should().BeFalse();
+
+		var recipe = Recipe.Empty.AppendStep(step);
+		var result = converter.FromRecipe(recipe);
+
+		result.IsSuccess.Should().BeTrue(result.IsFailed
+			? string.Join("; ", result.Errors.Select(error => error.Message))
+			: string.Empty);
+
+		var data = result.Value;
+		// Int slots: ActionKey, then gate_mode, icp_match, rie_match — each an enum with no
+		// default_value, so each seeds its group's minimum key (gate_mode min and match_mode
+		// Авто both being 1 in this config).
+		data.IntValues.Should().Equal(EtchActionId, GateModeDefault, MatchModeAuto, MatchModeAuto);
+
+		// All floats default to 0 (config default_value "0" for gas/power/gate, and the inactive
+		// capacitor columns left unseeded); step_duration defaults to 10.
+		data.FloatValues.Should().Equal(
+			0f, 0f, 0f, 0f, 0f, 0f, 0f,
+			0f,
+			0f,
+			0f, 0f,
+			0f,
+			0f, 0f,
+			10f);
+	}
+
+	[Fact]
+	public async Task SerialiseEtchStep_RoundTrips()
+	{
+		var registry = await BuildRieRegistryAsync();
+		var converter = new RecipeConverter(registry);
+
+		var original = Recipe.Empty.AppendStep(BuildEtchStep());
+
+		var serialised = converter.FromRecipe(original);
+		serialised.IsSuccess.Should().BeTrue();
+
+		var deserialised = converter.ToRecipe(serialised.Value);
+		deserialised.IsSuccess.Should().BeTrue();
+
+		deserialised.Value.Should().Be(original);
+	}
+
+	private static Step BuildEtchStep()
+	{
+		return new Step(EtchActionId, ImmutableDictionary<PropertyId, PropertyValue>.Empty)
+			.WithProperty("ar", PropertyValue.FromFloat(11f))
+			.WithProperty("o2", PropertyValue.FromFloat(12f))
+			.WithProperty("n2", PropertyValue.FromFloat(13f))
+			.WithProperty("sf6", PropertyValue.FromFloat(14f))
+			.WithProperty("cf4", PropertyValue.FromFloat(15f))
+			.WithProperty("cl2", PropertyValue.FromFloat(16f))
+			.WithProperty("he", PropertyValue.FromFloat(17f))
+			.WithProperty("gate_mode", PropertyValue.FromInt(0))
+			.WithProperty("gate_setpoint", PropertyValue.FromFloat(20f))
+			.WithProperty("icp_power", PropertyValue.FromFloat(100f))
+			.WithProperty("icp_match", PropertyValue.FromInt(MatchModeManual))
+			.WithProperty("icp_load", PropertyValue.FromFloat(51f))
+			.WithProperty("icp_tune", PropertyValue.FromFloat(52f))
+			.WithProperty("rie_power", PropertyValue.FromFloat(200f))
+			.WithProperty("rie_match", PropertyValue.FromInt(MatchModeManual))
+			.WithProperty("rie_load", PropertyValue.FromFloat(61f))
+			.WithProperty("rie_tune", PropertyValue.FromFloat(62f))
+			.WithProperty("step_duration", PropertyValue.FromFloat(30f))
+			.WithProperty("comment", PropertyValue.FromString("etch comment"));
+	}
+
+	private static Step BuildAutoEtchStep()
+	{
+		// Same active gas/power/duration values as BuildEtchStep, but Авто on both selectors
+		// and no capacitor values set (icp_load/icp_tune, rie_load/rie_tune omitted entirely).
+		return new Step(EtchActionId, ImmutableDictionary<PropertyId, PropertyValue>.Empty)
+			.WithProperty("ar", PropertyValue.FromFloat(11f))
+			.WithProperty("o2", PropertyValue.FromFloat(12f))
+			.WithProperty("n2", PropertyValue.FromFloat(13f))
+			.WithProperty("sf6", PropertyValue.FromFloat(14f))
+			.WithProperty("cf4", PropertyValue.FromFloat(15f))
+			.WithProperty("cl2", PropertyValue.FromFloat(16f))
+			.WithProperty("he", PropertyValue.FromFloat(17f))
+			.WithProperty("gate_mode", PropertyValue.FromInt(0))
+			.WithProperty("gate_setpoint", PropertyValue.FromFloat(20f))
+			.WithProperty("icp_power", PropertyValue.FromFloat(100f))
+			.WithProperty("icp_match", PropertyValue.FromInt(MatchModeAuto))
+			.WithProperty("rie_power", PropertyValue.FromFloat(200f))
+			.WithProperty("rie_match", PropertyValue.FromInt(MatchModeAuto))
+			.WithProperty("step_duration", PropertyValue.FromFloat(30f))
+			.WithProperty("comment", PropertyValue.FromString("etch comment"));
+	}
+
+	private static async Task<RecipeMetadataRegistry> BuildRieRegistryAsync()
+	{
+		var path = ShippedConfigLocator.GetConfigDirectory("RIE");
+		var result = await ConfigFacade.LoadAndValidateAsync(path);
+
+		result.IsSuccess.Should().BeTrue(result.IsFailed
+			? string.Join("; ", result.Errors.Select(error => error.Message))
+			: string.Empty);
+
+		return new RecipeMetadataRegistry(result.Value);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/ColumnBuilderIdempotencyTests.cs
@@ -193,16 +193,17 @@ public sealed class ColumnBuilderIdempotencyTests : IAsyncLifetime
 	{
 		var action = _fixture.RecipeMetadataRegistry.GetAction(actionId).Value;
 		var step = new Step(actionId, ImmutableDictionary<PropertyId, PropertyValue>.Empty);
-		var inapplicableColumns = BuildInapplicableColumns(action);
+		var inapplicableColumns = BuildInapplicableColumns(action, step);
 		return new RecipeRowViewModel(1, step, action, _fixture.RecipeMetadataRegistry, inapplicableColumns);
 	}
 
-	private IReadOnlySet<string> BuildInapplicableColumns(ActionDefinition action)
+	private IReadOnlySet<string> BuildInapplicableColumns(ActionDefinition action, Step step)
 	{
+		var activeColumnKeys = ActiveColumnSetResolver.Resolve(action, step);
 		var inapplicable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		foreach (var column in _fixture.RecipeMetadataRegistry.GetAllColumns())
 		{
-			if (CellStateResolver.IsInapplicable(column, action))
+			if (CellStateResolver.IsInapplicable(column, activeColumnKeys))
 			{
 				inapplicable.Add(column.Key);
 			}

--- a/SemiStep/SemiStep.Tests/UI/GroupComboBoxRecyclingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/GroupComboBoxRecyclingTests.cs
@@ -305,16 +305,17 @@ public sealed class GroupComboBoxRecyclingTests : IAsyncLifetime
 	{
 		var action = _fixture.RecipeMetadataRegistry.GetAction(actionId).Value;
 		var step = new Step(actionId, ImmutableDictionary<PropertyId, PropertyValue>.Empty);
-		var inapplicableColumns = BuildInapplicableColumns(action);
+		var inapplicableColumns = BuildInapplicableColumns(action, step);
 		return new RecipeRowViewModel(1, step, action, _fixture.RecipeMetadataRegistry, inapplicableColumns);
 	}
 
-	private IReadOnlySet<string> BuildInapplicableColumns(ActionDefinition action)
+	private IReadOnlySet<string> BuildInapplicableColumns(ActionDefinition action, Step step)
 	{
+		var activeColumnKeys = ActiveColumnSetResolver.Resolve(action, step);
 		var inapplicable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		foreach (var column in _fixture.RecipeMetadataRegistry.GetAllColumns())
 		{
-			if (CellStateResolver.IsInapplicable(column, action))
+			if (CellStateResolver.IsInapplicable(column, activeColumnKeys))
 			{
 				inapplicable.Add(column.Key);
 			}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeRowSelectorEditTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeRowSelectorEditTests.cs
@@ -1,0 +1,201 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+using Avalonia.Data.Converters;
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using SemiStep.Core.Plc;
+using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Helpers;
+using SemiStep.Core.Recipes.Import;
+using SemiStep.Tests.Core.Helpers;
+
+using SemiStep.UI.Coordinator;
+using SemiStep.UI.MessageService;
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+/// <summary>
+/// Exercises the selector-edit recompute end to end on the nested-action config (action 300
+/// "Branching" with a <c>branch_sel</c> selector whose value 1 pulls in the <c>sub_value</c>
+/// column). Maps onto the RIE example in the plan: <c>branch_sel</c> ~ <c>icp_match</c>,
+/// value 0 "Auto" ~ Авто, value 1 "Manual" ~ Ручной, <c>sub_value</c> ~ <c>icp_load</c>.
+/// </summary>
+[Trait("Component", "UI")]
+[Trait("Area", "NestedActions")]
+[Trait("Category", "Integration")]
+public sealed class RecipeRowSelectorEditTests : IAsyncLifetime
+{
+	private const int BranchingActionId = 300;
+	private const string SelectorColumn = "branch_sel";
+	private const string SubColumn = "sub_value";
+	private const string NonSelectorColumn = "comment";
+	private const string AutoValue = "0";
+	private const string ManualValue = "1";
+	private const float SubDefaultFloat = 50f;
+
+	private IServiceProvider _services = null!;
+	private RecipeSession _session = null!;
+	private RecipeMetadataRegistry _registry = null!;
+	private MessagePanelViewModel _messagePanel = null!;
+	private RecipeCoordinator _coordinator = null!;
+	private RecipeGridViewModel _grid = null!;
+
+	public async ValueTask InitializeAsync()
+	{
+		var (services, session, _) = await CoreTestHelper.BuildAsync("Standalone/NestedActionsValid");
+		_services = services;
+		_session = session;
+		_registry = services.GetRequiredService<RecipeMetadataRegistry>();
+		_messagePanel = new MessagePanelViewModel();
+
+		_coordinator = new RecipeCoordinator(
+			_session,
+			services.GetRequiredService<PlcLifecycleManager>(),
+			services.GetRequiredService<CsvService>(),
+			services.GetRequiredService<ImportedRecipeValidator>(),
+			services.GetRequiredService<SemiStep.Core.Configuration.AppConfiguration>(),
+			_registry,
+			_messagePanel,
+			NullLogger<RecipeCoordinator>.Instance);
+		_coordinator.Initialize();
+
+		_grid = new RecipeGridViewModel(
+			_coordinator,
+			_registry,
+			_messagePanel,
+			NullLogger<RecipeGridViewModel>.Instance);
+		_coordinator.Mutated += _grid.OnMutation;
+		_grid.Initialize();
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_grid.Dispose();
+		_coordinator.Dispose();
+		_messagePanel.Dispose();
+		return ValueTask.CompletedTask;
+	}
+
+	private RecipeRowViewModel AppendBranchingRow()
+	{
+		_coordinator.AppendStep(BranchingActionId);
+		return _grid.RecipeRows.Single();
+	}
+
+	[AvaloniaFact]
+	public void InitialAutoSelection_SubColumnInapplicable()
+	{
+		var row = AppendBranchingRow();
+
+		row.InapplicableColumns.Should().Contain(SubColumn);
+		row.IsApplicable(SubColumn).Should().BeFalse();
+	}
+
+	[AvaloniaFact]
+	public void SwitchToManual_SeedsSubValueDefault_AndMakesItApplicable()
+	{
+		var row = AppendBranchingRow();
+
+		row.SetPropertyValue(SelectorColumn, ManualValue);
+
+		row.GetPropertyValue(SubColumn).Should().Be(SubDefaultFloat);
+		row.InapplicableColumns.Should().NotContain(SubColumn);
+		row.IsApplicable(SubColumn).Should().BeTrue();
+	}
+
+	[AvaloniaFact]
+	public void SwitchBackToAuto_DropsSubValue_AndGreysIt()
+	{
+		var row = AppendBranchingRow();
+		row.SetPropertyValue(SelectorColumn, ManualValue);
+		row.GetPropertyValue(SubColumn).Should().Be(SubDefaultFloat);
+
+		row.SetPropertyValue(SelectorColumn, AutoValue);
+
+		row.GetPropertyValue(SubColumn).Should().BeNull();
+		row.InapplicableColumns.Should().Contain(SubColumn);
+		row.IsApplicable(SubColumn).Should().BeFalse();
+	}
+
+	[AvaloniaFact]
+	public void SwitchToAutoThenUndo_RestoresManualSelectorAndDroppedValue_InOneStep()
+	{
+		var row = AppendBranchingRow();
+		row.SetPropertyValue(SelectorColumn, ManualValue);
+		row.SetPropertyValue(SubColumn, "73");
+		row.GetPropertyValue(SubColumn).Should().Be(73f);
+
+		// Switching back to Auto drops sub_value; a single Undo must restore BOTH the Manual
+		// selector value and the prior sub_value in one step (the batched-mutation undo unit).
+		row.SetPropertyValue(SelectorColumn, AutoValue);
+		row.GetPropertyValue(SubColumn).Should().BeNull();
+
+		_coordinator.Undo();
+
+		var restored = _grid.RecipeRows.Single();
+		restored.GetPropertyValue(SelectorColumn).Should().Be(1);
+		restored.GetPropertyValue(SubColumn).Should().Be(73f);
+	}
+
+	[AvaloniaFact]
+	public void OrdinaryEdit_DoesNotRecomputeApplicability_ReferenceUnchanged()
+	{
+		// An edit on a non-selector column must route through the plain PropertyUpdated path
+		// (UpdateStepProperty -> UpdateSingleRowInPlace -> UpdateStep) and must NOT trigger an
+		// applicability recompute: InapplicableColumns keeps the same instance and raises no
+		// PropertyChanged for itself.
+		var row = AppendBranchingRow();
+		var before = row.InapplicableColumns;
+		var changed = new List<string>();
+		row.PropertyChanged += (_, args) => changed.Add(args.PropertyName ?? string.Empty);
+
+		row.SetPropertyValue(NonSelectorColumn, "hello");
+
+		row.GetPropertyValue(NonSelectorColumn).Should().Be("hello");
+		row.InapplicableColumns.Should().BeSameAs(before);
+		changed.Should().NotContain(nameof(RecipeRowViewModel.InapplicableColumns));
+	}
+
+	[AvaloniaFact]
+	public void SelectorReassignment_FlipsInapplicableColumns_ReferenceChanges()
+	{
+		var row = AppendBranchingRow();
+		var changed = new List<string>();
+		row.PropertyChanged += (_, args) => changed.Add(args.PropertyName ?? string.Empty);
+		var before = row.InapplicableColumns;
+
+		row.SetPropertyValue(SelectorColumn, ManualValue);
+
+		changed.Should().Contain(nameof(RecipeRowViewModel.InapplicableColumns));
+		row.InapplicableColumns.Should().NotBeSameAs(before);
+	}
+
+	[AvaloniaFact]
+	public void InapplicableBinding_Converter_FlipsOnReassignment()
+	{
+		// The cell theme is driven by the OneWay InapplicableColumns binding. Reproduce the
+		// converter the binding uses and confirm it reports the new applicability after the
+		// row reassigns InapplicableColumns on the selector edit.
+		var row = AppendBranchingRow();
+		var converter = new FuncValueConverter<IReadOnlySet<string>?, bool>(
+			set => set is not null && set.Contains(SubColumn));
+
+		var inapplicableBefore = converter.Convert(row.InapplicableColumns, typeof(bool), null, CultureInfo.InvariantCulture);
+		inapplicableBefore.Should().Be(true);
+
+		row.SetPropertyValue(SelectorColumn, ManualValue);
+
+		var inapplicableAfter = converter.Convert(row.InapplicableColumns, typeof(bool), null, CultureInfo.InvariantCulture);
+		inapplicableAfter.Should().Be(false);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
@@ -42,16 +42,17 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		_session.AppendStep(actionId);
 		var step = _session.Current.Steps[0];
 		var action = _recipeMetadataRegistry.GetAction(step.ActionKey).Value;
-		var inapplicableColumns = BuildInapplicableColumns(action);
+		var inapplicableColumns = BuildInapplicableColumns(action, step);
 		return new RecipeRowViewModel(1, step, action, _recipeMetadataRegistry, inapplicableColumns);
 	}
 
-	private IReadOnlySet<string> BuildInapplicableColumns(ActionDefinition action)
+	private IReadOnlySet<string> BuildInapplicableColumns(ActionDefinition action, Step step)
 	{
+		var activeColumnKeys = ActiveColumnSetResolver.Resolve(action, step);
 		var inapplicable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		foreach (var column in _recipeMetadataRegistry.GetAllColumns())
 		{
-			if (CellStateResolver.IsInapplicable(column, action))
+			if (CellStateResolver.IsInapplicable(column, activeColumnKeys))
 			{
 				inapplicable.Add(column.Key);
 			}
@@ -272,6 +273,26 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 		var row = CreateRow(RecipeTestDriver.PauseActionId);
 
 		row.IsApplicable("action").Should().BeTrue();
+	}
+
+	[AvaloniaFact]
+	public void RecomputeInapplicableColumns_ReassignsNewInstance_AndRaisesPropertyChanged()
+	{
+		var row = CreateRow(RecipeTestDriver.WaitActionId);
+		var before = row.InapplicableColumns;
+		var raised = false;
+		row.PropertyChanged += (_, args) =>
+		{
+			if (args.PropertyName == nameof(RecipeRowViewModel.InapplicableColumns))
+			{
+				raised = true;
+			}
+		};
+
+		row.RecomputeInapplicableColumns();
+
+		raised.Should().BeTrue();
+		row.InapplicableColumns.Should().NotBeSameAs(before);
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDanglingTarget/actions/service.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDanglingTarget/actions/service.yaml
@@ -1,0 +1,22 @@
+# Invalid: a column 'targets' entry points at an undefined action id 9999
+
+10:
+  ui_name: "Wait"
+  deploy_duration: longlasting
+  columns:
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: comment
+      property_type_id: string
+
+300:
+  ui_name: "Branching"
+  deploy_duration: immediate
+  columns:
+    - key: branch_sel
+      group_name: match_mode
+      property_type_id: enum
+      targets: { 1: 9999 }
+    - key: comment
+      property_type_id: string

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDanglingTarget/columns/columns.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDanglingTarget/columns/columns.yaml
@@ -1,0 +1,56 @@
+# Minimal column definitions plus a selector and a subaction column for nested-action tests
+
+action:
+  column_type: action_combo_box
+  ui:
+    ui_name: "Action"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+step_duration:
+  column_type: property_field
+  ui:
+    ui_name: "Duration"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+task:
+  column_type: property_field
+  ui:
+    ui_name: "Task"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+comment:
+  column_type: text_field
+  ui:
+    ui_name: "Comment"
+  business_logic:
+    property_type_id: string
+    save_to_csv: true
+    read_only: false
+
+branch_sel:
+  column_type: property_field
+  ui:
+    ui_name: "Branch"
+  business_logic:
+    property_type_id: enum
+    group_name: match_mode
+    read_only: false
+    save_to_csv: true
+
+sub_value:
+  column_type: property_field
+  ui:
+    ui_name: "SubValue"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDanglingTarget/groups/match_mode.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDanglingTarget/groups/match_mode.yaml
@@ -1,0 +1,4 @@
+# Selector group for nested-action tests
+match_mode:
+  0: "Auto"
+  1: "Manual"

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDuplicateId/actions/service.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDuplicateId/actions/service.yaml
@@ -1,0 +1,32 @@
+# Invalid: subaction id 3001 is declared twice across action files (duplicate id)
+
+10:
+  ui_name: "Wait"
+  deploy_duration: longlasting
+  columns:
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: comment
+      property_type_id: string
+
+300:
+  ui_name: "Branching"
+  role: action
+  deploy_duration: immediate
+  columns:
+    - key: branch_sel
+      group_name: match_mode
+      property_type_id: enum
+      targets: { 1: 3001 }
+    - key: comment
+      property_type_id: string
+
+3001:
+  ui_name: "Manual branch"
+  role: subaction
+  deploy_duration: immediate
+  columns:
+    - key: sub_value
+      default_value: "50"
+      property_type_id: float

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDuplicateId/actions/service2.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDuplicateId/actions/service2.yaml
@@ -1,0 +1,10 @@
+# Duplicate declaration of subaction id 3001
+
+3001:
+  ui_name: "Manual branch duplicate"
+  role: subaction
+  deploy_duration: immediate
+  columns:
+    - key: sub_value
+      default_value: "75"
+      property_type_id: float

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDuplicateId/columns/columns.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDuplicateId/columns/columns.yaml
@@ -1,0 +1,56 @@
+# Minimal column definitions plus a selector and a subaction column for nested-action tests
+
+action:
+  column_type: action_combo_box
+  ui:
+    ui_name: "Action"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+step_duration:
+  column_type: property_field
+  ui:
+    ui_name: "Duration"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+task:
+  column_type: property_field
+  ui:
+    ui_name: "Task"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+comment:
+  column_type: text_field
+  ui:
+    ui_name: "Comment"
+  business_logic:
+    property_type_id: string
+    save_to_csv: true
+    read_only: false
+
+branch_sel:
+  column_type: property_field
+  ui:
+    ui_name: "Branch"
+  business_logic:
+    property_type_id: enum
+    group_name: match_mode
+    read_only: false
+    save_to_csv: true
+
+sub_value:
+  column_type: property_field
+  ui:
+    ui_name: "SubValue"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDuplicateId/groups/match_mode.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedDuplicateId/groups/match_mode.yaml
@@ -1,0 +1,4 @@
+# Selector group for nested-action tests
+match_mode:
+  0: "Auto"
+  1: "Manual"

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedOrphanSubaction/actions/service.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedOrphanSubaction/actions/service.yaml
@@ -1,0 +1,20 @@
+# Invalid: subaction id 3001 is declared but never referenced by any column 'targets'
+
+10:
+  ui_name: "Wait"
+  deploy_duration: longlasting
+  columns:
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: comment
+      property_type_id: string
+
+3001:
+  ui_name: "Orphan branch"
+  role: subaction
+  deploy_duration: immediate
+  columns:
+    - key: sub_value
+      default_value: "50"
+      property_type_id: float

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedOrphanSubaction/columns/columns.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedOrphanSubaction/columns/columns.yaml
@@ -1,0 +1,56 @@
+# Minimal column definitions plus a selector and a subaction column for nested-action tests
+
+action:
+  column_type: action_combo_box
+  ui:
+    ui_name: "Action"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+step_duration:
+  column_type: property_field
+  ui:
+    ui_name: "Duration"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+task:
+  column_type: property_field
+  ui:
+    ui_name: "Task"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+comment:
+  column_type: text_field
+  ui:
+    ui_name: "Comment"
+  business_logic:
+    property_type_id: string
+    save_to_csv: true
+    read_only: false
+
+branch_sel:
+  column_type: property_field
+  ui:
+    ui_name: "Branch"
+  business_logic:
+    property_type_id: enum
+    group_name: match_mode
+    read_only: false
+    save_to_csv: true
+
+sub_value:
+  column_type: property_field
+  ui:
+    ui_name: "SubValue"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedOrphanSubaction/groups/match_mode.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedOrphanSubaction/groups/match_mode.yaml
@@ -1,0 +1,4 @@
+# Selector group for nested-action tests
+match_mode:
+  0: "Auto"
+  1: "Manual"

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedSharedWithinRoot/actions/service.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedSharedWithinRoot/actions/service.yaml
@@ -1,0 +1,33 @@
+# Invalid: one selector maps two values (2 and 3) to the SAME subaction 3001, so its columns are
+# reachable within one root via two different selector conditions (OR-activation, unsupported).
+
+10:
+  ui_name: "Wait"
+  deploy_duration: longlasting
+  columns:
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: comment
+      property_type_id: string
+
+3001:
+  ui_name: "Shared branch"
+  role: subaction
+  deploy_duration: immediate
+  columns:
+    - key: sub_value
+      default_value: "50"
+      property_type_id: float
+
+300:
+  ui_name: "Branching"
+  role: action
+  deploy_duration: immediate
+  columns:
+    - key: branch_sel
+      group_name: match_mode
+      property_type_id: enum
+      targets: { 2: 3001, 3: 3001 }
+    - key: comment
+      property_type_id: string

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedSharedWithinRoot/columns/columns.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedSharedWithinRoot/columns/columns.yaml
@@ -1,0 +1,56 @@
+# Minimal column definitions plus a selector and a subaction column for nested-action tests
+
+action:
+  column_type: action_combo_box
+  ui:
+    ui_name: "Action"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+step_duration:
+  column_type: property_field
+  ui:
+    ui_name: "Duration"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+task:
+  column_type: property_field
+  ui:
+    ui_name: "Task"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+comment:
+  column_type: text_field
+  ui:
+    ui_name: "Comment"
+  business_logic:
+    property_type_id: string
+    save_to_csv: true
+    read_only: false
+
+branch_sel:
+  column_type: property_field
+  ui:
+    ui_name: "Branch"
+  business_logic:
+    property_type_id: enum
+    group_name: match_mode
+    read_only: false
+    save_to_csv: true
+
+sub_value:
+  column_type: property_field
+  ui:
+    ui_name: "SubValue"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedSharedWithinRoot/groups/match_mode.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedSharedWithinRoot/groups/match_mode.yaml
@@ -1,0 +1,4 @@
+# Selector group for nested-action tests
+match_mode:
+  0: "Auto"
+  1: "Manual"

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedTargetIsAction/actions/service.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedTargetIsAction/actions/service.yaml
@@ -1,0 +1,23 @@
+# Invalid: a column 'targets' entry points at action id 10, which is role 'action', not 'subaction'
+
+10:
+  ui_name: "Wait"
+  deploy_duration: longlasting
+  columns:
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: comment
+      property_type_id: string
+
+300:
+  ui_name: "Branching"
+  role: action
+  deploy_duration: immediate
+  columns:
+    - key: branch_sel
+      group_name: match_mode
+      property_type_id: enum
+      targets: { 1: 10 }
+    - key: comment
+      property_type_id: string

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedTargetIsAction/columns/columns.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedTargetIsAction/columns/columns.yaml
@@ -1,0 +1,56 @@
+# Minimal column definitions plus a selector and a subaction column for nested-action tests
+
+action:
+  column_type: action_combo_box
+  ui:
+    ui_name: "Action"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+step_duration:
+  column_type: property_field
+  ui:
+    ui_name: "Duration"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+task:
+  column_type: property_field
+  ui:
+    ui_name: "Task"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+comment:
+  column_type: text_field
+  ui:
+    ui_name: "Comment"
+  business_logic:
+    property_type_id: string
+    save_to_csv: true
+    read_only: false
+
+branch_sel:
+  column_type: property_field
+  ui:
+    ui_name: "Branch"
+  business_logic:
+    property_type_id: enum
+    group_name: match_mode
+    read_only: false
+    save_to_csv: true
+
+sub_value:
+  column_type: property_field
+  ui:
+    ui_name: "SubValue"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedTargetIsAction/groups/match_mode.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Invalid/NestedTargetIsAction/groups/match_mode.yaml
@@ -1,0 +1,4 @@
+# Selector group for nested-action tests
+match_mode:
+  0: "Auto"
+  1: "Manual"

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/actions/service.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/actions/service.yaml
@@ -1,0 +1,37 @@
+# Valid nested config: a root action targets a defined subaction; the subaction is referenced.
+
+# Wait by time
+10:
+  ui_name: "Wait"
+  deploy_duration: longlasting
+  columns:
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: comment
+      property_type_id: string
+
+# Root action with a selector that branches into a subaction
+300:
+  ui_name: "Branching"
+  role: action
+  deploy_duration: immediate
+  columns:
+    - key: branch_sel
+      group_name: match_mode
+      property_type_id: enum
+      targets: { 1: 3001 }
+    - key: comment
+      property_type_id: string
+
+# Subaction referenced by action 300
+3001:
+  ui_name: "Manual branch"
+  role: subaction
+  deploy_duration: immediate
+  columns:
+    - key: sub_value
+      default_value: "50"
+      property_type_id: float
+    - key: sub_nodefault
+      property_type_id: float

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/columns/columns.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/columns/columns.yaml
@@ -1,0 +1,65 @@
+# Minimal column definitions plus a selector and a subaction column for nested-action tests
+
+action:
+  column_type: action_combo_box
+  ui:
+    ui_name: "Action"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+step_duration:
+  column_type: property_field
+  ui:
+    ui_name: "Duration"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+task:
+  column_type: property_field
+  ui:
+    ui_name: "Task"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+comment:
+  column_type: text_field
+  ui:
+    ui_name: "Comment"
+  business_logic:
+    property_type_id: string
+    save_to_csv: true
+    read_only: false
+
+branch_sel:
+  column_type: property_field
+  ui:
+    ui_name: "Branch"
+  business_logic:
+    property_type_id: enum
+    group_name: match_mode
+    read_only: false
+    save_to_csv: true
+
+sub_value:
+  column_type: property_field
+  ui:
+    ui_name: "SubValue"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+sub_nodefault:
+  column_type: property_field
+  ui:
+    ui_name: "SubNoDefault"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/connection/connection.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/connection/connection.yaml
@@ -1,0 +1,49 @@
+connection_file_version: "1.0"
+
+# -- Connection info --
+ip: "192.168.0.150:102"
+connection_protocol: "1.0"
+plc_rack: 0
+plc_slot: 1
+
+# -- Protocol settings --
+max_retries_attempts: 3
+polling_interval_ms: 100
+writing_timeout_ms: 5000
+commit_timeout_ms: 5000
+keep_alive_interval_ms: 5000
+
+# -- Managing DB --
+managing_db_number: 2
+version_offset: 0
+committed_offset: 4
+recipe_lines_offset: 6
+managing_db_total_size: 10
+
+# -- Int DB --
+int_db_number: 3
+int_db_total_capacity_offset: 0
+int_db_current_size_offset: 4
+int_db_data_offset: 8
+
+# -- Float DB --
+float_db_number: 4
+float_db_total_capacity_offset: 0
+float_db_current_size_offset: 4
+float_db_data_offset: 8
+
+# -- String DB --
+string_db_number: 5
+string_db_total_capacity_offset: 0
+string_db_current_size_offset: 4
+string_db_data_offset: 8
+
+# -- Execution DB --
+execution_db_number: 6
+recipe_active_offset: 0
+actual_line_offset: 2
+step_current_time_offset: 6
+for_loop_count1_offset: 10
+for_loop_count2_offset: 14
+for_loop_count3_offset: 18
+execution_db_total_size: 22

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/groups/match_mode.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/groups/match_mode.yaml
@@ -1,0 +1,4 @@
+# Selector group for nested-action tests
+match_mode:
+  0: "Auto"
+  1: "Manual"

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/groups/placeholder.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/groups/placeholder.yaml
@@ -1,0 +1,3 @@
+# Placeholder group for testing
+placeholder:
+  0: "None"

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/properties/properties.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/properties/properties.yaml
@@ -1,0 +1,29 @@
+# Minimal property definitions for testing
+
+int:
+  system_type: int
+  format_kind: numeric
+  units: ""
+
+float:
+  system_type: float
+  format_kind: numeric
+  units: ""
+
+string:
+  system_type: string
+  format_kind: numeric
+  units: ""
+  max_length: 255
+
+enum:
+  system_type: int
+  format_kind: numeric
+  units: ""
+
+time:
+  system_type: float
+  format_kind: time_hms
+  units: "s"
+  min: 0
+  max: 86400

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/ui/grid_style.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Standalone/NestedActionsValid/ui/grid_style.yaml
@@ -1,0 +1,42 @@
+# Default grid style options for tests
+fonts:
+  header_size: 12
+  cell_size: 11
+
+layout:
+  row_height: 24
+
+colors:
+  cells:
+    readonly:
+      depth_0: "#D8D8D8"
+      depth_1: "#CCD5E0"
+      depth_2: "#B8C3D1"
+      depth_3: "#94A2B3"
+      depth_0_past: "#C8C8C8"
+      depth_1_past: "#BCC4CE"
+      depth_2_past: "#ACB7C2"
+      depth_3_past: "#8590A0"
+      selected: "#6B95C0"
+      foreground: "#606060"
+    disabled:
+      depth_0: "#E0E0E0"
+      depth_1: "#D5DEEA"
+      depth_2: "#C2CEDB"
+      depth_3: "#9DABBC"
+      depth_0_past: "#D0D0D0"
+      depth_1_past: "#C5CDD8"
+      depth_2_past: "#B5C0CC"
+      depth_3_past: "#909AAA"
+      selected: "#89B4D7"
+      foreground: "#808080"
+    execution:
+      depth_0: "#FFFFFF"
+      depth_1: "#E8F3FF"
+      depth_2: "#D0E7FF"
+      depth_3: "#A8D0FF"
+      depth_0_past: "#F0F0F0"
+      depth_1_past: "#DCE5EE"
+      depth_2_past: "#C4D2E0"
+      depth_3_past: "#9CB4CC"
+      current_step_marker: "#FF8800"

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -297,6 +297,18 @@ public sealed class RecipeCoordinator : IDisposable
 			new MutationSignal.PropertyUpdated(stepIndex));
 	}
 
+	public Result UpdateStepForSelectorChange(
+		int stepIndex,
+		string selectorKey,
+		string value,
+		IReadOnlyCollection<string> columnsToDrop,
+		IReadOnlyCollection<string> columnsToSeed)
+	{
+		return TrackVoid(
+			_session.UpdateStepForSelectorChange(stepIndex, selectorKey, value, columnsToDrop, columnsToSeed),
+			new MutationSignal.PropertyUpdated(stepIndex));
+	}
+
 	public Result Undo()
 	{
 		return TrackVoid(_session.Undo(), new MutationSignal.RecipeReplaced());

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Logging;
 using ReactiveUI;
 
 using SemiStep.Core.Recipes;
-using SemiStep.Core.Recipes.Helpers;
 
 using SemiStep.UI.Coordinator;
 using SemiStep.UI.MessageService;
@@ -203,6 +202,35 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 		{
 			_messagePanel.ReportFailure(result, $"Step {stepIndex + 1}");
 		}
+	}
+
+	private void OnSelectorValueChanged(RecipeRowViewModel row, SelectorEdit selectorEdit)
+	{
+		if (IsReadOnly)
+		{
+			return;
+		}
+
+		var stepIndex = RecipeRows.IndexOf(row);
+		if (stepIndex < 0)
+		{
+			return;
+		}
+
+		var result = _coordinator.UpdateStepForSelectorChange(
+			stepIndex,
+			selectorEdit.SelectorKey,
+			selectorEdit.Value,
+			selectorEdit.ColumnsToDrop,
+			selectorEdit.ColumnsToSeed);
+
+		if (result.IsFailed)
+		{
+			_messagePanel.ReportFailure(result, $"Step {stepIndex + 1}");
+			return;
+		}
+
+		row.RecomputeInapplicableColumns();
 	}
 
 	private void OnActionChanged(RecipeRowViewModel row, int newActionId)
@@ -454,14 +482,7 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 		ActionDefinition action,
 		int stepNumber)
 	{
-		var inapplicableColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		foreach (var column in RecipeMetadataRegistry.GetAllColumns())
-		{
-			if (CellStateResolver.IsInapplicable(column, action))
-			{
-				inapplicableColumns.Add(column.Key);
-			}
-		}
+		var inapplicableColumns = RecipeRowViewModel.BuildInapplicableColumns(action, step, RecipeMetadataRegistry);
 
 		var row = new RecipeRowViewModel(
 			stepNumber,
@@ -472,6 +493,7 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 
 		row.PropertyValueChanged += (columnKey, value) => OnCellValueChanged(row, columnKey, value);
 		row.ActionChanged += actionId => OnActionChanged(row, actionId);
+		row.SelectorValueChanged += selectorEdit => OnSelectorValueChanged(row, selectorEdit);
 
 		return row;
 	}

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
@@ -3,6 +3,7 @@
 using ReactiveUI;
 
 using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Helpers;
 
 namespace SemiStep.UI.RecipeGrid;
 
@@ -75,7 +76,11 @@ public sealed class RecipeRowViewModel(
 	// but using `>=` guards against future UI cap drift so deeper nestings still render.
 	public bool IsForDepth3 => ForDepth >= 3;
 
-	public IReadOnlySet<string> InapplicableColumns { get; } = inapplicableColumns;
+	public IReadOnlySet<string> InapplicableColumns
+	{
+		get;
+		private set => this.RaiseAndSetIfChanged(ref field, value);
+	} = inapplicableColumns;
 
 	public IReadOnlyDictionary<string, string?> ColumnUnits => _columnMetadata.Units;
 
@@ -91,11 +96,13 @@ public sealed class RecipeRowViewModel(
 
 	public event Action<string, string?>? PropertyValueChanged;
 	public event Action<int>? ActionChanged;
+	public event Action<SelectorEdit>? SelectorValueChanged;
 
 	public void Dispose()
 	{
 		PropertyValueChanged = null;
 		ActionChanged = null;
+		SelectorValueChanged = null;
 	}
 
 	public void UpdateStep(Step newStep)
@@ -164,7 +171,115 @@ public sealed class RecipeRowViewModel(
 			return;
 		}
 
+		if (TryBuildSelectorEdit(columnKey, value, out var selectorEdit))
+		{
+			SelectorValueChanged?.Invoke(selectorEdit);
+			return;
+		}
+
 		PropertyValueChanged?.Invoke(columnKey, value);
+	}
+
+	/// <summary>
+	/// Recomputes <see cref="InapplicableColumns"/> from the row's current step and assigns a NEW
+	/// set instance. The OneWay cell binding only re-fires on a PropertyChanged that also carries a
+	/// reference change, so the value is always replaced rather than mutated in place.
+	/// </summary>
+	public void RecomputeInapplicableColumns()
+	{
+		InapplicableColumns = BuildInapplicableColumns(action, _step, recipeMetadataRegistry);
+	}
+
+	/// <summary>
+	/// Detects a selector-column edit and computes the columns the new selection deactivates (drop)
+	/// and activates (seed with their default values). A column is a selector when some union column
+	/// carries an <see cref="ActivationCondition"/> keyed on it (the resolver strips per-column
+	/// <c>Targets</c> from the resolved action and records the dependency as activation conditions
+	/// instead). Returns false for ordinary edits, non-selector columns, or values that do not parse
+	/// to a selector id.
+	/// </summary>
+	private bool TryBuildSelectorEdit(string columnKey, string? value, out SelectorEdit selectorEdit)
+	{
+		selectorEdit = default!;
+
+		if (!IsSelectorColumn(columnKey))
+		{
+			return false;
+		}
+
+		if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var selectorId))
+		{
+			return false;
+		}
+
+		var oldActive = ActiveColumnSetResolver.Resolve(action, _step);
+		var candidateStep = _step.WithProperty(columnKey, PropertyValue.FromInt(selectorId));
+		var newActive = ActiveColumnSetResolver.Resolve(action, candidateStep);
+
+		var columnsToDrop = new List<string>();
+		var columnsToSeed = new List<string>();
+
+		foreach (var property in action.Properties)
+		{
+			var key = property.Key;
+			var wasActive = oldActive.Contains(key);
+			var nowActive = newActive.Contains(key);
+
+			if (wasActive && !nowActive)
+			{
+				columnsToDrop.Add(key);
+			}
+			else if (!wasActive && nowActive)
+			{
+				columnsToSeed.Add(key);
+			}
+		}
+
+		selectorEdit = new SelectorEdit(
+			columnKey,
+			selectorId.ToString(CultureInfo.InvariantCulture),
+			columnsToDrop,
+			columnsToSeed);
+		return true;
+	}
+
+	private bool IsSelectorColumn(string columnKey)
+	{
+		foreach (var property in action.Properties)
+		{
+			if (property.Activation is null)
+			{
+				continue;
+			}
+
+			foreach (var condition in property.Activation)
+			{
+				if (string.Equals(condition.SelectorKey, columnKey, StringComparison.OrdinalIgnoreCase))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	public static IReadOnlySet<string> BuildInapplicableColumns(
+		ActionDefinition action,
+		Step step,
+		RecipeMetadataRegistry recipeMetadataRegistry)
+	{
+		var activeColumnKeys = ActiveColumnSetResolver.Resolve(action, step);
+		var inapplicable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var column in recipeMetadataRegistry.GetAllColumns())
+		{
+			if (CellStateResolver.IsInapplicable(column, activeColumnKeys))
+			{
+				inapplicable.Add(column.Key);
+			}
+		}
+
+		return inapplicable;
 	}
 
 	private static PropertyTypeDefinition? ResolvePropertyType(

--- a/SemiStep/SemiStep.UI/RecipeGrid/SelectorEdit.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/SelectorEdit.cs
@@ -1,0 +1,14 @@
+﻿namespace SemiStep.UI.RecipeGrid;
+
+/// <summary>
+/// Describes a selector-column edit emitted by <see cref="RecipeRowViewModel"/>: the selector value
+/// change together with the columns its new selection deactivates (<see cref="ColumnsToDrop"/>) and
+/// activates (<see cref="ColumnsToSeed"/>, the keys to seed; the core mutation resolves each column's
+/// default value). The grid view-model routes this to the batched core mutation so the whole
+/// composition change is one undo unit.
+/// </summary>
+public sealed record SelectorEdit(
+	string SelectorKey,
+	string Value,
+	IReadOnlyCollection<string> ColumnsToDrop,
+	IReadOnlyCollection<string> ColumnsToSeed);


### PR DESCRIPTION
Closes #71.

Generalizes recipe-row column composition from depth-1 to depth-N. A selector column carries `targets: {selectorValue -> actionId}`; the referenced action ("subaction") contributes more columns and may carry a further selector, recursively. Inactive columns reuse the existing greyed "inapplicable" state.

## Model
- **Reference-based subactions**, sharing across roots allowed (reference DAG). Explicit `role: action | subaction` (default `action`, so the 69 existing actions need no edit). Dropdown is built from `role: action` roots only; subactions never enter the registry's runtime collections.
- **Load-time resolver** (`ActionTreeResolver`) walks `targets` per root and produces: (1) the column **union** materialized into `ActionDefinition.Properties` in deterministic order (declaration order, depth-first splice at the selector site) — so PLC write / CSV / clipboard / import keep iterating `Properties` and no subaction-column value is silently dropped; (2) per-column `ActivationCondition` feeding dynamic applicability.
- **Config-load validation**: every target resolves; targets point only at subactions; every subaction is referenced; no cycles; a subaction reachable from two branches of one root is rejected.
- **Runtime**: `ActiveColumnSetResolver` computes the active set from activation conditions + step values; `CellStateResolver` consults it. `StepInitializer` seeds only active columns to a fixpoint (depth-N), so inactive slots serialize as 0. A selector edit goes through one batched `RecipeSession` mutation (set + drop inactive + seed activated) as a single undo unit. `FormulaEvaluator` skips recalc when a referenced variable is inactive instead of throwing.
- **Core untouched**: flat `Step`, one global flat grid column set, no PLC write-path change.

## Config change
RIE `Травление`: `icp_match` / `rie_match` gain `Авто` / `Ручной` capacitor branches. PLC byte order preserved (regression-tested: a fixed step serializes to the identical slot layout).

## Tests
Green per component (full single-process run hits a known pre-existing Avalonia `RxApp`-once-per-process harness limit, so the suite is run split by `Component`): Core 235, Config 208, S7 103, Domain 34, Csv 17, UI 236, `Area=NestedActions` 61. Build clean, `dotnet format` clean.

Architecture note: `Docs/architecture/nested-actions.md`. Implementation plan: `Docs/plans/completed/20260623-nested-actions-depth-n.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)