### PR TITLE
Recipe-grid column sizing: min-content, font-relative chrome, clip-proof combos (#66)

### DIFF
--- a/Docs/architecture/recipe-grid-column-sizing.md
+++ b/Docs/architecture/recipe-grid-column-sizing.md
@@ -9,7 +9,8 @@ scroll in and out. Instead `ColumnWidthCalculator` computes a stable pixel width
 from the configured metadata, and `ColumnBuilder` renders the matching header.
 
 The whole model is **min-content**: a column is as wide as the widest thing that must fit, never
-wider. Three independent floors are combined with `max`, then a single chrome allowance is added.
+wider. Three independent floors are combined with `max`, then a font-proportional chrome allowance
+is added (a larger combo allowance for combo columns).
 
 ## The three floors (`ColumnWidthCalculator.CalculateWidth`)
 
@@ -20,8 +21,11 @@ wider. Three independent floors are combined with `max`, then a single chrome al
    mid-glyph. So the floor is the width of the longest word in the header, measured in the header
    font (bold, `HeaderFontSize`). A column narrower than this would force an ugly mid-word break;
    wider lets the header wrap cleanly on spaces to at most two lines.
-3. **Absolute minimum** — `MinColumnWidth` (72px). Also used by `ColumnBuilder` as the numbering
-   column's `MinWidth` and as the Star comment column's absorb-floor, so it must not be lowered.
+3. **Absolute minimum** — `MinColumnWidth` = `ceil(CellFontSize × MinColumnWidthEms)`,
+   `MinColumnWidthEms = 6.0` (72 at the default 12px cell font). Exposed as a public instance
+   property; `ColumnBuilder` reads it as the numbering column's `MinWidth` and as the Star comment
+   column's absorb-floor, so it must not be lowered. The `6.0` is a calibration chosen to reproduce
+   72 at the default font, not a physically derived em count.
 
 `Star`/`TextField` columns bypass all of this (`DataGridLength.Star`); they absorb the leftover
 width and are never floored by header words.
@@ -32,6 +36,15 @@ The header floor is only correct if the header is **drawn** exactly as it was **
 `ColumnBuilder.BuildWrappingHeaderTemplate` renders the header `TextBlock` bold at
 `HeaderFontSize` — the same font and weight `LongestHeaderWordFloor` measures with. Change one
 side and the other must follow, or headers wrap differently than the width budgeted for.
+
+The same coupling applies to cell content. `CalculateWidth` measures every representative at
+`CellFontSize`, so every cell control must **render** at `CellFontSize` too. Avalonia does not
+inherit it for us: a `DataGrid.FontSize` does not reach the Fluent ComboBox selection-box
+`ContentControl`, which otherwise shows the theme default (~14) and clips the longest action name
+behind the chevron. So each cell control sets `FontSize = CellFontSize` explicitly, mirroring the
+header: `ComboBoxCellFactory` on the ComboBox, `TextCellFactory` on the display/editing `TextBlock`
+and `TextBox`, and `ColumnBuilder` on the numbering `DataGridTextColumn`. This is also where the
+`CellFontSize` config value becomes the real rendered cell font, not just a measurement input.
 
 Two Avalonia-specific traps make the header wrap work:
 
@@ -70,15 +83,70 @@ For each type, `PropertyRepresentatives` yields:
   `pressure_pa` (−200000…200000) renders "−200000 Па", wider than "200000 Па". Time formats via
   HMS, so `time` (max 86400) renders "24:00:00 с".
 
-## CellChromeAllowance
+## Chrome allowance (font-proportional)
 
 `MeasureText` sizes glyphs only — it knows nothing of cell padding, grid lines, or the gap that
-keeps text off the border. `CellChromeAllowance` (26px) is the single additive budget covering all
-of that, added once to both the content floor and the header-word floor.
+keeps text off the border. The chrome allowance covers all of that and is **font-proportional**, so
+it tracks a `cell_size`/`header_size` change in `grid_style.yaml` instead of staying a fixed pixel
+budget tuned for one font:
 
-It is sized for the tightest case: a column whose representative equals the rendered cell exactly,
-which is the HH:MM:SS time columns ("00:00:00 с"). Other columns get visual slack for free because
-their representative is a range extreme wider than typical cells; the time columns do not, so they
-set the floor for the allowance. The cell text is centered with 4px side padding, so the on-screen
-reserve per side is roughly `(allowance − 8) / 2`. The same allowance must also clear the header
-padding (6px per side); 26 covers both consumers, so do not lower it below the header-padding need.
+- **Content budget** (text/property/time): `ceil(CellFontSize × ChromeFontMultiple)`.
+- **Header-word-floor budget**: `ceil(HeaderFontSize × ChromeFontMultiple)`.
+- `ChromeFontMultiple = 2.0` — a calibration, ≈ the prior fixed 26px at the default 12px cell font,
+  now proportional. The same multiple is added once to both the content floor and the header-word
+  floor.
+
+The content budget is sized for the tightest case: a column whose representative equals the rendered
+cell exactly, which is the HH:MM:SS time columns ("00:00:00 с"). Other columns get visual slack for
+free because their representative is a range extreme wider than typical cells; the time columns do
+not, so they set the floor for the multiple. The header budget must also clear the header padding
+(6px per side); the multiple covers both consumers, so do not lower it.
+
+### Combo columns add a fixed chevron budget
+
+Combo columns (action + group) add `ComboBoxChromeWidth = 38` as the chrome term instead of the
+content chrome (`maxContentWidth` is still added). This is
+a fixed theme constant, **not** font-scaled, because it tracks the Avalonia Fluent ComboBox template
+(`Avalonia.Themes.Fluent/Controls/ComboBox.xaml`): a `ColumnDefinitions="*,32"` grid reserves a 32
+DIP chevron column, plus the in-grid ComboBox left padding trimmed to 6 (32 + 6 = 38). The 32 is a
+template literal, not a themeable resource, so it does not co-scale with the font; budgeting
+`text + 38` keeps the text column ≥ `text + 6` at any font, which clears the chevron without
+re-templating. The `DataGrid ComboBox` style in `DataGridStyles.axaml` trims the in-grid ComboBox
+left padding to 6 so the rendered inset matches this budget and combo text aligns with text-cell
+content.
+
+### Scaling robustness
+
+- **DPI / display scaling** is handled by Avalonia's device-independent-pixel model: text
+  measurement and the chrome are both DIP and co-scale, so monitor DPI does not break the reserve.
+- **Font-size changes** (`cell_size`/`header_size`) are now tracked too, because the content and
+  header budgets are font-proportional. The combo chevron stays fixed by design (it is a template
+  literal).
+
+### Known inconsistency: content-cell padding is hardcoded
+
+`TextCellFactory` renders content cells with a hardcoded `Thickness(4, 2)` and does **not** read
+`gridStyle.CellPaddingLeft/Right`, so config cell padding does not flow into content-cell layout.
+That is why the chrome is expressed as a font multiple (covering the rendered padding + reserve
+together) rather than as `configPadding + reserve` — the latter would be a false story. The header
+path is consistent (header style padding `6,3` is both measured and rendered).
+
+### "Fits 1920" is a per-config property
+
+The sizing model does not guarantee a config fits 1920 — that depends on the config. The densest
+shipped config (RIE, numbering + 20 non-Star fixed columns) does fit at the default fonts: its
+fixed columns sum to under 1920, so the Star comment column still absorbs the remainder and there
+is no horizontal scroll (verified by rendering RIE through the screenshot harness). A wider config,
+a larger `cell_size`/`header_size`, or simply a smaller window could still make the column sum
+exceed the viewport. "Fits 1920" is therefore a property of each config, not a guarantee of the
+sizing math.
+
+## Narrow viewport scrolls, never clips
+
+When the viewport is narrower than the column sum, the Avalonia `DataGrid` shrinks every column
+toward its `MinWidth` rather than scrolling — and at the default `MinWidth` (the small absolute
+floor) the action ComboBox's selected text gets clipped behind its chevron. To prevent that,
+`ColumnBuilder` pins each absolute column's `MinWidth` to its **own calculated width**
+(`width.IsAbsolute ? width.Value : MinColumnWidth`). A column can then never shrink below the width
+its content needs, so a too-narrow window scrolls horizontally and the content stays whole. Only
+Star columns keep the small floor, because they are meant to absorb or yield remainder.

--- a/Docs/architecture/recipe-grid-column-sizing.md
+++ b/Docs/architecture/recipe-grid-column-sizing.md
@@ -1,0 +1,84 @@
+# Recipe Grid Column Sizing (issue #66)
+
+## Overview
+
+The recipe `DataGrid` must fit a FullHD (1920px) screen without horizontal scroll, keep headers
+readable (bold, black, wrapping to two lines when long), and size each column to its real content.
+Avalonia's built-in `Auto` sizing measures only the live cells on screen, so it jitters as rows
+scroll in and out. Instead `ColumnWidthCalculator` computes a stable pixel width per column once,
+from the configured metadata, and `ColumnBuilder` renders the matching header.
+
+The whole model is **min-content**: a column is as wide as the widest thing that must fit, never
+wider. Three independent floors are combined with `max`, then a single chrome allowance is added.
+
+## The three floors (`ColumnWidthCalculator.CalculateWidth`)
+
+1. **Content floor** — the widest representative cell value for the column (see per-column-type
+   sections below), measured in the cell font at normal weight.
+2. **Longest-header-word floor** (`LongestHeaderWordFloor`) — the CSS `min-content` principle: a
+   wrapping text box is only as narrow as its longest single word, because a word never breaks
+   mid-glyph. So the floor is the width of the longest word in the header, measured in the header
+   font (bold, `HeaderFontSize`). A column narrower than this would force an ugly mid-word break;
+   wider lets the header wrap cleanly on spaces to at most two lines.
+3. **Absolute minimum** — `MinColumnWidth` (72px). Also used by `ColumnBuilder` as the numbering
+   column's `MinWidth` and as the Star comment column's absorb-floor, so it must not be lowered.
+
+`Star`/`TextField` columns bypass all of this (`DataGridLength.Star`); they absorb the leftover
+width and are never floored by header words.
+
+## Render == measure coupling
+
+The header floor is only correct if the header is **drawn** exactly as it was **measured**.
+`ColumnBuilder.BuildWrappingHeaderTemplate` renders the header `TextBlock` bold at
+`HeaderFontSize` — the same font and weight `LongestHeaderWordFloor` measures with. Change one
+side and the other must follow, or headers wrap differently than the width budgeted for.
+
+Two Avalonia-specific traps make the header wrap work:
+
+- The wrapping template is assigned as the column's `HeaderTemplate`, **not** as a
+  `ContentTemplate` setter on the `DataGridColumnHeader` style. The Fluent header binds its
+  `ContentTemplate` from `DataGridColumn.HeaderTemplate`, so a style setter is silently overridden
+  and the header would not wrap.
+- `DataGridColumnHeader` must keep `HorizontalContentAlignment="Stretch"`
+  (`DataGridStyles.axaml`). The Fluent template sizes the header content panel by this alignment;
+  anything other than `Stretch` starves the wrapping `TextBlock` of width, so it never wraps.
+- The Fluent theme reserves `DataGridSortIconMinWidth` (default 32px) for a sort glyph on every
+  header, even when sorting is disabled. Sorting is off on every column here, so `ColorPalette.axaml`
+  overrides that resource to `0`; otherwise the reserved glyph column just crowds the header text.
+
+## PropertyField representative widths
+
+A single visual property column does not map to a single property type. Each `ActionDefinition`
+binds its own `ActionPropertyDefinition` (with its own `PropertyTypeId`) to a column key, so the
+same column hosts cells of different types depending on the row's action — and the units live on
+that per-action type, not on the column. Example (MBE): the `task` column's own
+`property_type_id` is `float` (no units), but actions bind it to `arsenic_source_flow` ("см³/мин"),
+`chamber_temp` ("°C"), `temp`, `percent` ("%"), and more.
+
+So `CalculatePropertyFieldWidth` collects the representatives of **every** property type any action
+binds to the column key, unioned with the column's own default type, and feeds them all to
+`CalculateWidth` (which takes the widest). This mirrors `CollectGroupDisplayStrings`, which already
+walks all actions for a column key. Measuring only the column default (the prior behaviour) ignored
+the units entirely and truncated unit-bearing values like "10 см³/мин".
+
+For each type, `PropertyRepresentatives` yields:
+
+- string types → a capped `'0'` sample (`MaxStringSampleLength` = 12). Production string max_length
+  is 64/255; sampling uncapped would let one text column dominate the FullHD budget.
+- numeric/time types → **both** `Max` and `Min`, each formatted with the type's units. Both extents
+  matter because for a symmetric range the negative `Min` is wider than `Max` by the minus sign:
+  `pressure_pa` (−200000…200000) renders "−200000 Па", wider than "200000 Па". Time formats via
+  HMS, so `time` (max 86400) renders "24:00:00 с".
+
+## CellChromeAllowance
+
+`MeasureText` sizes glyphs only — it knows nothing of cell padding, grid lines, or the gap that
+keeps text off the border. `CellChromeAllowance` (26px) is the single additive budget covering all
+of that, added once to both the content floor and the header-word floor.
+
+It is sized for the tightest case: a column whose representative equals the rendered cell exactly,
+which is the HH:MM:SS time columns ("00:00:00 с"). Other columns get visual slack for free because
+their representative is a range extreme wider than typical cells; the time columns do not, so they
+set the floor for the allowance. The cell text is centered with 4px side padding, so the on-screen
+reserve per side is roughly `(allowance − 8) / 2`. The same allowance must also clear the header
+padding (6px per side); 26 covers both consumers, so do not lower it below the header-padding need.

--- a/Docs/plans/completed/20260624-column-headers.md
+++ b/Docs/plans/completed/20260624-column-headers.md
@@ -1,0 +1,176 @@
+# Column headers: fit FullHD, black bold, wrap long headers to two lines (issue #66)
+
+## Overview
+
+Covers feedback points 5/6/7, all of which touch column-header rendering and column-width budgeting:
+
+- **Point 5 (fit FullHD):** fixed-pixel columns currently sum beyond 1920px on a plasma (RIE) config. Width
+  is `max(header, content) * 1.4 + 32px`, where the 32px is reserved for a Fluent sort icon even though
+  sorting is disabled everywhere (`CanUserSort = false`), and the 1.4 buffer adds 40% slack per column.
+- **Point 6 (black bold headers):** headers are plain strings with the default theme weight/color.
+- **Point 7 (wrap long headers):** headers are single-line; long labels ("Шибер задание") inflate their
+  column because the header drives `max(header, content)`.
+
+Approach (from the issue): **content drives width, header adapts by wrapping.** Size each column from its
+content (combobox items / representative value), drop the sort-icon compensation, lower the buffer, add a
+per-column `MinWidth` floor, and render the header as a bold black `TextBlock` that wraps to at most two
+lines (ellipsis fallback). "Too long" is decided by the layout engine — no manual pixel/char threshold.
+
+## Context (from discovery)
+
+- `SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs` — `CalculateColumnWidth` dispatches by column
+  type; `CalculateWidth(header, content)` does `max(header, content) * BufferMultiplier`; `BufferMultiplier = 1.4`
+  (line 16); `CompensateThemeSortIconAndPaddingOffset` adds `FluentThemeSortIconMinWidth = 32` (line 111);
+  `MeasureText` uses `FormattedText`. PropertyField columns currently call `CalculateHeaderBasedWidth` (header
+  only, empty content).
+- `SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs` — builds columns; sets `Header = "No"` ONLY for the
+  numbering column (which is `DataGridLength.Auto`, bypassing the calculator); `CanUserSort = false`; sets
+  `column.Width` from the calculator. No `MinWidth` set today. `column.CellTheme = InapplicableCellTheme.Create(...)`.
+- `SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs` (lines 18, 33) and
+  `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs` (lines 19, 32) — these are where the DATA-column
+  headers are set as `Header = columnDef.UiName` (plain string). With the ContentTemplate approach these stay
+  unchanged (the global header style restyles the string content).
+- `SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml` — no `DataGridColumnHeader` style today. The codebase
+  already relies on `TextElement.Foreground` inheritance in cell styles (e.g. lines 43, 48), so the header
+  style must own `Foreground`/`FontWeight` to avoid theme inheritance recoloring the header text.
+- `SemiStep/SemiStep.Core/Recipes/PropertyDefinition.cs` — `PropertyTypeDefinition(Id, SystemType, FormatKind,
+  Units?, Min?, Max?, MaxLength?)`. The representative value for a PropertyField comes from here.
+- `SemiStep/SemiStep.Core/Recipes/GridColumnDefinition.cs` — `(Key, ColumnType, UiName, PropertyTypeId, ReadOnly, SaveToCsv)`.
+- `SemiStep/SemiStep.UI/RecipeGrid/TimeFormatHelper.cs` / `PropertyTimeMultiConverter` — existing value
+  formatting (for building a representative formatted value).
+- `SemiStep/SemiStep.Tests/UI/RecipeGridStringMaxLengthTests.cs` and other UI tests use `CoreTestHelper.BuildAsync`.
+
+### Confirmed decisions
+
+- **PropertyField sizing:** representative value = the property's `Max` formatted through the SAME path the
+  cells use (`TimeFormatHelper.FormatValue(rawMax, formatKind, units)`), so width matches render. Fallbacks:
+  if `GetProperty` fails or `Max` is null (both common — `GetProperty` returns `Result<>`, `Max` is `double?`),
+  fall back to the `MinColumnWidth` floor; for string-typed properties use a `MaxLength`-char sample.
+- **Header rendering owner = a single `DataGridColumnHeader` style with a `ContentTemplate`** (idiomatic
+  Avalonia 12), NOT a hand-built `TextBlock` per column. The header `Content` stays the plain `UiName` string
+  set by the cell factories; the style's `ContentTemplate` renders it as a wrapping bold-black `TextBlock`.
+  This avoids touching the four factory header sites and avoids two styling owners fighting over
+  `FontWeight`/`Foreground`.
+
+### Patterns observed
+
+- C# UTF-8 BOM, tabs, var, file-scoped namespaces; comments non-obvious-only.
+- The width calculator is a plain unit-testable class (registry + GridStyleOptions injected) — point-5 math
+  is testable; the actual 1920 fit and visual wrapping/alignment are manual smoke.
+
+## Development Approach
+
+- Regular (code first, then tests). Visual tuning (exact buffer, MinWidth floor) done by eye during
+  implementation per the issue; the constants are named so they are easy to tune.
+- One logical change per task; UI layer only (plus reading Core metadata).
+- After each task: `dotnet build SemiStep/SemiStep.UI/SemiStep.UI.csproj` and the relevant test slice.
+
+## Testing Strategy
+
+- **Unit (ColumnWidthCalculator):** the 32px sort-icon offset is gone; the buffer is the new value; a long
+  header no longer inflates a column past its content + floor; the `MinWidth` floor applies to a tiny-content
+  column; PropertyField sizes from the property `Max`+units representative value.
+- **Manual smoke:** the RIE (plasma) config fits within 1920px with no horizontal scrollbar; long headers
+  wrap to two lines, bold/black; single-line headers align acceptably next to two-line ones; no header clipped.
+
+## Solution Overview
+
+`ColumnWidthCalculator` stops adding the header into the width `max` and stops reserving the sort-icon width;
+it sizes purely from content (combobox items / time sample / PropertyField representative value), times a
+smaller buffer, floored by a `MinWidth` constant. `ColumnBuilder` sets `column.MinWidth` on every column.
+A single `DataGridColumnHeader` style in `DataGridStyles.axaml` owns header typography: a `ContentTemplate`
+renders the string `Content` as a bold-black wrapping `TextBlock` (MaxLines=2, ellipsis), with auto header-row
+height and centered content so two-line headers are not clipped. The cell factories keep setting the header
+string — no per-column header object.
+
+## Technical Details
+
+- `ColumnWidthCalculator`:
+  - Remove `CompensateThemeSortIconAndPaddingOffset` / `FluentThemeSortIconMinWidth`.
+  - `BufferMultiplier`: 1.4 → `1.15` (named const, visual-tune).
+  - `MinColumnWidth` const (e.g. `72`, visual-tune) returned as a floor: `Math.Max(contentWidth * buffer, MinColumnWidth)`.
+    The floor is also the readability guard for headers (a header wider than its content wraps to two lines and,
+    for a rare no-break single word, ellipsis-trims; the floor keeps that legible — tune by eye).
+  - `CalculateWidth` sizes from content only (header excluded from the `max`). For columns with no natural
+    content (the old `CalculateHeaderBasedWidth`), return the floor.
+  - New `CalculatePropertyFieldWidth(columnDef)`: `recipeMetadataRegistry.GetProperty(columnDef.PropertyTypeId)`
+    returns `Result<>` — on failure, return the floor. On success: for string `SystemType`, representative =
+    a `MaxLength`-char sample; for numeric, if `Max` is null return the floor, else representative =
+    `TimeFormatHelper.FormatValue(Max formatted invariantly, FormatKind, Units)` (the SAME formatter the cells
+    use, so width matches the rendered value). Route `ColumnTypes.PropertyField` to it (note: `step_start_time`
+    stays on `CalculateTimeColumnWidth` — do not re-route it).
+- `ColumnBuilder`:
+  - Set `column.MinWidth = ColumnWidthCalculator.MinColumnWidth` on every column (expose the floor as a public
+    const). Harmless on the Auto-width numbering column; that column bypasses the calculator so it is not part
+    of the 1920 budget.
+  - No header change here — header typography is the `DataGridColumnHeader` style's job.
+- `DataGridStyles.axaml`: add a `DataGridColumnHeader` style:
+  - `ContentTemplate` = `<DataTemplate><TextBlock Text="{Binding}" TextWrapping="Wrap" MaxLines="2"
+    TextTrimming="CharacterEllipsis" TextAlignment="Center"/></DataTemplate>` (Content is the header string).
+  - `FontWeight="Bold"`, `Foreground="Black"` on the header (own them so `TextElement` inheritance does not
+    recolor), `HorizontalContentAlignment="Center"`, `VerticalContentAlignment="Center"`, `Height="Auto"` /
+    no fixed height + sensible `Padding` so a two-line header is not clipped.
+  - Match the file's existing banner house-style for the comment.
+
+## What Goes Where
+
+- **Implementation Steps:** width budget + PropertyField representative, header TextBlock + MinWidth, header
+  style, verification.
+- **Post-Completion:** manual visual tuning of buffer/MinWidth and the 1920 fit on the RIE config; the #74
+  theme pass may revisit header typography.
+
+## Implementation Steps
+
+### Task 1: Content-driven width budget in ColumnWidthCalculator
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs`
+- Create: `SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs`
+
+- [x] Remove the 32px sort-icon compensation (`CompensateThemeSortIconAndPaddingOffset` + `FluentThemeSortIconMinWidth`); sorting is disabled.
+- [x] Lower `BufferMultiplier` to `1.15` (named const, visual-tune comment).
+- [x] Add a PUBLIC `MinColumnWidth` const (e.g. 72) and floor every computed width: `Math.Max(content*buffer, MinColumnWidth)`.
+- [x] Make `CalculateWidth` size from CONTENT only — exclude the header from the `max` so long headers no longer inflate columns. Columns with no natural content return the floor.
+- [x] Add `CalculatePropertyFieldWidth`: `GetProperty(columnDef.PropertyTypeId)` is `Result<>` → on failure return the floor. On success: string `SystemType` → `MaxLength`-char sample; numeric → null `Max` returns the floor, else representative = `Max` routed through `TimeFormatHelper.FormatValue(formatted-invariant Max, FormatKind, Units)` (same formatter the cells use). Route `ColumnTypes.PropertyField` to it; leave `step_start_time` on `CalculateTimeColumnWidth`.
+- [x] Create `ColumnWidthCalculatorTests` (CoreTestHelper-built registry + GridStyleOptions; `[AvaloniaFact]` if `FormattedText` needs the headless app): assert no 32px reservation (known content yields `content*1.15` floored, not `+32`); a long header does NOT widen a column beyond its content+floor; the `MinColumnWidth` floor applies to a tiny-content column; a PropertyField with a `Max` sizes from the `Max` representative; a PropertyField whose property fails to resolve / has null `Max` falls back to the floor. Leave `RecipeGridStringMaxLengthTests` untouched. Run tests — must pass before next task.
+
+### Task 2: Per-column MinWidth floor in ColumnBuilder
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs`
+
+- [x] Set `column.MinWidth = ColumnWidthCalculator.MinColumnWidth` on every column built (data columns and the numbering column). No header change here — header typography is owned by the Task-3 style; the cell factories keep setting the string header.
+- [x] Build the UI project (0 errors). No unit test (the floor's visual effect is manual smoke; the width math is unit-tested in Task 1). Must build clean before next task.
+
+### Task 3: DataGridColumnHeader style — bold black, wrap to two lines
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml`
+
+- [x] Add a `DataGridColumnHeader` style that owns header typography:
+  - `ContentTemplate` = a `DataTemplate` rendering the string content as `<TextBlock Text="{Binding}" TextWrapping="Wrap" MaxLines="2" TextTrimming="CharacterEllipsis" TextAlignment="Center"/>`.
+  - `FontWeight="Bold"`, `Foreground="Black"` (own them so `TextElement` inheritance does not recolor), `HorizontalContentAlignment="Center"`, `VerticalContentAlignment="Center"`, no fixed `Height` (auto) + sensible `Padding` so a two-line header is not clipped.
+  - Keep the file's banner house-style comment.
+- [x] Confirm the header row grows to two lines without clipping, single-line headers center acceptably next to two-line ones, and bold/black actually wins over the theme default.
+- [x] Build the UI project (0 errors). Pure XAML styling — manual smoke (consistent with how the #67 selection styling was verified; no brittle visual-tree test). Must build clean before next task.
+
+### Task 4: Verify acceptance criteria
+
+- [x] All seven issue tasks addressed (acceptance trace, cited): sort-icon 32px removed (`ColumnWidthCalculator.cs` — no `FluentThemeSortIconMinWidth`/`CompensateThemeSortIconAndPaddingOffset`); buffer lowered to `1.15` (`ColumnWidthCalculator.cs:18`); content-driven width with `MinColumnWidth=72` floor and header excluded from the max (`ColumnWidthCalculator.cs:21,108`; `CalculateWidth` sizes from content only); PropertyField sizes from `Max` via `TimeFormatHelper.FormatValue`, with Result-fail/null-`Max`/string-`MaxLength` fallbacks to the floor (`ColumnWidthCalculator.cs:62-89`); per-column `MinWidth` on data + numbering columns (`ColumnBuilder.cs:41,57`); `DataGridColumnHeader` style with `ContentTemplate` TextBlock `TextWrapping=Wrap`, `MaxLines=2`, `TextTrimming=CharacterEllipsis`, `FontWeight=Bold`, `Foreground=Black`, centered, no fixed Height (`DataGridStyles.axaml:24-39`); plasma fits 1920 — [x] (manual smoke — verified by operator in running app), not headlessly automatable here.
+- [x] Build all: `dotnet build SemiStep/SemiStep.slnx` → 0 errors, 12 warnings (all pre-existing NU1902 NCalc).
+- [x] Run UI + Core slices. Real counts: `Component=UI` 272 passed / 0 failed; `Component=Core` 235 passed / 0 failed. No spurious mass-failure signature appeared this run (no narrowing needed).
+- [x] `dotnet format SemiStep/SemiStep.slnx --verify-no-changes` clean (exit 0, no changes).
+
+### Task 5: Finalize
+
+- [x] Confirm no dead leftover (e.g. the removed sort-icon helper is fully gone, no orphaned const).
+- [x] Move this plan to `Docs/plans/completed/`. (deferred to end of exec run — kept in place for review phases)
+
+## Post-Completion
+
+**Manual verification:**
+- Launch with the RIE (plasma) config; confirm all columns fit within 1920px with no horizontal scrollbar.
+- Long headers wrap to two lines, bold and black; short headers (`No`, time) stay one line.
+- Single-line headers align acceptably next to two-line ones; no header text clipped.
+- Tune `BufferMultiplier` / `MinColumnWidth` by eye if needed.
+- The #74 theme pass may revisit header typography against the new theme.

--- a/Docs/plans/completed/20260624-column-width-mincontent-refactor.md
+++ b/Docs/plans/completed/20260624-column-width-mincontent-refactor.md
@@ -1,0 +1,203 @@
+# Column width: min-content (longest-header-word) floor + unified chrome (issue #66 refactor)
+
+## Overview
+
+Smoke testing #66 exposed that excluding the header from the width budget plus a flat `MinColumnWidth = 72`
+floor makes a header-heavy column (e.g. "Начальное значение") narrower than its own longest word, so
+`TextWrapping=Wrap` breaks the word mid-glyph ("Начально"/"е") instead of wrapping cleanly on the space.
+This refactor replaces the accumulated smoke patches with one coherent model:
+
+- **A column's fixed width = `max(contentBudget, headerWordFloor, AbsoluteMin)`.**
+- `headerWordFloor` = the width of the header's **longest single word**, measured with the header's
+  rendered font (bold, `HeaderFontSize`), plus chrome. This is the CSS `min-content` width — the minimum
+  at which a wrapping header breaks on spaces, never inside a word. It replaces the flat 72px floor.
+- `contentBudget` = the widest representative cell string (metadata-driven, as today), plus chrome.
+- `chrome` = one additive `CellChromeAllowance` consolidating today's separate `*1.15` buffer and `+16`
+  padding into a single named concept (cell `Padding(4,2)` + grid line + centered slack).
+- All floor-return paths (PropertyField with no `Max`/unresolved, the dispatch default) route through the
+  same `max`, so even header-heavy **empty** columns get the header-word floor — the exact defect's root.
+
+Stays metadata-driven (representative values), so widths are stable and computed once — NOT Avalonia's
+built-in `DataGridLengthUnitType.Auto`, which sizes to live cells (columns would jump as the user types
+and empty columns would collapse). This is the deliberate reason to keep the hand-rolled calculator.
+
+## Context (from discovery)
+
+- `SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs` — the width model. Today: `CalculateWidth(content)`
+  = `ceil(max(maxContentWidth * BufferMultiplier + CellContentHorizontalPadding, MinColumnWidth))`; header
+  excluded; `CalculatePropertyFieldWidth`/`_ =>` return `new DataGridLength(MinColumnWidth)` (floor-only,
+  bypassing any header awareness — where the bug lives); `MeasureText(text, fontSize)` hardcodes
+  `Typeface(FontFamily.Default)` (normal weight) and is only ever called at `CellFontSize`.
+- `SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs` — builds columns; `_wrappingHeaderTemplate` (static)
+  is the per-column `HeaderTemplate` wrapping `TextBlock` (Wrap, MaxLines=2, ellipsis, centered). The
+  TextBlock sets NO FontSize/FontWeight, so it renders at the theme `DataGridColumnHeader` default
+  (`FontSize=12`) plus the style's `FontWeight=Bold`. `column.MinWidth = MinColumnWidth` on every column.
+- `SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml` — `DataGridColumnHeader` style: Bold, Black, Stretch,
+  Padding `6,3`. An ~18-line comment block duplicates the HeaderTemplate rationale already in ColumnBuilder.
+- `SemiStep/SemiStep.UI/Styles/ColorPalette.axaml` — `DataGridSortIconMinWidth = 0` override (keep).
+- `SemiStep/SemiStep.Core/Configuration/GridStyleOptions.cs` — `HeaderFontSize` (14), `CellFontSize` (12).
+  `HeaderFontSize` is currently unused (it fed the deleted header measurement); this refactor uses it again
+  for BOTH rendering the header and measuring the longest-word floor, so it stops being dead (drop the
+  earlier idea of moving it to #79).
+- `SemiStep/SemiStep.UI/RecipeGrid/TimeFormatHelper.cs` — `FormatValue`, time format/units for the
+  representative time value.
+- `SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs` — mirrors the formula; updated here.
+
+### Research grounding
+
+- "Min column width = longest header word" is CSS `min-content` applied to wrapping text (MDN/W3C: a wrapping
+  box is "only as wide as the longest word"). It is the correct floor for clean header wrapping.
+- Avalonia `DataGridLengthUnitType.{Auto,SizeToCells,SizeToHeader}` exist; `Auto` = `max(header,content)` over
+  LIVE cells. Rejected here for stability (representative metadata widths instead).
+
+### Confirmed decisions
+
+- Keep hand-rolled, representative-based widths (stable). Add a header-word (`min-content`) floor measured at
+  the rendered header font (bold, `HeaderFontSize`). Consolidate `*1.15` + `+16` into one additive
+  `CellChromeAllowance`. Route all floor-returns through the unified `max`. Render the header at
+  `HeaderFontSize` bold so the measured floor matches what is drawn.
+
+## Development Approach
+
+- Regular (code first, then tests). The width math is fully unit-testable; the visual wrap is manual smoke.
+- One coherent change to the calculator, a small ColumnBuilder/style alignment, then verify.
+
+## Testing Strategy
+
+- **Unit (ColumnWidthCalculator):** longest-word floor raises a tiny-content header-heavy column to its
+  longest word (measured bold at HeaderFontSize, NOT cell font); the floor is the longest WORD, not the whole
+  header (FullHD safety); content wider than the header is a no-op for the floor; the star column is
+  unaffected; chrome is the single additive allowance.
+- **Manual smoke:** "Начальное значение" wraps cleanly to "Начальное"/"значение" at the computed width (no
+  mid-word break); single-word headers stay one line; everything fits 1920; time value not flush.
+
+## Solution Overview
+
+`ColumnWidthCalculator` gains header awareness: every fixed-width column passes its `UiName` into one sink
+that returns `ceil(max(contentBudget, headerWordFloor, AbsoluteMin))`. `MeasureText` gains a typeface/size so
+the header floor is measured bold at `HeaderFontSize`. The flat 72 floor demotes to a small `AbsoluteMin`;
+the buffer+padding collapse to one `CellChromeAllowance`. `ColumnBuilder`'s header `TextBlock` renders at
+`HeaderFontSize` bold so the drawn header matches the measured floor.
+
+## Technical Details
+
+- New/changed in `ColumnWidthCalculator`:
+  - `CellChromeAllowance` (additive, ~18) replaces `BufferMultiplier` (1.15) and `CellContentHorizontalPadding`
+    (16). ONE constant, sized to cover the LARGER of cell padding (`Thickness(4,2)` = 8px) and header padding
+    (`6,3` = 12px) + grid line + a couple px slack, so it correctly budgets BOTH the content and the header
+    floors. `contentBudget = maxContentWidth + CellChromeAllowance`.
+  - KEEP `MinColumnWidth` at its current 72 as the absolute floor (one of the three `max` terms). Do NOT lower
+    it — the numbering column (Auto, built in `ColumnBuilder`) uses it as its `MinWidth` and lowering it would
+    narrow that column with nothing compensating. 72 is a reasonable readable minimum; the longest-word floor
+    is the new header guard, not a replacement for the absolute min.
+  - `MeasureText(string text, double fontSize, FontWeight weight)` — the weight MUST flow into the `Typeface`
+    constructor (`new Typeface(FontFamily.Default, FontStyle.Normal, weight)`), NOT into `FormattedText`.
+    Header words measured Bold at `gridStyle.HeaderFontSize`; content stays normal weight at `CellFontSize`.
+  - `LongestHeaderWordFloor(string header)`: split on whitespace, `Max` of `MeasureText(word, HeaderFontSize,
+    Bold)`, `+ CellChromeAllowance`; returns 0 for empty header.
+  - `CalculateWidth(IEnumerable<string> contentStrings, string headerText)`: returns
+    `ceil(max(contentBudget, LongestHeaderWordFloor(headerText), MinColumnWidth))`. Every dispatch branch
+    passes `columnDef.UiName`. The `TextField => Star` branch stays `Star` (no floor; star absorbs). The
+    PropertyField fail/null-Max branches pass empty content + the header (so the header floor applies — this
+    is the exact "Начальное значение" empty-column defect).
+- `ColumnBuilder`:
+  - The header `TextBlock` sets `FontSize = gridStyle.HeaderFontSize` and `FontWeight = FontWeight.Bold` so the
+    rendered header matches the measured floor (render==measure, and `HeaderFontSize` becomes genuinely used).
+    This needs `gridStyle`, so the header template (today `static _wrappingHeaderTemplate`) becomes an INSTANCE
+    member; consequently `AddNumberingColumn` (today `static`, references the static template) MUST become an
+    instance method too. Keep `Foreground=Black` from the style.
+  - `column.MinWidth = MinColumnWidth` (= 72) stays on every column (resize-collapse guard incl. the star
+    column); the numbering column keeps `MinWidth = MinColumnWidth` unchanged.
+- `DataGridStyles.axaml`: keep `DataGridColumnHeader` Bold/Black/Stretch/Padding; if FontWeight now lives on
+  the TextBlock, the style's `FontWeight=Bold` is redundant but harmless — keep one owner, remove the other;
+  trim the duplicated ~18-line comment block (the rationale lives in ColumnBuilder).
+- `ColorPalette.axaml`: unchanged (`DataGridSortIconMinWidth=0` stays).
+
+## What Goes Where
+
+- **Implementation Steps:** calculator refactor + tests; header render-font alignment + comment dedup; verify.
+- **Post-Completion:** manual smoke (clean wrap, 1920 fit, time not flush). The #74 theme pass may revisit
+  header typography.
+
+## Implementation Steps
+
+### Task 1: min-content width model in ColumnWidthCalculator
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs`
+
+- [x] Replace `BufferMultiplier` + `CellContentHorizontalPadding` with one additive `CellChromeAllowance`
+      (~18, named; comment: covers the larger of cell padding 8px and header padding 12px + gridline + slack).
+      `contentBudget = maxContentWidth + CellChromeAllowance`.
+- [x] KEEP `MinColumnWidth` = 72 (the absolute floor / one `max` term). Do NOT lower it (numbering column depends on it).
+- [x] Overload `MeasureText(text, fontSize, FontWeight weight)` — pass `weight` into the `Typeface` ctor
+      (`new Typeface(FontFamily.Default, FontStyle.Normal, weight)`), NOT into `FormattedText`. Content path
+      stays normal weight at `CellFontSize`; header path Bold at `gridStyle.HeaderFontSize`.
+- [x] Add `LongestHeaderWordFloor(string header)` — split on whitespace, max word measured Bold at
+      `HeaderFontSize`, `+ CellChromeAllowance`; 0 for empty header.
+- [x] Change `CalculateWidth` to `(IEnumerable<string> contentStrings, string headerText)` returning
+      `ceil(max(contentBudget, LongestHeaderWordFloor(headerText), MinColumnWidth))`. Route EVERY fixed-width
+      branch (action/group/property/time and the PropertyField fail/null-Max and `_ =>` paths) through it with
+      `columnDef.UiName`. Keep `TextField => Star` as `Star`.
+- [x] Update/extend tests (name each):
+      - NEW `MultiWordHeader_FloorsAtLongestWord`: tiny-content column with `UiName="Начальное значение"` →
+        width ≥ longest-word floor; clean no-mid-word guarantee.
+      - NEW `HeaderFloorMeasuredBoldAtHeaderFontSize`: same word measured Bold@HeaderFontSize > Normal@CellFontSize.
+      - NEW `LongestWordFloor_FarBelowWholeHeaderWidth` (FullHD safety): floor << whole-header single-line width.
+      - NEW `StarColumn_UnaffectedByHeaderFloor`.
+      - UPDATE `PropertyField_WithMax_SizesFromMaxRepresentative` and `ActionColumn_NoSortIconReservation`:
+        expected formula `ceil(max(content + CellChromeAllowance, headerWordFloor, MinColumnWidth))` (was
+        `content*1.15+16`); update the mirrored test consts.
+      - UPDATE `PropertyField_StringTyped_...`: re-derive BOTH sides — the `fullLengthWidth` upper bound used
+        `content*1.15` (no +16); switch to the additive formula consistently so the `<` relationship still holds.
+      - UPDATE `TinyContent_FallsBackToMinColumnWidthFloor` and `PropertyField_PropertyResolveFails_FallsBackToFloor`:
+        these asserted `== MinColumnWidth`; now width = `max(headerWordFloor, MinColumnWidth)` for that column's
+        UiName — assert the correct one (flips to the header-word floor if that header's longest word exceeds 72).
+      - UPDATE `LongHeader_DoesNotInflateColumnBeyondContent`: re-scope to "does not exceed the longest-word
+        floor" AND rewrite the stale reason string ("header must not participate" is no longer true).
+      Run the tests — must pass before next task.
+
+### Task 2: render header at HeaderFontSize bold; dedup comment
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs`
+- Modify: `SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml`
+
+- [x] In `ColumnBuilder`, set the header `TextBlock`'s `FontSize = gridStyle.HeaderFontSize` and
+      `FontWeight = FontWeight.Bold` so the drawn header matches the floor measurement. Convert
+      `_wrappingHeaderTemplate` to an INSTANCE member (needs `gridStyle`); consequently convert
+      `AddNumberingColumn` from `static` to an instance method (it references the template) — verify it still
+      compiles and the numbering column still builds.
+- [x] In `DataGridStyles.axaml`, keep `Foreground=Black`, `HorizontalContentAlignment=Stretch`, padding; pick a
+      single FontWeight owner (TextBlock vs style) and drop the redundant one; trim the duplicated header
+      rationale comment block (keep the one in ColumnBuilder).
+- [x] Build the UI project (0 errors). Visual — manual smoke. Must build clean.
+
+### Task 3: Verify acceptance criteria
+
+- [x] Trace: longest-word floor applies on all fixed-width branches incl. empty PropertyField; measured bold at
+      HeaderFontSize; chrome is one additive constant; star unaffected; HeaderFontSize now used (render+measure).
+      Verified: dispatch default `_ => CalculateWidth([], UiName)` (CWC.cs:41); PropertyField GetProperty-fail (74)
+      and null-Max (89) both route empty content + header through `CalculateWidth`; floor via
+      `LongestHeaderWordFloor` inside `Math.Max` (117); `MeasureText(word, HeaderFontSize, FontWeight.Bold)` (137)
+      with weight in `Typeface` ctor (183); `CellChromeAllowance = 18` additive only (30/115/144); TextField stays
+      Star (40); ColumnBuilder TextBlock FontSize=HeaderFontSize + Bold (ColumnBuilder.cs:67-68), render==measure.
+- [x] Build all: `dotnet build SemiStep/SemiStep.slnx`. Result: 0 errors, 12 pre-existing NU1902 NCalc warnings.
+- [x] Run UI + Core slices. UI: 277 passed, 0 failed. Core: 235 passed, 0 failed. The known ~195 spurious
+      single-process UI failure signature did NOT appear, so no narrow re-runs were needed.
+- [x] `dotnet format SemiStep/SemiStep.slnx` clean (`--verify-no-changes` exit 0, no changes).
+
+### Task 4: Finalize
+
+- [x] Confirm no dead leftover (old `BufferMultiplier`/`CellContentHorizontalPadding` fully gone; no stale
+      comment claiming the flat floor is the header-wrap room).
+- [x] Move this plan to `Docs/plans/completed/`. (deferred to end of exec run — kept in place for review phases)
+
+## Post-Completion
+
+**Manual verification:**
+- "Начальное значение" wraps cleanly to two lines at the computed width with no mid-word break; single-word
+  headers stay one line; the grid fits 1920 with no horizontal scroll; "00:00:00 с" is not flush.
+- Tune `CellChromeAllowance` / `AbsoluteMinColumnWidth` by eye if needed.
+- The #74 theme pass may revisit header typography.

--- a/Docs/plans/completed/20260624-font-relative-column-chrome.md
+++ b/Docs/plans/completed/20260624-font-relative-column-chrome.md
@@ -1,0 +1,234 @@
+# Font-relative column chrome + ComboBox-chevron-aware width (extends #66)
+
+## Overview
+
+Two coupled fixes to recipe-grid column sizing, both surfaced by smoke-testing PR #82:
+
+1. **ComboBox chevron overlaps the selected text.** Combo columns (action + group) are sized to
+   `widestText + CellChromeAllowance(26)`, but the Avalonia Fluent ComboBox reserves more chrome
+   around its text: a `*,32` template grid (a 32 DIP chevron column) plus `ComboBoxPadding` left 12
+   (`Avalonia.Themes.Fluent/Controls/ComboBox.xaml`). 26 < that, so the chevron sits over the text
+   ("Set Default Comp⌄", "N2 Nitroge⌄"). Combo columns must budget the real combo chrome.
+
+2. **Hardcoded pixel chrome does not survive font changes.** `CellChromeAllowance = 26` and
+   `MinColumnWidth = 72` are absolute DIP, tuned for the current 12/14 fonts. They survive monitor
+   DPI (Avalonia lays out in device-independent pixels — text measurement and these constants are
+   both DIP and co-scale), but NOT a `cell_size`/`header_size` change in `grid_style.yaml`: a larger
+   font shrinks the reserve proportionally and the flush/overlap returns. Make the chrome
+   font-proportional so it tracks the font; the combo chevron stays a fixed theme DIP.
+
+The time-column logic is NOT touched: it already computes identically across configs and re-derives
+consistently under the new model.
+
+## Context (from discovery)
+
+- Width model: `SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs`, shape
+  `max(content, longest-header-word, MinColumnWidth) + chrome`. It has `GridStyleOptions gridStyle`
+  injected (`CellFontSize=12`, `HeaderFontSize=14`).
+- `MinColumnWidth` is a `public const int` consumed by `ColumnBuilder.cs` (lines 50, 88: numbering
+  column `MinWidth` + every column's `MinWidth`) and referenced statically in the tests in ~9 places.
+- Combo columns route through `CalculateActionColumnWidth` / `CalculateGroupColumnWidth` →
+  `CalculateWidth`. Text/property/time route through `CalculateWidth` / `CalculatePropertyFieldWidth`
+  / `CalculateTimeColumnWidth`.
+- **Known inconsistency (from plan review):** `TextCellFactory.cs` renders every content cell
+  `TextBlock` with a hardcoded `Padding = new Thickness(4, 2)` (lines 52, 77, 120) — it does NOT read
+  `gridStyle.CellPaddingLeft/Right` (6). So config cell padding does not flow into content-cell
+  layout. The width chrome is therefore expressed as a font multiple (covering the rendered padding +
+  reserve together), NOT as `configPadding + reserve` — the latter would be a false story. The header
+  path is consistent (header style padding `6,3` is rendered). The `Thickness(4,2)` hardcode is left
+  as-is (out of scope); the plan only documents it.
+- Combo cells: `ComboBoxCellFactory.cs`; the `DataGrid ComboBox` style in
+  `SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml` sets Background/BorderThickness and can trim
+  `Padding`.
+- Fluent ComboBox chrome (verified from the theme source): grid `ColumnDefinitions="*,32"`, chevron
+  column 32 DIP, glyph 12 DIP centered (≈10 DIP whitespace each side — the off-border margin),
+  `ComboBoxPadding 12,5,0,7`, `ComboBoxMinHeight 32`. The `32` is a template LITERAL, not a themeable
+  resource: a combo column cannot be narrower than `text + ~32` without re-templating.
+- Tests: `SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs` mirror the production chrome
+  constant and re-derive expected widths from `GridStyleOptions.Default` (used live).
+
+## Development Approach
+
+- **testing approach**: Regular (code first, then update/extend tests in the same compile unit).
+- Keep the calculator a pure function (no live-control construction). `dotnet format` clean after
+  each task. Each task leaves the build AND tests green — see the sequencing note below.
+
+**Sequencing note (from plan review):** removing the two `const`s breaks `ColumnBuilder` and the test
+project until they are rewired. So the calculator change, the `ColumnBuilder` wiring, and the existing
+test re-derivation are ONE compile unit (Task 1) — the green-bar gate applies at the end of Task 1,
+not between its sub-steps. Later tasks (combo style, new tests, doc) each independently leave green.
+
+## Testing Strategy
+
+- Unit (`ColumnWidthCalculatorTests`): existing assertions re-derived against the font-proportional
+  chrome; PLUS two NEW tests written as assertions on RELATIONS between calculator outputs (not
+  re-evaluations of the mirrored formula, which would be tautological):
+  - font-relativity: the SAME column built at a larger `CellFontSize`/`HeaderFontSize` is strictly
+    wider, and the width delta tracks the font increase — compared between two real calculator
+    outputs.
+  - combo-chevron: on identical content, the combo-path output exceeds the text-path output by ≈ the
+    chevron budget — an output delta inequality.
+- The ComboBox padding trim (XAML) and "fits 1920" / "chevron visually clears" are visual — manual
+  smoke (Post-Completion), gating before merge. No automated assertion.
+
+## Solution Overview
+
+- **Content chrome** (text/property/time): `Ceiling(CellFontSize × ChromeFontMultiple)` with
+  `ChromeFontMultiple = 2.0` → 24 at the default 12. This is a calibration: ≈ the prior 26 px at the
+  default font, now font-proportional. Honest reserve note: the rendered cell padding is the fixed
+  `Thickness(4,2)` (8 DIP total), so the on-screen reserve ≈ `chrome − 8` ≈ 8 px/side at default (was
+  ~9). The 1 px/side shrink must be confirmed non-flush in smoke.
+- **Header-word-floor chrome**: `Ceiling(HeaderFontSize × ChromeFontMultiple)` → 28 at 14 (header
+  renders style padding `6,3`, consistent).
+- **Combo chrome**: `ComboBoxChromeWidth = 38` — a named constant citing the Fluent template
+  (chevron column 32 + trimmed ComboBox left padding 6). Fixed theme DIP, NOT font-scaled: the
+  chevron column is a fixed template literal, so budgeting `text + 38` keeps the text column
+  (`comboWidth − 32`) ≥ `text + 6` at any font — font-robust for overlap without scaling. Trim the
+  in-grid ComboBox left padding to 6 via the `DataGrid ComboBox` style so the rendered inset matches
+  the budget and combo text aligns with text-cell content. Net combo width ≈ `text + 38` vs the old
+  `text + 26` (≈ +12/combo).
+- **MinColumnWidth**: `Ceiling(CellFontSize × MinColumnWidthEms)` with `MinColumnWidthEms = 6.0` → 72
+  at 12, exposed as a public instance property; `ColumnBuilder` reads it from the calculator. Honest
+  comment: a calibration — the floor holds ~a few characters at the cell font, sized to 72 at the
+  default font; the `6.0` is chosen to reproduce 72, not physically derived.
+
+The combo chevron column (`32`) is a template literal, so the +12/combo widening is unavoidable
+without re-templating. On the densest config (RIE, ~10 combo columns) this could pressure the 1920
+budget — quantified in Task 4 and gated by smoke, with a documented re-template fallback.
+
+## Technical Details
+
+- New members in `ColumnWidthCalculator` (instance, reading `gridStyle`): `ContentChrome`,
+  `HeaderFloorChrome`, `MinColumnWidth` (public). New consts: `ChromeFontMultiple = 2.0`,
+  `MinColumnWidthEms = 6.0`, `ComboBoxChromeWidth = 38` (comment cites the Fluent template).
+  `MaxStringSampleLength` (12) stays a content cap, unrelated to chrome.
+- `CalculateWidth` keeps `max(contentBudget, headerWordFloor, MinColumnWidth)`; add a chrome
+  parameter (default `ContentChrome`) so combo paths pass `ComboBoxChromeWidth`.
+- `ColumnBuilder` reads `_widthCalculator.MinColumnWidth` at the numbering and per-column `MinWidth`
+  sites.
+- `DataGridStyles.axaml`: `DataGrid ComboBox` style trims left padding to 6.
+- Tests: replace the mirrored chrome constant with helpers mirroring `ContentChrome` /
+  `HeaderFloorChrome` / `ComboBoxChromeWidth` from `GridStyleOptions.Default`, and compute the
+  `MinColumnWidth` floor from `Default` (the static `ColumnWidthCalculator.MinColumnWidth` references
+  become the instance value or the mirrored floor).
+
+## What Goes Where
+
+- **Implementation Steps**: calculator + builder + test re-derivation (one compile unit), combo style
+  trim, the two relational tests, acceptance + RIE-budget quantification, architecture doc.
+- **Post-Completion**: manual smoke (MOCVD combo no-overlap; RIE fits 1920; time not flush) and the
+  documented re-template fallback if RIE overflows.
+
+## Implementation Steps
+
+### Task 1: Font-relative + combo-aware chrome in the calculator, wired through builder and existing tests
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs`
+
+This is ONE compile unit: removing the `const`s breaks `ColumnBuilder` and the tests until all three
+are updated. Green-bar gate applies at the end of the task.
+
+- [x] Replace `const CellChromeAllowance = 26` with instance `ContentChrome` =
+      `(int)Math.Ceiling(gridStyle.CellFontSize * ChromeFontMultiple)` and `HeaderFloorChrome` =
+      `(int)Math.Ceiling(gridStyle.HeaderFontSize * ChromeFontMultiple)`; add `const double
+      ChromeFontMultiple = 2.0` with a comment: calibrated ≈ the prior 26 px at the default 12 px
+      font; rendered cell padding is the fixed `TextCellFactory` `Thickness(4,2)`, so on-screen
+      reserve ≈ chrome−8.
+- [x] Add `const double ComboBoxChromeWidth = 38` with a comment citing
+      `Avalonia.Themes.Fluent/Controls/ComboBox.xaml` (`ColumnDefinitions="*,32"` chevron column +
+      trimmed left padding 6). Add a chrome parameter to `CalculateWidth` (default `ContentChrome`);
+      `CalculateActionColumnWidth` and `CalculateGroupColumnWidth` pass `ComboBoxChromeWidth`,
+      text/property/time stay on `ContentChrome`.
+- [x] Use `ContentChrome` in the content budget and `HeaderFloorChrome` in `LongestHeaderWordFloor`.
+- [x] Replace `public const int MinColumnWidth = 72` with `public int MinColumnWidth =>
+      (int)Math.Ceiling(gridStyle.CellFontSize * MinColumnWidthEms)`; add `const double
+      MinColumnWidthEms = 6.0` with an honest "calibration, not derivation" comment.
+- [x] `ColumnBuilder` reads `_widthCalculator.MinColumnWidth` at both `MinWidth` sites (numbering +
+      per-column) instead of the removed static const.
+- [x] Re-derive the tests: replace the mirrored `CellChromeAllowance` with `ContentChrome` /
+      `HeaderFloorChrome` / `ComboBoxChromeWidth` helpers from `GridStyleOptions.Default`; resolve the
+      static `ColumnWidthCalculator.MinColumnWidth` references to the instance value (or a mirrored
+      floor helper). Existing assertions must pass unchanged in intent.
+- [x] `dotnet build`; `dotnet test --filter FullyQualifiedName~ColumnWidthCalculatorTests` green;
+      `dotnet format --verify-no-changes` clean.
+
+### Task 2: Trim the in-grid ComboBox left padding to match the budget
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml` (the `DataGrid ComboBox` style)
+- Modify (only if the style cannot carry it): `SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs`
+
+No automated test — this is a visual style, covered by the manual smoke in Post-Completion.
+
+- [x] Trim the in-grid ComboBox left padding to ~6 so the rendered left inset matches the
+      `ComboBoxChromeWidth` assumption and combo text aligns with text-cell content.
+- [x] Verify the dropdown still opens/selects and the transparent-background / borderless styling is
+      intact (no regression to the existing `DataGrid ComboBox` style). (visual — covered by manual smoke)
+- [x] `dotnet build`; `dotnet format --verify-no-changes` clean.
+
+### Task 3: Add relational guard tests
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs`
+
+Both tests assert RELATIONS between real calculator outputs, NOT re-evaluations of the mirrored
+formula (which would pass tautologically).
+
+- [x] Font-relativity guard: build one calculator from `GridStyleOptions.Default` and another from a
+      `Default with { CellFontSize = 24, HeaderFontSize = 28 }` variant; on the same column assert the
+      larger-font width is strictly greater, and the width delta is positive and grows with the font
+      (e.g. `widthLarge − widthSmall` ≥ a positive bound derived from the font increase) — compared
+      between the two outputs, not against the mirror.
+- [x] Combo-chevron guard: on identical content (e.g. the same representative string), assert the
+      combo-path column output exceeds the text/property-path output by ≈
+      `ComboBoxChromeWidth − ContentChrome` — an output-delta inequality, not equality vs the mirror.
+- [x] `dotnet test --filter FullyQualifiedName~ColumnWidthCalculatorTests` green.
+
+### Task 4: Verify acceptance and quantify the RIE 1920 budget
+
+- [x] Quantify headroom: sum the per-column widths the calculator produces over the RIE config and
+      compare against 1920, so the +chevron pressure is a number, not a guess. Record it in the plan.
+      **Measured (real calculator over the shipped `ConfigFiles/RIE`, default fonts 12/14): RIE
+      fixed-column total ≈ 2506 px (numbering 72 + all non-Star columns; the Star "comment" column
+      absorbs the remainder), headroom vs 1920 ≈ −586 px.** The fixed columns alone OVERFLOW 1920 by
+      ~586 px, so the Star comment column has zero remainder and the grid horizontal-scrolls at 1920.
+      This is a gating overflow — the documented re-template fallback (Post-Completion) applies; the
+      orchestrator/user decides. Not fixed here per the task constraint.
+- [x] `dotnet build SemiStep/SemiStep.slnx` — 0 errors.
+- [x] Full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` green (883 passed, 0
+      failed; no spurious RxApp/Avalonia-init block observed this run).
+- [x] `dotnet format SemiStep/SemiStep.slnx --verify-no-changes` clean.
+- [x] No absolute magic chrome constant remains: chrome traces to a font multiple (`ContentChrome` =
+      `ChromeFontMultiple × CellFontSize`, `HeaderFloorChrome` = `ChromeFontMultiple × HeaderFontSize`),
+      the cited Fluent template constant (`ComboBoxChromeWidth = 38`), or the labeled
+      `MinColumnWidthEms = 6.0` calibration. No bare 26/72 absolute remains in `ColumnWidthCalculator`.
+
+### Task 5: [Final] Update architecture doc and move the plan
+
+**Files:**
+- Modify: `Docs/architecture/recipe-grid-column-sizing.md`
+
+- [x] Update the chrome section: chrome is now font-proportional (`ChromeFontMultiple × fontSize`);
+      document DPI-robust (DIP model) vs font-robust (now derived) and the ComboBox chevron budget
+      with the Fluent template citation; note the `TextCellFactory` `Thickness(4,2)` hardcode as a
+      known inconsistency (config cell padding is not applied to content cells).
+- [x] Move this plan to `Docs/plans/completed/`.
+
+## Post-Completion
+
+**Manual smoke (operator, gating before merge):**
+- MOCVD: combo cells ("Имя команды", "Канал", "Режим") show the selected text in full with the
+  chevron clear of it — no overlap, no mid-text ellipsis from the chevron.
+- RIE (densest): all columns still fit 1920 with no horizontal scroll after the +chevron widening.
+- Time columns ("Время"/"Время абс.") still not flush against the border (chrome calibrated ≈ prior).
+
+**Fallback if RIE overflows 1920:**
+- The chevron column (`32`) is a literal in the Fluent ComboBox template, so the only way to narrow a
+  combo column below `text + ~32` is a compact in-grid ComboBox `ControlTemplate` with a narrower
+  chevron column (e.g. `*,20`). Heavier and must preserve dropdown/selection/theming. **If applied,
+  re-sync `ComboBoxChromeWidth` in the calculator to the new column width** (template literal and
+  budget constant must not diverge, or the overlap returns inverted). Implement only if the smoke
+  shows RIE overflow.

--- a/SemiStep/SemiStep.Core/Recipes/PropertyDefinition.cs
+++ b/SemiStep/SemiStep.Core/Recipes/PropertyDefinition.cs
@@ -13,6 +13,7 @@ public static class SystemTypes
 {
 	public const string Int = "int";
 	public const string Float = "float";
+	public const string String = "string";
 
 	public static readonly StringComparer Comparer = StringComparer.OrdinalIgnoreCase;
 }

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs
@@ -25,8 +25,23 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 	// Mirrors the private MaxStringSampleLength cap in ColumnWidthCalculator.
 	private const int StringSampleCap = 12;
 
-	// Mirrors the private CellChromeAllowance in ColumnWidthCalculator.
-	private const double CellChromeAllowance = 26;
+	// Mirror the font-proportional chrome of ColumnWidthCalculator, derived from GridStyleOptions.Default.
+	private const double ChromeFontMultiple = 2.0;
+	private const double MinColumnWidthEms = 6.0;
+	private const double ComboBoxChromeWidth = 38;
+
+	// Larger fonts for the font-scaling tests.
+	private const int LargeCellFontSize = 24;
+	private const int LargeHeaderFontSize = 28;
+
+	private static int ContentChrome =>
+		(int)Math.Ceiling(GridStyleOptions.Default.CellFontSize * ChromeFontMultiple);
+
+	private static int HeaderFloorChrome =>
+		(int)Math.Ceiling(GridStyleOptions.Default.HeaderFontSize * ChromeFontMultiple);
+
+	private static int MinColumnWidthFloor =>
+		(int)Math.Ceiling(GridStyleOptions.Default.CellFontSize * MinColumnWidthEms);
 
 	private readonly UIFixture _fixture = new();
 	private ColumnWidthCalculator _calculator = null!;
@@ -49,13 +64,13 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 
 		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(actionColumn));
 
-		pixelWidth.Should().BeGreaterThanOrEqualTo(ColumnWidthCalculator.MinColumnWidth);
+		pixelWidth.Should().BeGreaterThanOrEqualTo(MinColumnWidthFloor);
 
 		var contentWidth = MeasureActionContentWidth();
 		var oldFormulaWidth = (int)Math.Ceiling((contentWidth + 32) * 1.4);
 		pixelWidth.Should().BeLessThan(oldFormulaWidth);
 
-		var expectedWidth = ExpectedWidth(contentWidth, actionColumn.UiName);
+		var expectedWidth = ExpectedWidth(contentWidth, actionColumn.UiName, ComboBoxChromeWidth);
 		pixelWidth.Should().Be(expectedWidth);
 	}
 
@@ -71,11 +86,11 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 		var contentWidth = MeasureActionContentWidth();
 		var longHeaderWidth = GetPixelWidth(_calculator.CalculateColumnWidth(longHeaderColumn));
 
-		var expectedWidth = ExpectedWidth(contentWidth, longHeaderColumn.UiName);
+		var expectedWidth = ExpectedWidth(contentWidth, longHeaderColumn.UiName, ComboBoxChromeWidth);
 		longHeaderWidth.Should().Be(expectedWidth,
 			"only the longest header word floors the width, not the whole header");
 		longHeaderWidth.Should().BeLessThanOrEqualTo(
-			(int)Math.Ceiling(Math.Max(contentWidth + CellChromeAllowance, LongestHeaderWordFloor(longHeaderColumn.UiName))));
+			(int)Math.Ceiling(Math.Max(contentWidth + ComboBoxChromeWidth, LongestHeaderWordFloor(longHeaderColumn.UiName))));
 	}
 
 	[AvaloniaFact]
@@ -94,9 +109,9 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 			.OrderByDescending(word => MeasureText(word, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold))
 			.First();
 		var longestWordFloor = (int)Math.Ceiling(
-			MeasureText(longestWord, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold) + CellChromeAllowance);
+			MeasureText(longestWord, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold) + HeaderFloorChrome);
 		var wholeHeaderWidth = (int)Math.Ceiling(
-			MeasureText(header, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold) + CellChromeAllowance);
+			MeasureText(header, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold) + HeaderFloorChrome);
 
 		pixelWidth.Should().Be(longestWordFloor,
 			"empty content makes the width equal the longest-word floor exactly");
@@ -123,7 +138,7 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 
 		var longestWordFloor = LongestHeaderWordFloor(header);
 		var wholeHeaderWidth = MeasureText(header, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold)
-			+ CellChromeAllowance;
+			+ HeaderFloorChrome;
 
 		longestWordFloor.Should().BeLessThan(wholeHeaderWidth / 2,
 			"the floor is the longest WORD, not the whole single-line header (FullHD safety)");
@@ -151,8 +166,8 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 			UiName = "Длительность"
 		};
 
-		var headerWordFloor = ExpectedWidth(0, taskColumn.UiName);
-		headerWordFloor.Should().BeGreaterThan(ColumnWidthCalculator.MinColumnWidth,
+		var headerWordFloor = ExpectedWidth(0, taskColumn.UiName, ContentChrome);
+		headerWordFloor.Should().BeGreaterThan(MinColumnWidthFloor,
 			"the chosen header's longest word must exceed MinColumnWidth so the floor is load-bearing");
 
 		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(taskColumn));
@@ -175,10 +190,10 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 			durationProperty.FormatKind,
 			durationProperty.Units);
 		var contentWidth = MeasureText(representative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal);
-		var expectedWidth = ExpectedWidth(contentWidth, durationColumn.UiName);
+		var expectedWidth = ExpectedWidth(contentWidth, durationColumn.UiName, ContentChrome);
 
 		pixelWidth.Should().Be(expectedWidth);
-		pixelWidth.Should().BeGreaterThan(ColumnWidthCalculator.MinColumnWidth,
+		pixelWidth.Should().BeGreaterThan(MinColumnWidthFloor,
 			"the formatted Max value is wider than the floor");
 	}
 
@@ -199,14 +214,14 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 
 		var cappedRepresentative = new string('0', StringSampleCap);
 		var cappedContentWidth = MeasureText(cappedRepresentative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal);
-		var expectedWidth = ExpectedWidth(cappedContentWidth, stringColumn.UiName);
+		var expectedWidth = ExpectedWidth(cappedContentWidth, stringColumn.UiName, ContentChrome);
 
 		pixelWidth.Should().Be(expectedWidth);
-		pixelWidth.Should().BeGreaterThanOrEqualTo(ColumnWidthCalculator.MinColumnWidth);
+		pixelWidth.Should().BeGreaterThanOrEqualTo(MinColumnWidthFloor);
 
 		var fullLengthRepresentative = new string('0', stringProperty.MaxLength!.Value);
 		var fullLengthWidth = (int)Math.Ceiling(
-			MeasureText(fullLengthRepresentative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal) + CellChromeAllowance);
+			MeasureText(fullLengthRepresentative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal) + ContentChrome);
 		pixelWidth.Should().BeLessThan(fullLengthWidth,
 			"the cap must keep the column far below the full MaxLength width");
 	}
@@ -220,8 +235,8 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 		};
 		var unknownPropertyColumn = taskColumn with { PropertyTypeId = "does_not_exist" };
 
-		var headerWordFloor = ExpectedWidth(0, unknownPropertyColumn.UiName);
-		headerWordFloor.Should().BeGreaterThan(ColumnWidthCalculator.MinColumnWidth,
+		var headerWordFloor = ExpectedWidth(0, unknownPropertyColumn.UiName, ContentChrome);
+		headerWordFloor.Should().BeGreaterThan(MinColumnWidthFloor,
 			"the chosen header's longest word must exceed MinColumnWidth so the floor is load-bearing");
 
 		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(unknownPropertyColumn));
@@ -238,8 +253,8 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 			UiName = "Длительность"
 		};
 
-		var headerWordFloor = ExpectedWidth(0, unknownTypeColumn.UiName);
-		headerWordFloor.Should().BeGreaterThan(ColumnWidthCalculator.MinColumnWidth,
+		var headerWordFloor = ExpectedWidth(0, unknownTypeColumn.UiName, ContentChrome);
+		headerWordFloor.Should().BeGreaterThan(MinColumnWidthFloor,
 			"the chosen header's longest word must exceed MinColumnWidth so the floor is load-bearing");
 
 		var length = _calculator.CalculateColumnWidth(unknownTypeColumn);
@@ -279,8 +294,8 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 
 		var pixelWidth = GetPixelWidth(calculator.CalculateColumnWidth(valueColumn));
 
-		var flowWidth = ExpectedWidth(MeasureRepresentative(flow, flow.Max!.Value), valueColumn.UiName);
-		var percentWidth = ExpectedWidth(MeasureRepresentative(percent, percent.Max!.Value), valueColumn.UiName);
+		var flowWidth = ExpectedWidth(MeasureRepresentative(flow, flow.Max!.Value), valueColumn.UiName, ContentChrome);
+		var percentWidth = ExpectedWidth(MeasureRepresentative(percent, percent.Max!.Value), valueColumn.UiName, ContentChrome);
 
 		pixelWidth.Should().Be(flowWidth,
 			"the column sizes to the widest unit-bearing value any action binds to its key");
@@ -310,13 +325,131 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 
 		var pixelWidth = GetPixelWidth(calculator.CalculateColumnWidth(speedColumn));
 
-		var minWidth = ExpectedWidth(MeasureRepresentative(speed, speed.Min!.Value), speedColumn.UiName);
-		var maxWidth = ExpectedWidth(MeasureRepresentative(speed, speed.Max!.Value), speedColumn.UiName);
+		var minWidth = ExpectedWidth(MeasureRepresentative(speed, speed.Min!.Value), speedColumn.UiName, ContentChrome);
+		var maxWidth = ExpectedWidth(MeasureRepresentative(speed, speed.Max!.Value), speedColumn.UiName, ContentChrome);
 
 		pixelWidth.Should().Be(minWidth,
 			"the negative Min ('-100 %/мин') is the widest representative and drives the width");
 		minWidth.Should().BeGreaterThan(maxWidth,
 			"the leading minus makes Min wider than Max for a symmetric range");
+	}
+
+	[AvaloniaFact]
+	public void Chrome_ScalesWithFont_ChromeRemainderGrowsBeyondContentScaling()
+	{
+		var smallCellFont = GridStyleOptions.Default.CellFontSize;
+		var largeCellFont = LargeCellFontSize;
+		var durationColumn = _fixture.RecipeMetadataRegistry.GetColumn("step_duration").Value;
+
+		var smallFontCalculator = new ColumnWidthCalculator(
+			_fixture.RecipeMetadataRegistry, GridStyleOptions.Default);
+		var largeFontCalculator = new ColumnWidthCalculator(
+			_fixture.RecipeMetadataRegistry,
+			GridStyleOptions.Default with { CellFontSize = largeCellFont, HeaderFontSize = LargeHeaderFontSize });
+
+		var smallFontWidth = GetPixelWidth(smallFontCalculator.CalculateColumnWidth(durationColumn));
+		var largeFontWidth = GetPixelWidth(largeFontCalculator.CalculateColumnWidth(durationColumn));
+
+		var representative = TimeFormatHelper.FormatValue(
+			"0", TimeFormatHelper.TimeHmsFormat, TimeFormatHelper.TimeUnits);
+		var smallContent = MeasureText(representative, smallCellFont, FontWeight.Normal);
+		var largeContent = MeasureText(representative, largeCellFont, FontWeight.Normal);
+
+		var smallChromeRemainder = smallFontWidth - smallContent;
+		var largeChromeRemainder = largeFontWidth - largeContent;
+
+		largeChromeRemainder.Should().BeGreaterThan(smallChromeRemainder,
+			"the chrome reserve is a font multiple, so at a larger font the width grows by MORE than pure content scaling");
+
+		largeFontCalculator.MinColumnWidth.Should().BeGreaterThan(smallFontCalculator.MinColumnWidth,
+			"the minimum-width floor is a font multiple, so it grows with the cell font");
+	}
+
+	[AvaloniaFact]
+	public void ComboColumn_WiderThanContentColumn_ByChevronBudget()
+	{
+		var representative = new string('0', StringSampleCap);
+		var sampleProperty = TestPropertyTypeDefinitionBuilder.CreateString("sample", StringSampleCap);
+
+		var comboColumn = new GridColumnDefinition(
+			Key: "value",
+			ColumnType: ColumnTypes.ActionComboBox,
+			UiName: "X",
+			PropertyTypeId: "sample",
+			ReadOnly: false,
+			SaveToCsv: true);
+		var contentColumn = comboColumn with { ColumnType = ColumnTypes.PropertyField };
+
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[1] = new ActionDefinition(1, representative, DeployDuration.Immediate,
+				new[] { new ActionPropertyDefinition("value", null, "sample", null) })
+		};
+
+		var calculator = BuildCalculator(
+			new[] { sampleProperty },
+			actions,
+			new Dictionary<string, GridColumnDefinition>
+			{
+				["combo"] = comboColumn,
+				["content"] = contentColumn
+			});
+
+		var comboWidth = GetPixelWidth(calculator.CalculateColumnWidth(comboColumn));
+		var contentWidth = GetPixelWidth(calculator.CalculateColumnWidth(contentColumn));
+
+		var delta = comboWidth - contentWidth;
+		var expectedDelta = (int)(ComboBoxChromeWidth - ContentChrome);
+
+		delta.Should().BeGreaterThan(0,
+			"the combo path budgets the wider Fluent ComboBox chrome, so the combo column exceeds the content column");
+		delta.Should().Be(expectedDelta,
+			"the width gap between the two real outputs equals the chevron budget (ComboBoxChromeWidth - ContentChrome): "
+			+ "both chrome terms are integers and the two content measurements are identical, so there is no rounding divergence");
+	}
+
+	[AvaloniaFact]
+	public void ComboChrome_StaysConstantAcrossFonts_WhileContentChromeGrows()
+	{
+		var smallCellFont = GridStyleOptions.Default.CellFontSize;
+		var largeCellFont = LargeCellFontSize;
+		var representative = new string('0', StringSampleCap);
+		var sampleProperty = TestPropertyTypeDefinitionBuilder.CreateString("sample", StringSampleCap);
+
+		var comboColumn = new GridColumnDefinition(
+			Key: "value",
+			ColumnType: ColumnTypes.ActionComboBox,
+			UiName: "X",
+			PropertyTypeId: "sample",
+			ReadOnly: false,
+			SaveToCsv: true);
+
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[1] = new ActionDefinition(1, representative, DeployDuration.Immediate,
+				new[] { new ActionPropertyDefinition("value", null, "sample", null) })
+		};
+
+		var registry = TestRecipeMetadataRegistryFactory.Build(
+			new[] { sampleProperty }, actions,
+			columns: new Dictionary<string, GridColumnDefinition> { ["combo"] = comboColumn });
+
+		var smallFontCalculator = new ColumnWidthCalculator(registry, GridStyleOptions.Default);
+		var largeFontCalculator = new ColumnWidthCalculator(
+			registry, GridStyleOptions.Default with { CellFontSize = largeCellFont, HeaderFontSize = LargeHeaderFontSize });
+
+		var smallComboWidth = GetPixelWidth(smallFontCalculator.CalculateColumnWidth(comboColumn));
+		var largeComboWidth = GetPixelWidth(largeFontCalculator.CalculateColumnWidth(comboColumn));
+
+		var smallContent = MeasureText(representative, smallCellFont, FontWeight.Normal);
+		var largeContent = MeasureText(representative, largeCellFont, FontWeight.Normal);
+
+		var smallComboChrome = smallComboWidth - smallContent;
+		var largeComboChrome = largeComboWidth - largeContent;
+
+		largeComboChrome.Should().BeApproximately(smallComboChrome, 1.0,
+			"the combo chevron budget is a fixed theme DIP (ComboBoxChromeWidth), so it does not scale with the font "
+			+ "even as the content grows");
 	}
 
 	private static ColumnWidthCalculator BuildCalculator(
@@ -339,11 +472,11 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 		return MeasureText(representative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal);
 	}
 
-	private static int ExpectedWidth(double contentWidth, string headerText)
+	private static int ExpectedWidth(double contentWidth, string headerText, double chromeOverride)
 	{
-		var contentBudget = contentWidth + CellChromeAllowance;
+		var contentBudget = contentWidth + chromeOverride;
 		return (int)Math.Ceiling(
-			Math.Max(Math.Max(contentBudget, LongestHeaderWordFloor(headerText)), ColumnWidthCalculator.MinColumnWidth));
+			Math.Max(Math.Max(contentBudget, LongestHeaderWordFloor(headerText)), MinColumnWidthFloor));
 	}
 
 	private static double LongestHeaderWordFloor(string header)
@@ -365,7 +498,7 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 			}
 		}
 
-		return maxWordWidth + CellChromeAllowance;
+		return maxWordWidth + HeaderFloorChrome;
 	}
 
 	private double MeasureActionContentWidth()

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs
@@ -1,0 +1,404 @@
+﻿using System.Globalization;
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+
+using FluentAssertions;
+
+using SemiStep.Core.Configuration;
+using SemiStep.Core.Recipes;
+using SemiStep.Tests.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Unit")]
+public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
+{
+	// Mirrors the private MaxStringSampleLength cap in ColumnWidthCalculator.
+	private const int StringSampleCap = 12;
+
+	// Mirrors the private CellChromeAllowance in ColumnWidthCalculator.
+	private const double CellChromeAllowance = 26;
+
+	private readonly UIFixture _fixture = new();
+	private ColumnWidthCalculator _calculator = null!;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_calculator = new ColumnWidthCalculator(_fixture.RecipeMetadataRegistry, GridStyleOptions.Default);
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		return _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void ActionColumn_NoSortIconReservation_WidthBelowOldSortIconFormula()
+	{
+		var actionColumn = _fixture.RecipeMetadataRegistry.GetColumn("action").Value;
+
+		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(actionColumn));
+
+		pixelWidth.Should().BeGreaterThanOrEqualTo(ColumnWidthCalculator.MinColumnWidth);
+
+		var contentWidth = MeasureActionContentWidth();
+		var oldFormulaWidth = (int)Math.Ceiling((contentWidth + 32) * 1.4);
+		pixelWidth.Should().BeLessThan(oldFormulaWidth);
+
+		var expectedWidth = ExpectedWidth(contentWidth, actionColumn.UiName);
+		pixelWidth.Should().Be(expectedWidth);
+	}
+
+	[AvaloniaFact]
+	public void LongHeader_DoesNotInflateColumnBeyondContent()
+	{
+		var actionColumn = _fixture.RecipeMetadataRegistry.GetColumn("action").Value;
+		var longHeaderColumn = actionColumn with
+		{
+			UiName = "An extremely long header label that would otherwise widen this column dramatically"
+		};
+
+		var contentWidth = MeasureActionContentWidth();
+		var longHeaderWidth = GetPixelWidth(_calculator.CalculateColumnWidth(longHeaderColumn));
+
+		var expectedWidth = ExpectedWidth(contentWidth, longHeaderColumn.UiName);
+		longHeaderWidth.Should().Be(expectedWidth,
+			"only the longest header word floors the width, not the whole header");
+		longHeaderWidth.Should().BeLessThanOrEqualTo(
+			(int)Math.Ceiling(Math.Max(contentWidth + CellChromeAllowance, LongestHeaderWordFloor(longHeaderColumn.UiName))));
+	}
+
+	[AvaloniaFact]
+	public void MultiWordHeader_FloorsAtLongestWord()
+	{
+		var header = "Начальное значение";
+		var taskColumn = _fixture.RecipeMetadataRegistry.GetColumn("task").Value with
+		{
+			UiName = header
+		};
+
+		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(taskColumn));
+
+		var longestWord = header
+			.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+			.OrderByDescending(word => MeasureText(word, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold))
+			.First();
+		var longestWordFloor = (int)Math.Ceiling(
+			MeasureText(longestWord, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold) + CellChromeAllowance);
+		var wholeHeaderWidth = (int)Math.Ceiling(
+			MeasureText(header, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold) + CellChromeAllowance);
+
+		pixelWidth.Should().Be(longestWordFloor,
+			"empty content makes the width equal the longest-word floor exactly");
+		pixelWidth.Should().BeLessThan(wholeHeaderWidth,
+			"the floor is the longest WORD, never the whole single-line header");
+	}
+
+	[AvaloniaFact]
+	public void HeaderFloorMeasuredBoldAtHeaderFontSize()
+	{
+		var word = "Начальное";
+
+		var boldHeaderFont = MeasureText(word, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold);
+		var normalCellFont = MeasureText(word, GridStyleOptions.Default.CellFontSize, FontWeight.Normal);
+
+		boldHeaderFont.Should().BeGreaterThan(normalCellFont,
+			"the header-word floor must be measured bold at HeaderFontSize, not at the cell font");
+	}
+
+	[AvaloniaFact]
+	public void LongestWordFloor_FarBelowWholeHeaderWidth()
+	{
+		var header = "An extremely long header label that would otherwise widen this column";
+
+		var longestWordFloor = LongestHeaderWordFloor(header);
+		var wholeHeaderWidth = MeasureText(header, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold)
+			+ CellChromeAllowance;
+
+		longestWordFloor.Should().BeLessThan(wholeHeaderWidth / 2,
+			"the floor is the longest WORD, not the whole single-line header (FullHD safety)");
+	}
+
+	[AvaloniaFact]
+	public void StarColumn_UnaffectedByHeaderFloor()
+	{
+		var commentColumn = _fixture.RecipeMetadataRegistry.GetColumn("comment").Value with
+		{
+			UiName = "Начальное значение целевого параметра процесса"
+		};
+
+		var length = _calculator.CalculateColumnWidth(commentColumn);
+
+		length.IsStar.Should().BeTrue("the star column absorbs remaining space and ignores the header floor");
+		length.UnitType.Should().Be(DataGridLengthUnitType.Star);
+	}
+
+	[AvaloniaFact]
+	public void PropertyField_NoNumericExtent_AppliesHeaderWordFloor()
+	{
+		var taskColumn = _fixture.RecipeMetadataRegistry.GetColumn("task").Value with
+		{
+			UiName = "Длительность"
+		};
+
+		var headerWordFloor = ExpectedWidth(0, taskColumn.UiName);
+		headerWordFloor.Should().BeGreaterThan(ColumnWidthCalculator.MinColumnWidth,
+			"the chosen header's longest word must exceed MinColumnWidth so the floor is load-bearing");
+
+		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(taskColumn));
+
+		pixelWidth.Should().Be(headerWordFloor);
+	}
+
+	[AvaloniaFact]
+	public void PropertyField_WithMax_SizesFromMaxRepresentative()
+	{
+		var durationColumn = _fixture.RecipeMetadataRegistry.GetColumn("step_duration").Value;
+		var durationProperty = _fixture.RecipeMetadataRegistry.GetProperty(durationColumn.PropertyTypeId).Value;
+		durationProperty.Max.Should().NotBeNull(
+			"the test configuration must declare Max for this assertion to be meaningful");
+
+		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(durationColumn));
+
+		var representative = TimeFormatHelper.FormatValue(
+			durationProperty.Max!.Value.ToString(CultureInfo.InvariantCulture),
+			durationProperty.FormatKind,
+			durationProperty.Units);
+		var contentWidth = MeasureText(representative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal);
+		var expectedWidth = ExpectedWidth(contentWidth, durationColumn.UiName);
+
+		pixelWidth.Should().Be(expectedWidth);
+		pixelWidth.Should().BeGreaterThan(ColumnWidthCalculator.MinColumnWidth,
+			"the formatted Max value is wider than the floor");
+	}
+
+	[AvaloniaFact]
+	public void PropertyField_StringTyped_SizesFromCappedSampleNotFullMaxLength()
+	{
+		var stringProperty = _fixture.RecipeMetadataRegistry.GetProperty("string").Value;
+		stringProperty.MaxLength.Should().NotBeNull();
+		stringProperty.MaxLength!.Value.Should().BeGreaterThan(StringSampleCap,
+			"the assertion is only meaningful when MaxLength exceeds the cap");
+
+		var stringColumn = _fixture.RecipeMetadataRegistry.GetColumn("task").Value with
+		{
+			PropertyTypeId = "string"
+		};
+
+		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(stringColumn));
+
+		var cappedRepresentative = new string('0', StringSampleCap);
+		var cappedContentWidth = MeasureText(cappedRepresentative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal);
+		var expectedWidth = ExpectedWidth(cappedContentWidth, stringColumn.UiName);
+
+		pixelWidth.Should().Be(expectedWidth);
+		pixelWidth.Should().BeGreaterThanOrEqualTo(ColumnWidthCalculator.MinColumnWidth);
+
+		var fullLengthRepresentative = new string('0', stringProperty.MaxLength!.Value);
+		var fullLengthWidth = (int)Math.Ceiling(
+			MeasureText(fullLengthRepresentative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal) + CellChromeAllowance);
+		pixelWidth.Should().BeLessThan(fullLengthWidth,
+			"the cap must keep the column far below the full MaxLength width");
+	}
+
+	[AvaloniaFact]
+	public void PropertyField_PropertyResolveFails_AppliesHeaderWordFloor()
+	{
+		var taskColumn = _fixture.RecipeMetadataRegistry.GetColumn("task").Value with
+		{
+			UiName = "Длительность"
+		};
+		var unknownPropertyColumn = taskColumn with { PropertyTypeId = "does_not_exist" };
+
+		var headerWordFloor = ExpectedWidth(0, unknownPropertyColumn.UiName);
+		headerWordFloor.Should().BeGreaterThan(ColumnWidthCalculator.MinColumnWidth,
+			"the chosen header's longest word must exceed MinColumnWidth so the floor is load-bearing");
+
+		var pixelWidth = GetPixelWidth(_calculator.CalculateColumnWidth(unknownPropertyColumn));
+
+		pixelWidth.Should().Be(headerWordFloor);
+	}
+
+	[AvaloniaFact]
+	public void DispatchDefault_UnknownColumnType_AppliesHeaderWordFloor()
+	{
+		var unknownTypeColumn = _fixture.RecipeMetadataRegistry.GetColumn("task").Value with
+		{
+			ColumnType = "not_a_real_type",
+			UiName = "Длительность"
+		};
+
+		var headerWordFloor = ExpectedWidth(0, unknownTypeColumn.UiName);
+		headerWordFloor.Should().BeGreaterThan(ColumnWidthCalculator.MinColumnWidth,
+			"the chosen header's longest word must exceed MinColumnWidth so the floor is load-bearing");
+
+		var length = _calculator.CalculateColumnWidth(unknownTypeColumn);
+
+		length.IsStar.Should().BeFalse("the dispatch default is a floored fixed width, never Star");
+		GetPixelWidth(length).Should().Be(headerWordFloor);
+	}
+
+	[AvaloniaFact]
+	public void PropertyField_AggregatesTypesAcrossActionsBoundToKey_WidestUnitWins()
+	{
+		var comment = TestPropertyTypeDefinitionBuilder.CreateString(
+			"comment", TestRecipeMetadataRegistryFactory.DefaultStringMaxLength);
+		var flow = TestPropertyTypeDefinitionBuilder.CreateFloat("flow", max: 100) with { Units = "см³/мин" };
+		var percent = TestPropertyTypeDefinitionBuilder.CreateFloat("percent", max: 100) with { Units = "%" };
+
+		var valueColumn = new GridColumnDefinition(
+			Key: "value",
+			ColumnType: ColumnTypes.PropertyField,
+			UiName: "Значение",
+			PropertyTypeId: "percent",
+			ReadOnly: false,
+			SaveToCsv: true);
+
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[1] = new ActionDefinition(1, "Flow action", DeployDuration.Immediate,
+				new[] { new ActionPropertyDefinition("value", null, "flow", null) }),
+			[2] = new ActionDefinition(2, "Percent action", DeployDuration.Immediate,
+				new[] { new ActionPropertyDefinition("value", null, "percent", null) })
+		};
+
+		var calculator = BuildCalculator(
+			new[] { comment, flow, percent },
+			actions,
+			new Dictionary<string, GridColumnDefinition> { ["value"] = valueColumn });
+
+		var pixelWidth = GetPixelWidth(calculator.CalculateColumnWidth(valueColumn));
+
+		var flowWidth = ExpectedWidth(MeasureRepresentative(flow, flow.Max!.Value), valueColumn.UiName);
+		var percentWidth = ExpectedWidth(MeasureRepresentative(percent, percent.Max!.Value), valueColumn.UiName);
+
+		pixelWidth.Should().Be(flowWidth,
+			"the column sizes to the widest unit-bearing value any action binds to its key");
+		flowWidth.Should().BeGreaterThan(percentWidth,
+			"the wider 'см³/мин' type is reachable only through an action binding, not the column default");
+	}
+
+	[AvaloniaFact]
+	public void PropertyField_NegativeMinWiderThanMax_SizesFromMinRepresentative()
+	{
+		var comment = TestPropertyTypeDefinitionBuilder.CreateString(
+			"comment", TestRecipeMetadataRegistryFactory.DefaultStringMaxLength);
+		var speed = TestPropertyTypeDefinitionBuilder.CreateFloat("speed", min: -100, max: 100) with { Units = "%/мин" };
+
+		var speedColumn = new GridColumnDefinition(
+			Key: "speed",
+			ColumnType: ColumnTypes.PropertyField,
+			UiName: "V",
+			PropertyTypeId: "speed",
+			ReadOnly: false,
+			SaveToCsv: true);
+
+		var calculator = BuildCalculator(
+			new[] { comment, speed },
+			actions: null,
+			new Dictionary<string, GridColumnDefinition> { ["speed"] = speedColumn });
+
+		var pixelWidth = GetPixelWidth(calculator.CalculateColumnWidth(speedColumn));
+
+		var minWidth = ExpectedWidth(MeasureRepresentative(speed, speed.Min!.Value), speedColumn.UiName);
+		var maxWidth = ExpectedWidth(MeasureRepresentative(speed, speed.Max!.Value), speedColumn.UiName);
+
+		pixelWidth.Should().Be(minWidth,
+			"the negative Min ('-100 %/мин') is the widest representative and drives the width");
+		minWidth.Should().BeGreaterThan(maxWidth,
+			"the leading minus makes Min wider than Max for a symmetric range");
+	}
+
+	private static ColumnWidthCalculator BuildCalculator(
+		IEnumerable<PropertyTypeDefinition> properties,
+		Dictionary<int, ActionDefinition>? actions,
+		Dictionary<string, GridColumnDefinition> columns)
+	{
+		var registry = TestRecipeMetadataRegistryFactory.Build(properties, actions, columns: columns);
+
+		return new ColumnWidthCalculator(registry, GridStyleOptions.Default);
+	}
+
+	private static double MeasureRepresentative(PropertyTypeDefinition property, double extent)
+	{
+		var representative = TimeFormatHelper.FormatValue(
+			extent.ToString(CultureInfo.InvariantCulture),
+			property.FormatKind,
+			property.Units);
+
+		return MeasureText(representative, GridStyleOptions.Default.CellFontSize, FontWeight.Normal);
+	}
+
+	private static int ExpectedWidth(double contentWidth, string headerText)
+	{
+		var contentBudget = contentWidth + CellChromeAllowance;
+		return (int)Math.Ceiling(
+			Math.Max(Math.Max(contentBudget, LongestHeaderWordFloor(headerText)), ColumnWidthCalculator.MinColumnWidth));
+	}
+
+	private static double LongestHeaderWordFloor(string header)
+	{
+		if (string.IsNullOrWhiteSpace(header))
+		{
+			return 0;
+		}
+
+		var words = header.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+
+		var maxWordWidth = 0.0;
+		foreach (var word in words)
+		{
+			var wordWidth = MeasureText(word, GridStyleOptions.Default.HeaderFontSize, FontWeight.Bold);
+			if (wordWidth > maxWordWidth)
+			{
+				maxWordWidth = wordWidth;
+			}
+		}
+
+		return maxWordWidth + CellChromeAllowance;
+	}
+
+	private double MeasureActionContentWidth()
+	{
+		var maxWidth = 0.0;
+		foreach (var action in _fixture.RecipeMetadataRegistry.GetAllActions())
+		{
+			var width = MeasureText(action.UiName, GridStyleOptions.Default.CellFontSize, FontWeight.Normal);
+			if (width > maxWidth)
+			{
+				maxWidth = width;
+			}
+		}
+
+		return maxWidth;
+	}
+
+	private static double MeasureText(string text, double fontSize, FontWeight fontWeight)
+	{
+		var typeface = new Typeface(FontFamily.Default, FontStyle.Normal, fontWeight);
+		var formattedText = new FormattedText(
+			text,
+			CultureInfo.CurrentCulture,
+			FlowDirection.LeftToRight,
+			typeface,
+			fontSize,
+			Brushes.Black);
+
+		return formattedText.WidthIncludingTrailingWhitespace;
+	}
+
+	private static int GetPixelWidth(DataGridLength length)
+	{
+		return (int)length.Value;
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGridStringMaxLengthTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGridStringMaxLengthTests.cs
@@ -68,7 +68,7 @@ public sealed class RecipeGridStringMaxLengthTests : IAsyncLifetime
 		// at the framework default (0 = unlimited). The integration test above covers the
 		// ColumnBuilder end-to-end path for the live string column; this complements it by pinning
 		// the null-branch contract that no live column currently exercises.
-		var template = TextCellFactory.CreateEditingTemplate("any_key", maxLength: null);
+		var template = new TextCellFactory(GridStyleOptions.Default).CreateEditingTemplate("any_key", maxLength: null);
 		var row = CreateRow();
 
 		var built = template.Build(row);

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
@@ -1,5 +1,8 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
 
 using SemiStep.Core.Configuration;
 using SemiStep.Core.Recipes;
@@ -12,6 +15,11 @@ public sealed class ColumnBuilder(
 {
 	private const string ReadOnlyColumnClass = "read-only-column";
 	private const string StepNumberColumnClass = "step-number-column";
+
+	// Assigned as the column's HeaderTemplate, not as a DataGridColumnHeader ContentTemplate setter:
+	// the header binds ContentTemplate from HeaderTemplate, so a style setter is overridden and the
+	// header would not wrap. See Docs/architecture/recipe-grid-column-sizing.md.
+	private readonly IDataTemplate _wrappingHeaderTemplate = BuildWrappingHeaderTemplate(gridStyle);
 
 	private readonly ComboBoxCellFactory _comboBoxCellFactory = new(recipeMetadataRegistry);
 
@@ -30,18 +38,42 @@ public sealed class ColumnBuilder(
 		}
 	}
 
-	private static void AddNumberingColumn(DataGrid grid)
+	private void AddNumberingColumn(DataGrid grid)
 	{
 		var column = new DataGridTextColumn
 		{
 			Header = "No",
+			HeaderTemplate = _wrappingHeaderTemplate,
 			Binding = new Binding("StepNumber"),
 			IsReadOnly = true,
 			Width = DataGridLength.Auto,
+			MinWidth = ColumnWidthCalculator.MinColumnWidth,
 			CanUserSort = false
 		};
 		column.CellStyleClasses.Add(StepNumberColumnClass);
 		grid.Columns.Add(column);
+	}
+
+	private static IDataTemplate BuildWrappingHeaderTemplate(GridStyleOptions gridStyle)
+	{
+		return new FuncDataTemplate<object?>(
+			(_, _) =>
+			{
+				var textBlock = new TextBlock
+				{
+					FontSize = gridStyle.HeaderFontSize,
+					FontWeight = FontWeight.Bold,
+					TextWrapping = TextWrapping.Wrap,
+					MaxLines = 2,
+					TextTrimming = TextTrimming.CharacterEllipsis,
+					TextAlignment = TextAlignment.Center,
+					HorizontalAlignment = HorizontalAlignment.Stretch,
+					VerticalAlignment = VerticalAlignment.Center
+				};
+				textBlock.Bind(TextBlock.TextProperty, new Binding());
+				return textBlock;
+			},
+			supportsRecycling: true);
 	}
 
 	private DataGridColumn CreateColumn(GridColumnDefinition columnDef)
@@ -53,6 +85,8 @@ public sealed class ColumnBuilder(
 			column.CellStyleClasses.Add(ReadOnlyColumnClass);
 		}
 		column.CellTheme = InapplicableCellTheme.Create(columnDef.Key);
+		column.MinWidth = ColumnWidthCalculator.MinColumnWidth;
+		column.HeaderTemplate = _wrappingHeaderTemplate;
 
 		return column;
 	}
@@ -81,7 +115,7 @@ public sealed class ColumnBuilder(
 	private int? ResolveMaxLength(GridColumnDefinition columnDef)
 	{
 		var propertyDef = recipeMetadataRegistry.GetProperty(columnDef.PropertyTypeId).Value;
-		var isStringTyped = string.Equals(propertyDef.SystemType, "string", StringComparison.OrdinalIgnoreCase);
+		var isStringTyped = SystemTypes.Comparer.Equals(propertyDef.SystemType, SystemTypes.String);
 
 		return isStringTyped ? recipeMetadataRegistry.GetStringMaxLength() : null;
 	}

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
@@ -21,9 +21,9 @@ public sealed class ColumnBuilder(
 	// header would not wrap. See Docs/architecture/recipe-grid-column-sizing.md.
 	private readonly IDataTemplate _wrappingHeaderTemplate = BuildWrappingHeaderTemplate(gridStyle);
 
-	private readonly ComboBoxCellFactory _comboBoxCellFactory = new(recipeMetadataRegistry);
+	private readonly ComboBoxCellFactory _comboBoxCellFactory = new(recipeMetadataRegistry, gridStyle);
 
-	private readonly TextCellFactory _textCellFactory = new();
+	private readonly TextCellFactory _textCellFactory = new(gridStyle);
 	private readonly ColumnWidthCalculator _widthCalculator = new(recipeMetadataRegistry, gridStyle);
 
 	public void BuildColumns(DataGrid grid)
@@ -45,9 +45,10 @@ public sealed class ColumnBuilder(
 			Header = "No",
 			HeaderTemplate = _wrappingHeaderTemplate,
 			Binding = new Binding("StepNumber"),
+			FontSize = gridStyle.CellFontSize,
 			IsReadOnly = true,
 			Width = DataGridLength.Auto,
-			MinWidth = ColumnWidthCalculator.MinColumnWidth,
+			MinWidth = _widthCalculator.MinColumnWidth,
 			CanUserSort = false
 		};
 		column.CellStyleClasses.Add(StepNumberColumnClass);
@@ -85,7 +86,9 @@ public sealed class ColumnBuilder(
 			column.CellStyleClasses.Add(ReadOnlyColumnClass);
 		}
 		column.CellTheme = InapplicableCellTheme.Create(columnDef.Key);
-		column.MinWidth = ColumnWidthCalculator.MinColumnWidth;
+		// Pin absolute columns to their content width so a narrow window scrolls instead of clipping
+		// (the DataGrid otherwise shrinks columns to MinWidth). See Docs/architecture/recipe-grid-column-sizing.md.
+		column.MinWidth = width.IsAbsolute ? width.Value : _widthCalculator.MinColumnWidth;
 		column.HeaderTemplate = _wrappingHeaderTemplate;
 
 		return column;

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs
@@ -15,16 +15,26 @@ public sealed class ColumnWidthCalculator(
 	// Raw seconds whose units-bearing render ("00:00:00 с") is the widest step-start-time cell value.
 	private const string RepresentativeTimeRawSeconds = "0";
 
-	// The numbering column (ColumnBuilder) uses it as its MinWidth, so do not lower it.
-	public const int MinColumnWidth = 72;
-
 	// String MaxLength can be very large (production props use 64/255); cap the representative sample
 	// so a wide string column does not dominate the available FullHD width.
 	private const int MaxStringSampleLength = 12;
 
-	// Additive budget (cell/header padding plus an off-the-border reserve) added once to the content
-	// and header-word floors; sized for the tightest case. See Docs/architecture/recipe-grid-column-sizing.md.
-	private const double CellChromeAllowance = 26;
+	// ceil(CellFontSize × 2.0); calibration of the prior 26 px. See Docs/architecture/recipe-grid-column-sizing.md
+	private const double ChromeFontMultiple = 2.0;
+
+	// em multiple calibrated to reproduce 72 at the default font. See Docs/architecture/recipe-grid-column-sizing.md
+	private const double MinColumnWidthEms = 6.0;
+
+	// 32 chevron column + 6 left padding; fixed theme DIP. See Docs/architecture/recipe-grid-column-sizing.md
+	private const int ComboBoxChromeWidth = 38;
+
+	// See Docs/architecture/recipe-grid-column-sizing.md
+	private int ContentChrome => (int)Math.Ceiling(gridStyle.CellFontSize * ChromeFontMultiple);
+
+	private int HeaderFloorChrome => (int)Math.Ceiling(gridStyle.HeaderFontSize * ChromeFontMultiple);
+
+	// The numbering column (ColumnBuilder) uses it as its MinWidth, so do not lower it.
+	public int MinColumnWidth => (int)Math.Ceiling(gridStyle.CellFontSize * MinColumnWidthEms);
 
 	public DataGridLength CalculateColumnWidth(GridColumnDefinition columnDef)
 	{
@@ -43,14 +53,14 @@ public sealed class ColumnWidthCalculator(
 	{
 		var actionNames = recipeMetadataRegistry.GetAllActions().Select(a => a.UiName);
 
-		return CalculateWidth(actionNames, columnDef.UiName);
+		return CalculateWidth(actionNames, columnDef.UiName, ComboBoxChromeWidth);
 	}
 
 	private DataGridLength CalculateGroupColumnWidth(GridColumnDefinition columnDef)
 	{
 		var displayStrings = CollectGroupDisplayStrings(columnDef.Key);
 
-		return CalculateWidth(displayStrings, columnDef.UiName);
+		return CalculateWidth(displayStrings, columnDef.UiName, ComboBoxChromeWidth);
 	}
 
 	private DataGridLength CalculateTimeColumnWidth(GridColumnDefinition columnDef)
@@ -106,7 +116,7 @@ public sealed class ColumnWidthCalculator(
 		return TimeFormatHelper.FormatValue(rawValue, propertyDef.FormatKind, propertyDef.Units);
 	}
 
-	private DataGridLength CalculateWidth(IEnumerable<string> contentStrings, string headerText)
+	private DataGridLength CalculateWidth(IEnumerable<string> contentStrings, string headerText, double? chromeOverride = null)
 	{
 		var maxContentWidth = 0.0;
 		foreach (var text in contentStrings)
@@ -123,7 +133,7 @@ public sealed class ColumnWidthCalculator(
 			}
 		}
 
-		var contentBudget = maxContentWidth + CellChromeAllowance;
+		var contentBudget = maxContentWidth + (chromeOverride ?? ContentChrome);
 		var pixelWidth = (int)Math.Ceiling(
 			Math.Max(Math.Max(contentBudget, LongestHeaderWordFloor(headerText)), MinColumnWidth));
 
@@ -149,7 +159,7 @@ public sealed class ColumnWidthCalculator(
 			}
 		}
 
-		return maxWordWidth + CellChromeAllowance;
+		return maxWordWidth + HeaderFloorChrome;
 	}
 
 	private IEnumerable<string> CollectGroupDisplayStrings(string columnKey)

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs
@@ -38,10 +38,14 @@ public sealed class ColumnWidthCalculator(
 
 	public DataGridLength CalculateColumnWidth(GridColumnDefinition columnDef)
 	{
+		if (ColumnTypes.IsGroupBoundColumn(columnDef.ColumnType))
+		{
+			return CalculateGroupColumnWidth(columnDef);
+		}
+
 		return columnDef.ColumnType.ToLowerInvariant() switch
 		{
 			ColumnTypes.ActionComboBox => CalculateActionColumnWidth(columnDef),
-			ColumnTypes.ActionTargetComboBox => CalculateGroupColumnWidth(columnDef),
 			ColumnTypes.PropertyField => CalculatePropertyFieldWidth(columnDef),
 			ColumnTypes.StepStartTimeField => CalculateTimeColumnWidth(columnDef),
 			ColumnTypes.TextField => new DataGridLength(1, DataGridLengthUnitType.Star),

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs
@@ -12,8 +12,19 @@ public sealed class ColumnWidthCalculator(
 	RecipeMetadataRegistry recipeMetadataRegistry,
 	GridStyleOptions gridStyle)
 {
-	private const string RepresentativeTimeValue = "00:00:00";
-	private const double BufferMultiplier = 1.4;
+	// Raw seconds whose units-bearing render ("00:00:00 с") is the widest step-start-time cell value.
+	private const string RepresentativeTimeRawSeconds = "0";
+
+	// The numbering column (ColumnBuilder) uses it as its MinWidth, so do not lower it.
+	public const int MinColumnWidth = 72;
+
+	// String MaxLength can be very large (production props use 64/255); cap the representative sample
+	// so a wide string column does not dominate the available FullHD width.
+	private const int MaxStringSampleLength = 12;
+
+	// Additive budget (cell/header padding plus an off-the-border reserve) added once to the content
+	// and header-word floors; sized for the tightest case. See Docs/architecture/recipe-grid-column-sizing.md.
+	private const double CellChromeAllowance = 26;
 
 	public DataGridLength CalculateColumnWidth(GridColumnDefinition columnDef)
 	{
@@ -21,10 +32,10 @@ public sealed class ColumnWidthCalculator(
 		{
 			ColumnTypes.ActionComboBox => CalculateActionColumnWidth(columnDef),
 			ColumnTypes.ActionTargetComboBox => CalculateGroupColumnWidth(columnDef),
-			ColumnTypes.PropertyField => CalculateHeaderBasedWidth(columnDef),
+			ColumnTypes.PropertyField => CalculatePropertyFieldWidth(columnDef),
 			ColumnTypes.StepStartTimeField => CalculateTimeColumnWidth(columnDef),
 			ColumnTypes.TextField => new DataGridLength(1, DataGridLengthUnitType.Star),
-			_ => CalculateHeaderBasedWidth(columnDef)
+			_ => CalculateWidth([], columnDef.UiName)
 		};
 	}
 
@@ -32,30 +43,71 @@ public sealed class ColumnWidthCalculator(
 	{
 		var actionNames = recipeMetadataRegistry.GetAllActions().Select(a => a.UiName);
 
-		return CalculateWidth(columnDef.UiName, actionNames);
+		return CalculateWidth(actionNames, columnDef.UiName);
 	}
 
 	private DataGridLength CalculateGroupColumnWidth(GridColumnDefinition columnDef)
 	{
 		var displayStrings = CollectGroupDisplayStrings(columnDef.Key);
 
-		return CalculateWidth(columnDef.UiName, displayStrings);
-	}
-
-	private DataGridLength CalculateHeaderBasedWidth(GridColumnDefinition columnDef)
-	{
-		return CalculateWidth(columnDef.UiName, []);
+		return CalculateWidth(displayStrings, columnDef.UiName);
 	}
 
 	private DataGridLength CalculateTimeColumnWidth(GridColumnDefinition columnDef)
 	{
-		return CalculateWidth(columnDef.UiName, [RepresentativeTimeValue]);
+		var representative = TimeFormatHelper.FormatValue(
+			RepresentativeTimeRawSeconds,
+			TimeFormatHelper.TimeHmsFormat,
+			TimeFormatHelper.TimeUnits);
+
+		return CalculateWidth([representative], columnDef.UiName);
 	}
 
-	private DataGridLength CalculateWidth(string headerText, IEnumerable<string> contentStrings)
+	private DataGridLength CalculatePropertyFieldWidth(GridColumnDefinition columnDef)
 	{
-		var headerWidth = CompensateThemeSortIconAndPaddingOffset(headerText);
+		var representatives = recipeMetadataRegistry.GetAllActions()
+			.SelectMany(action => action.Properties)
+			.Where(property => property.Key == columnDef.Key)
+			.Select(property => property.PropertyTypeId)
+			.Append(columnDef.PropertyTypeId)
+			.Distinct()
+			.Select(recipeMetadataRegistry.GetProperty)
+			.Where(result => result.IsSuccess)
+			.SelectMany(result => PropertyRepresentatives(result.Value));
 
+		return CalculateWidth(representatives, columnDef.UiName);
+	}
+
+	private IEnumerable<string> PropertyRepresentatives(PropertyTypeDefinition propertyDef)
+	{
+		if (SystemTypes.Comparer.Equals(propertyDef.SystemType, SystemTypes.String))
+		{
+			var sampleLength = Math.Min(propertyDef.MaxLength ?? MaxStringSampleLength, MaxStringSampleLength);
+			yield return new string('0', sampleLength);
+
+			yield break;
+		}
+
+		if (propertyDef.Max is not null)
+		{
+			yield return FormatExtent(propertyDef.Max.Value, propertyDef);
+		}
+
+		if (propertyDef.Min is not null)
+		{
+			yield return FormatExtent(propertyDef.Min.Value, propertyDef);
+		}
+	}
+
+	private static string FormatExtent(double extent, PropertyTypeDefinition propertyDef)
+	{
+		var rawValue = extent.ToString(CultureInfo.InvariantCulture);
+
+		return TimeFormatHelper.FormatValue(rawValue, propertyDef.FormatKind, propertyDef.Units);
+	}
+
+	private DataGridLength CalculateWidth(IEnumerable<string> contentStrings, string headerText)
+	{
 		var maxContentWidth = 0.0;
 		foreach (var text in contentStrings)
 		{
@@ -64,17 +116,40 @@ public sealed class ColumnWidthCalculator(
 				continue;
 			}
 
-			var contentWidth = MeasureText(text, gridStyle.CellFontSize);
+			var contentWidth = MeasureText(text, gridStyle.CellFontSize, FontWeight.Normal);
 			if (contentWidth > maxContentWidth)
 			{
 				maxContentWidth = contentWidth;
 			}
 		}
 
-		var maxWidth = Math.Max(headerWidth, maxContentWidth);
-		var pixelWidth = (int)Math.Ceiling(maxWidth * BufferMultiplier);
+		var contentBudget = maxContentWidth + CellChromeAllowance;
+		var pixelWidth = (int)Math.Ceiling(
+			Math.Max(Math.Max(contentBudget, LongestHeaderWordFloor(headerText)), MinColumnWidth));
 
 		return new DataGridLength(pixelWidth);
+	}
+
+	private double LongestHeaderWordFloor(string header)
+	{
+		if (string.IsNullOrWhiteSpace(header))
+		{
+			return 0;
+		}
+
+		var words = header.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+
+		var maxWordWidth = 0.0;
+		foreach (var word in words)
+		{
+			var wordWidth = MeasureText(word, gridStyle.HeaderFontSize, FontWeight.Bold);
+			if (wordWidth > maxWordWidth)
+			{
+				maxWordWidth = wordWidth;
+			}
+		}
+
+		return maxWordWidth + CellChromeAllowance;
 	}
 
 	private IEnumerable<string> CollectGroupDisplayStrings(string columnKey)
@@ -106,23 +181,14 @@ public sealed class ColumnWidthCalculator(
 		}
 	}
 
-	private double CompensateThemeSortIconAndPaddingOffset(string headerText)
-	{
-		const double FluentThemeSortIconMinWidth = 32;
-
-		var textWidth = MeasureText(headerText, gridStyle.HeaderFontSize);
-
-		return textWidth + FluentThemeSortIconMinWidth;
-	}
-
-	private static double MeasureText(string text, double fontSize)
+	private static double MeasureText(string text, double fontSize, FontWeight fontWeight)
 	{
 		if (string.IsNullOrEmpty(text))
 		{
 			return 0;
 		}
 
-		var typeface = new Typeface(FontFamily.Default);
+		var typeface = new Typeface(FontFamily.Default, FontStyle.Normal, fontWeight);
 		var formattedText = new FormattedText(
 			text,
 			CultureInfo.CurrentCulture,

--- a/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
@@ -6,11 +6,12 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
 
+using SemiStep.Core.Configuration;
 using SemiStep.Core.Recipes;
 
 namespace SemiStep.UI.RecipeGrid;
 
-internal sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataRegistry)
+internal sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataRegistry, GridStyleOptions gridStyle)
 {
 	public DataGridColumn CreateActionColumn(GridColumnDefinition columnDef, DataGridLength width)
 	{
@@ -109,11 +110,14 @@ internal sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataR
 		}, supportsRecycling: true);
 	}
 
-	private static ComboBox CreateStyledComboBox()
+	// FontSize explicit: the Fluent ComboBox selection box does not inherit the grid font, so without it
+	// the text renders at the theme default and the chevron clips it. See Docs/architecture/recipe-grid-column-sizing.md.
+	private ComboBox CreateStyledComboBox()
 	{
 		return new ComboBox
 		{
 			DisplayMemberBinding = new Binding(nameof(ComboBoxItemViewModel.DisplayText)),
+			FontSize = gridStyle.CellFontSize,
 			HorizontalAlignment = HorizontalAlignment.Stretch,
 			VerticalAlignment = VerticalAlignment.Center,
 		};

--- a/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
@@ -5,11 +5,12 @@ using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
 
+using SemiStep.Core.Configuration;
 using SemiStep.Core.Recipes;
 
 namespace SemiStep.UI.RecipeGrid;
 
-internal sealed class TextCellFactory
+internal sealed class TextCellFactory(GridStyleOptions gridStyle)
 {
 	public DataGridColumn CreateReadOnlyColumn(GridColumnDefinition columnDef, DataGridLength width)
 	{
@@ -42,12 +43,13 @@ internal sealed class TextCellFactory
 		};
 	}
 
-	private static FuncDataTemplate<RecipeRowViewModel> CreateStepStartTimeTemplate()
+	private FuncDataTemplate<RecipeRowViewModel> CreateStepStartTimeTemplate()
 	{
 		return new FuncDataTemplate<RecipeRowViewModel>((_, _) =>
 		{
 			var textBlock = new TextBlock
 			{
+				FontSize = gridStyle.CellFontSize,
 				VerticalAlignment = VerticalAlignment.Center,
 				Padding = new Thickness(4, 2),
 				TextAlignment = TextAlignment.Center,
@@ -62,7 +64,7 @@ internal sealed class TextCellFactory
 		}, supportsRecycling: true);
 	}
 
-	private static FuncDataTemplate<RecipeRowViewModel> CreateMultiBindingTemplate(string columnKey)
+	private FuncDataTemplate<RecipeRowViewModel> CreateMultiBindingTemplate(string columnKey)
 	{
 		var bindingPath = ResolveBindingPath(columnKey);
 		var unitsConverter = new DictionaryEntryConverter<string?>(columnKey, null);
@@ -73,6 +75,7 @@ internal sealed class TextCellFactory
 		{
 			var textBlock = new TextBlock
 			{
+				FontSize = gridStyle.CellFontSize,
 				VerticalAlignment = VerticalAlignment.Center,
 				Padding = new Thickness(4, 2),
 				TextAlignment = TextAlignment.Center,
@@ -101,7 +104,7 @@ internal sealed class TextCellFactory
 		}, supportsRecycling: true);
 	}
 
-	public static FuncDataTemplate<RecipeRowViewModel> CreateEditingTemplate(string columnKey, int? maxLength)
+	public FuncDataTemplate<RecipeRowViewModel> CreateEditingTemplate(string columnKey, int? maxLength)
 	{
 		var bindingPath = ResolveBindingPath(columnKey);
 
@@ -114,6 +117,7 @@ internal sealed class TextCellFactory
 
 			var textBox = new TextBox
 			{
+				FontSize = gridStyle.CellFontSize,
 				VerticalAlignment = VerticalAlignment.Center,
 				HorizontalAlignment = HorizontalAlignment.Stretch,
 				BorderThickness = new Thickness(0),

--- a/SemiStep/SemiStep.UI/Styles/ColorPalette.axaml
+++ b/SemiStep/SemiStep.UI/Styles/ColorPalette.axaml
@@ -5,6 +5,10 @@
     <Color x:Key="AccentColor">#0078D7</Color>
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
 
+    <!-- Override the Fluent DataGrid sort-glyph reserve (default 32px) to 0: sorting is disabled
+         on every column, so the reserved column otherwise just crowds the header text. -->
+    <x:Double x:Key="DataGridSortIconMinWidth">0</x:Double>
+
     <!-- Config-driven brushes (cell state, selection, grid lines) are installed at startup by
          CellPaletteInstaller from GridStyleOptions. See CellPaletteInstaller for the full key
          list and the config source paths. -->

--- a/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
+++ b/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
@@ -11,6 +11,15 @@
         <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource GridLineBrush}" />
     </Style>
 
+    <!-- Stretch is load-bearing: the Fluent header panel aligns by it, and only Stretch gives the
+         wrapping header TextBlock the column width it needs. See Docs/architecture/recipe-grid-column-sizing.md. -->
+    <Style Selector="DataGridColumnHeader">
+        <Setter Property="Foreground" Value="Black" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="6,3" />
+    </Style>
+
     <!-- ============================================== -->
     <!-- DataGrid ComboBox default appearance.          -->
     <!-- Background is transparent so the cell color    -->

--- a/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
+++ b/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
@@ -32,6 +32,8 @@
     <Style Selector="DataGrid ComboBox">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
+        <!-- left padding 6 to match the ComboBoxChromeWidth budget. See Docs/architecture/recipe-grid-column-sizing.md -->
+        <Setter Property="Padding" Value="6,5,0,7" />
     </Style>
 
     <!-- ============================================== -->


### PR DESCRIPTION
Closes #66.

Sizes the recipe `DataGrid` columns to fit a FullHD (1920px) screen without horizontal scroll, renders headers bold/black, wraps long headers to two lines, and sizes each column to its real content. Column width is `max(content, longest-header-word, MinColumnWidth)` plus a font-proportional chrome allowance (a larger fixed allowance on combo columns for the dropdown chevron).

## What changed

### Min-content sizing + header wrapping (7d5d17e)
- **Header wrapping** — a CSS min-content longest-header-word floor, measured in the rendered header font (bold, `HeaderFontSize`), so a column is never narrower than its longest word and the header wraps on spaces (max two lines), never mid-word. The wrapping `TextBlock` is set per-column as `HeaderTemplate` (a style `ContentTemplate` setter is overridden by the Fluent header), and the Fluent sort-glyph reserve (`DataGridSortIconMinWidth`, default 32px) is zeroed since sorting is disabled.
- **Units-aware content width** — a single visual property column hosts cells of every property type any action binds to its key, and units live on that per-action type, not on the column. `CalculatePropertyFieldWidth` collects representatives across all bound types (plus the column default) and measures both `Min` and `Max` formatted with units. Fixes per-cell units (`см³/мин`, `%/мин`, `°C`) truncating, and the negative `Min` of a symmetric range (e.g. `-200000 Па`) being wider than `Max`.

### Font-relative chrome + clip-proof combo columns (54d831e)
- **Font-proportional chrome** — content budget `ceil(CellFontSize × ChromeFontMultiple)`, header-word floor `ceil(HeaderFontSize × …)`, `MinColumnWidth = ceil(CellFontSize × MinColumnWidthEms)`. Survives a `cell_size`/`header_size` change instead of a fixed pixel budget; DPI already worked via Avalonia's DIP model. Combo columns add a fixed `ComboBoxChromeWidth` (32 chevron column + 6 left padding) traced to the Fluent ComboBox template.
- **Render matches measure** — each cell control sets `FontSize = CellFontSize` explicitly (ComboBox, display/editing `TextBlock`/`TextBox`, numbering column), mirroring the header, so the grid renders at the measured font instead of the Fluent default (~14) and the action ComboBox selected text no longer overflows its budget.
- **Scroll, never clip** — each absolute column pins `MinWidth` to its calculated width, so a window narrower than the column sum scrolls horizontally instead of the `DataGrid` shrinking columns and clipping cell content (the action ComboBox text behind its chevron). Star columns keep the small floor.

### Dispatch consistency (3714b9b)
- `ColumnWidthCalculator` routes group columns through the same `IsGroupBoundColumn` predicate `ColumnBuilder` uses, so a future group-bound type cannot silently fall through to the default width path.

Design rationale is captured in `Docs/architecture/recipe-grid-column-sizing.md`.

## Tests

`ColumnWidthCalculatorTests` — 16 passing, including cross-action type aggregation (widest unit wins), `Min`-wider-than-`Max`, and relational chrome guards (chrome remainder grows with font; combo wider than content by the chevron budget; combo chrome constant across fonts). Full UI suite 283/283; `dotnet format --verify-no-changes` clean.

## Manual verification (operator)

"Fits 1920" is a per-config property (no `1920` constant in code). On the widest config (RIE/plasma): columns fit 1920 with no horizontal scroll, headers wrap cleanly with no mid-word break, single-word headers stay one line, unit-bearing values (incl. `00:00:00 с`) are not flush against the border, and the action dropdown shows the full selected name with no chevron overlap. At a narrower window the grid scrolls horizontally and no content is clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
