### PR TITLE
refactor: strip noise comments flagged by comment-hater

### DIFF
--- a/SemiStep/SemiStep.Core/Configuration/GridStyleOptions.cs
+++ b/SemiStep/SemiStep.Core/Configuration/GridStyleOptions.cs
@@ -53,12 +53,7 @@ public sealed record GridStyleOptions(
 	string ExecutionDepth3PastColor,
 	string ExecutionCurrentStepMarkerColor)
 {
-	/// <summary>
-	/// Fallback configuration used for shape/wiring tests only. The `#000000` sentinel values on
-	/// the readonly, disabled, and execution cell palettes are intentional placeholders — production
-	/// runs load real colors via <c>GridStyleValidator</c> + <c>GridStyleMapper</c> and never observe
-	/// these defaults.
-	/// </summary>
+	// Test-only fallback; the #000000 cell palettes are placeholders, never rendered in production.
 	public static GridStyleOptions Default { get; } = new(
 		HeaderFontSize: 14,
 		CellFontSize: 12,

--- a/SemiStep/SemiStep.Core/Configuration/Mapping/ActionMapper.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Mapping/ActionMapper.cs
@@ -162,7 +162,6 @@ internal static class ActionMapper
 
 		var failures = new List<Result>();
 
-		// Normalize expression dictionary to a case-insensitive lookup once; reject case-only duplicates.
 		var expressionsByKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		foreach (var (key, value) in rawExpressions)
 		{
@@ -189,14 +188,12 @@ internal static class ActionMapper
 				$"[{section}] formula.recalc_order contains duplicate entries"));
 		}
 
-		// Map case-insensitively to action column key (canonical casing).
 		var columnByKey = new Dictionary<string, ActionPropertyDefinition>(StringComparer.OrdinalIgnoreCase);
 		foreach (var column in columns)
 		{
 			columnByKey[column.Key] = column;
 		}
 
-		// Normalize recalc_order entries to canonical column casing.
 		var canonicalRecalcOrder = new List<string>(rawRecalcOrder.Count);
 		foreach (var variable in rawRecalcOrder)
 		{
@@ -211,7 +208,6 @@ internal static class ActionMapper
 			}
 		}
 
-		// Validate system_type is numeric (int/float).
 		foreach (var variable in canonicalRecalcOrder)
 		{
 			if (!columnByKey.TryGetValue(variable, out var column))

--- a/SemiStep/SemiStep.Core/Configuration/Mapping/GridStyleMapper.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Mapping/GridStyleMapper.cs
@@ -12,10 +12,7 @@ internal static class GridStyleMapper
 		}
 
 		var defaults = GridStyleOptions.Default;
-		// Validator-first invariant: GridStyleValidator runs before this mapper and rejects
-		// any DTO where `colors.cells.readonly`, `colors.cells.disabled` or
-		// `colors.cells.execution` (or any of their hex keys) is missing. The local aliases
-		// below let us read each field without re-suppressing the chain on every line.
+		// Presence guaranteed by GridStyleValidator, which runs before this mapper; hence the `!` chain.
 		var readOnlyCells = dto.Colors!.Cells!.ReadOnly!;
 		var disabledCells = dto.Colors!.Cells!.Disabled!;
 		var executionCells = dto.Colors!.Cells!.Execution!;

--- a/SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Validation/CrossReferenceValidator.cs
@@ -109,13 +109,7 @@ internal static class CrossReferenceValidator
 		ValidateNoSharedColumnAcrossBranches(actions, actionsById, validationResults);
 	}
 
-	/// <summary>
-	/// Mirrors the resolver's rejection of a column reachable within a single root via more than
-	/// one selector condition (OR-activation is unsupported), so the config load fails with a clean
-	/// aggregated error instead of throwing later at registry construction. The resolver keeps its
-	/// own guard as defense-in-depth. For each root the column-key map is fresh, so the same column
-	/// shared across DIFFERENT roots is allowed and not flagged.
-	/// </summary>
+	// Shared-column / OR-activation rule documented in Docs/architecture/nested-actions.md.
 	private static void ValidateNoSharedColumnAcrossBranches(
 		List<ActionDto> actions,
 		Dictionary<int, ActionDto> actionsById,
@@ -149,15 +143,6 @@ internal static class CrossReferenceValidator
 		}
 	}
 
-	/// <summary>
-	/// Depth-first walk of the <c>targets</c> graph from one root, tracking per column key the
-	/// activation-path signature (the ordered selector edges taken to reach it; the root's own
-	/// columns have an empty signature = always-active). Returns <c>true</c> with the conflicting
-	/// key the first time a column key is reached with a path signature different from the one first
-	/// seen (OR-activation, which is unsupported), stopping the walk at most one finding per root.
-	/// Cycle-safe via <paramref name="onPath"/> (cycles are reported separately by
-	/// <see cref="ValidateNoCycles"/>).
-	/// </summary>
 	private static bool TryFindSharedColumn(
 		int actionId,
 		string pathSignature,
@@ -230,12 +215,7 @@ internal static class CrossReferenceValidator
 		}
 	}
 
-	/// <summary>
-	/// Surfaces a reference-graph cycle as a clean config-load validation error, consistent with
-	/// the sibling dangling/orphan rules. The resolver also guards against cycles defensively, but
-	/// reporting it here means the config load fails with all reference errors together rather than
-	/// throwing later at registry construction.
-	/// </summary>
+	// Reported here, not at registry construction, so all reference errors surface together.
 	private static void ValidateNoCycles(
 		List<ActionDto> actions,
 		Dictionary<int, ActionDto> actionsById,

--- a/SemiStep/SemiStep.Core/Plc/Sync/Ownership/SyncLockRootProvisioner.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/Ownership/SyncLockRootProvisioner.cs
@@ -46,8 +46,7 @@ internal sealed class SyncLockRootProvisioner
 		{
 			// Best-effort ACL provisioning. A different Windows user that cannot open the
 			// lock file is mapped to a clean refusal in FileSyncOwnership.TryAcquire,
-			// so a failure to widen the ACL here does not crash the caller. Installer-time
-			// provisioning is documented in the plan's Post-Completion section.
+			// so a failure to widen the ACL here does not crash the caller.
 		}
 	}
 }

--- a/SemiStep/SemiStep.Core/Plc/Sync/PlcRecipeDataComparer.cs
+++ b/SemiStep/SemiStep.Core/Plc/Sync/PlcRecipeDataComparer.cs
@@ -4,11 +4,6 @@ namespace SemiStep.Core.Plc.Sync;
 
 internal static class PlcRecipeDataComparer
 {
-	// Floats are serialised to raw IEEE 754 bytes, written to the PLC, and read back without
-	// any arithmetic transformation. The round-trip is byte-exact, so bit-exact equality is
-	// the correct comparison here — not an epsilon-based approximation.
-	// BitConverter.SingleToInt32Bits is used rather than == to correctly handle NaN payloads
-	// and distinguish +0 from -0 (different IEEE-754 bit patterns).
 	internal static bool DataMatchesExpected(PlcRecipeData actual, PlcRecipeData expected)
 	{
 		if (actual.IntValues.Length != expected.IntValues.Length)

--- a/SemiStep/SemiStep.Core/Recipes/Import/CsvStepReader.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Import/CsvStepReader.cs
@@ -1,4 +1,3 @@
 ﻿namespace SemiStep.Core.Recipes.Import;
 
-// Parsing logic moved to TypesConverter.CsvRowConverter
 internal static class CsvStepReader { }

--- a/SemiStep/SemiStep.Tests/Config/Helpers/TestDataCopier.cs
+++ b/SemiStep/SemiStep.Tests/Config/Helpers/TestDataCopier.cs
@@ -27,7 +27,6 @@ public static class TestDataCopier
 	{
 		var tempDir = new TempDirectory();
 
-		// Step 1: Copy baseline (Standard)
 		var baselineDir = GetTestDataPath(BaselineCaseName);
 		if (!Directory.Exists(baselineDir))
 		{
@@ -36,7 +35,6 @@ public static class TestDataCopier
 
 		CopyDirectory(baselineDir, tempDir.Path);
 
-		// Step 2: Overlay invalid case files
 		var invalidDir = GetTestDataPath(Path.Combine(InvalidCasesFolder, invalidCaseName));
 		if (!Directory.Exists(invalidDir))
 		{

--- a/SemiStep/SemiStep.Tests/Core/RecipeSessionBehaviourCharacterizationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/RecipeSessionBehaviourCharacterizationTests.cs
@@ -12,9 +12,6 @@ using Xunit;
 
 namespace SemiStep.Tests.Core;
 
-/// <summary>
-/// Characterization tests pinning the observable contract of <see cref="RecipeSession"/>.
-/// </summary>
 [Trait("Category", "Integration")]
 [Trait("Component", "Core")]
 [Trait("Area", "Characterization")]

--- a/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/PlcLifecycleManagerReconnectTests.cs
@@ -75,16 +75,13 @@ public sealed class PlcLifecycleManagerReconnectTests
 	{
 		var (plc, session, s7Service, _) = await BuildAsync();
 
-		// Populate local recipe so it is non-empty.
 		var appendResult = session.AppendStep(WaitActionId);
 		appendResult.IsSuccess.Should().BeTrue();
 
-		// Configure stub: committed=true, PLC recipe different from local.
 		var plcRecipe = BuildSingleStepRecipe();
 		s7Service.ManagingAreaToReturn = new PlcManagingAreaState(Committed: true, RecipeLines: 1);
 		s7Service.RecipeToReturn = plcRecipe;
 
-		// Activate sync so the relay handles Connected events.
 		var enableResult = await plc.EnableSync(PlcConfiguration.Default);
 		enableResult.IsSuccess.Should().BeTrue();
 
@@ -96,10 +93,8 @@ public sealed class PlcLifecycleManagerReconnectTests
 			conflictPlcRecipe = plcRec;
 		};
 
-		// Simulate an auto-reconnect: StateChanged fires Connected while sync is active.
 		s7Service.RaiseStateChanged(PlcConnectionState.Connected);
 
-		// (a) Observable state: wait until the fire-and-forget reconciliation has raised the conflict event.
 		await TestHelpers.WaitUntilAsync(
 			() => conflictLocalRecipe is not null,
 			cancellationToken: TestContext.Current.CancellationToken);
@@ -114,12 +109,9 @@ public sealed class PlcLifecycleManagerReconnectTests
 	{
 		var (plc, session, s7Service, syncService) = await BuildAsync();
 
-		// Populate local recipe so it is non-empty; AppendStep populates default properties
-		// per the action definition, so the local step is not empty.
 		var appendResult = session.AppendStep(WaitActionId);
 		appendResult.IsSuccess.Should().BeTrue();
 
-		// Configure stub: committed=true, PLC recipe is a fresh-instance deep copy of the local one.
 		// Reusing BuildSingleStepRecipe() would yield empty Properties, which differ from the
 		// session's populated step and would wrongly trip the conflict branch.
 		s7Service.ManagingAreaToReturn = new PlcManagingAreaState(Committed: true, RecipeLines: 1);
@@ -133,11 +125,8 @@ public sealed class PlcLifecycleManagerReconnectTests
 
 		var countBeforeStateChange = syncService.NotifyRecipeChangedCallCount;
 
-		// Simulate an auto-reconnect: StateChanged fires Connected while sync is active.
 		s7Service.RaiseStateChanged(PlcConnectionState.Connected);
 
-		// (a) Observable state: identical content takes the equal branch, which falls through
-		// to NotifyLocalRecipe and increments the counter.
 		await TestHelpers.WaitUntilAsync(
 			() => syncService.NotifyRecipeChangedCallCount > countBeforeStateChange,
 			cancellationToken: TestContext.Current.CancellationToken);
@@ -159,19 +148,15 @@ public sealed class PlcLifecycleManagerReconnectTests
 	{
 		var (plc, _, s7Service, syncService) = await BuildAsync();
 
-		// Configure stub: committed=false, so reconciliation should push local recipe.
 		s7Service.ManagingAreaToReturn = new PlcManagingAreaState(Committed: false, RecipeLines: 0);
 
 		var enableResult = await plc.EnableSync(PlcConfiguration.Default);
 		enableResult.IsSuccess.Should().BeTrue();
 
-		// Capture the call count after EnableSync to measure only the reconnect-triggered push.
 		var countBeforeStateChange = syncService.NotifyRecipeChangedCallCount;
 
-		// Simulate an auto-reconnect.
 		s7Service.RaiseStateChanged(PlcConnectionState.Connected);
 
-		// (a) Observable state: wait until the reconcile-on-reconnect pushes the local recipe.
 		await TestHelpers.WaitUntilAsync(
 			() => syncService.NotifyRecipeChangedCallCount > countBeforeStateChange,
 			cancellationToken: TestContext.Current.CancellationToken);
@@ -188,7 +173,6 @@ public sealed class PlcLifecycleManagerReconnectTests
 		var enableResult = await plc.EnableSync(PlcConfiguration.Default);
 		enableResult.IsSuccess.Should().BeTrue();
 
-		// Simulate a connection drop while sync is active.
 		s7Service.RaiseStateChanged(PlcConnectionState.Disconnected);
 
 		syncService.WasHandleConnectionLostCalled.Should().BeTrue(
@@ -252,7 +236,6 @@ public sealed class PlcLifecycleManagerReconnectTests
 		s7Service.ManagingAreaToReturn = new PlcManagingAreaState(Committed: true, RecipeLines: 1);
 		s7Service.RecipeToReturn = plcRecipe;
 
-		// Register a no-op callback so the path completes without applying anything to the session.
 		// The session must remain empty: the lifecycle manager is forbidden from mutating it directly,
 		// because such a mutation skips UI-thread marshalling and the mutation-signal channel.
 		var callbackInvoked = false;

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -140,7 +140,6 @@ public sealed class PlcSyncCoordinatorTests
 		var (coordinator, transport, connectionService) = Build(connected: true);
 		connectionService.SetConnected(true);
 
-		// Configure read-back for verification (empty arrays)
 		var layout = BuildTestConfiguration().Layout;
 		transport.SetReadResponseForDb(layout.IntDb.DbNumber, (_, count) => new byte[count]);
 		transport.SetReadResponseForDb(layout.FloatDb.DbNumber, (_, count) => new byte[count]);

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorLoadRecipeTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorLoadRecipeTests.cs
@@ -165,7 +165,6 @@ public sealed class RecipeCoordinatorLoadRecipeTests
 
 		try
 		{
-			// Save the default empty recipe so we have a valid CSV file with no steps.
 			await coordinator.SaveRecipeAsync(tempFilePath);
 
 			var result = await coordinator.LoadRecipeAsync(tempFilePath);

--- a/SemiStep/SemiStep.UI/App.axaml.cs
+++ b/SemiStep/SemiStep.UI/App.axaml.cs
@@ -80,10 +80,8 @@ public class App : Application
 		EnsureSingleStart();
 		BuildAvaloniaApp()
 			.AfterSetup(_ =>
-				// UseReactiveUI() above has already registered AvaloniaScheduler as
-				// RxSchedulers.MainThreadScheduler. Initialize services here — after the
-				// scheduler is set — so that ReactiveCommand singletons capture the
-				// correct scheduler at construction time.
+				// Initialize after setup: UseReactiveUI() has registered AvaloniaScheduler as
+				// MainThreadScheduler by now, so ReactiveCommand singletons capture it at construction.
 				InitializeServices(serviceProvider))
 			.AfterSetup(builder =>
 			{
@@ -97,10 +95,7 @@ public class App : Application
 	{
 		var session = provider.GetRequiredService<RecipeSession>();
 
-		// session.Reset() returns Result<RecipeSnapshot> from analyzing Recipe.Empty.
-		// Empty-recipe analysis can surface configuration validator warnings that should
-		// be logged but never block startup — the MessagePanel rebuild on first PLC tick
-		// will surface them to the user. Logged for diagnostic visibility only.
+		// Empty-recipe analysis can surface validator warnings; log them but never block startup.
 		var resetResult = session.Reset();
 		if (resetResult.IsFailed)
 		{

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -27,10 +27,7 @@ public sealed class RecipeCoordinator : IDisposable
 	private readonly IDisposable _canEditRecipeConnection;
 	private readonly CsvService _csvService;
 	private readonly object _disposeLock = new();
-	// PLC channels: hop to MainThreadScheduler once here at the source, expose via
-	// Publish().RefCount() so all subscribers share a single ObserveOn. Subscribers
-	// (RecipeGridViewModel, MainWindowViewModel, PlcMonitorViewModel) consume these
-	// without applying their own ObserveOn.
+	// Hopped to MainThreadScheduler once and shared via Publish().RefCount(); subscribers add no ObserveOn.
 	private readonly IObservable<PlcExecutionInfo> _executionState;
 	private readonly ImportedRecipeValidator _importedRecipeValidator;
 	private readonly ILogger<RecipeCoordinator> _logger;
@@ -209,7 +206,6 @@ public sealed class RecipeCoordinator : IDisposable
 		}
 		else
 		{
-			// Marshal the session mutation onto the UI thread (see DispatchMutation).
 			result = await Dispatcher.UIThread.InvokeAsync(() => _plc.ApplyRecipeFromPlc(readResult.Value));
 		}
 
@@ -336,7 +332,6 @@ public sealed class RecipeCoordinator : IDisposable
 		}
 		else
 		{
-			// Marshal the session mutation onto the UI thread (see DispatchMutation).
 			result = await Dispatcher.UIThread.InvokeAsync(() =>
 			{
 				var validateResult = _session.LoadAsCurrentValidated(loadResult.Value, _importedRecipeValidator);
@@ -397,7 +392,6 @@ public sealed class RecipeCoordinator : IDisposable
 		}
 		else
 		{
-			// Marshal the dirty-flag mutation onto the UI thread (see DispatchMutation).
 			await Dispatcher.UIThread.InvokeAsync(() => _session.MarkSaved());
 			_logger.LogInformation("Saved recipe to {FilePath}", filePath);
 			// Not a step-graph mutation; subscribers refresh window-title / IsDirty / status.
@@ -411,9 +405,7 @@ public sealed class RecipeCoordinator : IDisposable
 
 	private async Task<Result> ApplyReconnectPlcRecipeAsync(Recipe recipe)
 	{
-		// Reconnect reconciliation resumes on a thread-pool continuation. Hop to the UI
-		// dispatcher before mutating the session so the grid sink observes the change on
-		// the thread it asserts, then dispatch the mutation signal from the same context.
+		// Reconnect reconciliation resumes off-thread; marshal to the UI dispatcher before mutating.
 		return await Dispatcher.UIThread.InvokeAsync(() =>
 		{
 			var applyResult = _plc.ApplyRecipeFromPlc(recipe);
@@ -472,9 +464,7 @@ public sealed class RecipeCoordinator : IDisposable
 			signal.GetType().Name,
 			_session.Current.StepCount);
 
-		// Mutation entry points include async file/PLC paths that may resume off the UI
-		// thread. Subscribers (RecipeGridViewModel.OnMutation) assert UI-thread access, so
-		// marshal explicitly here instead of relying on captured sync context.
+		// Async file/PLC paths may resume off-thread; the grid sink asserts UI-thread, so marshal explicitly.
 		if (Dispatcher.UIThread.CheckAccess())
 		{
 			RaiseMutatedSafely(signal);
@@ -551,10 +541,8 @@ public sealed class RecipeCoordinator : IDisposable
 
 	private void RebuildMessagePanel()
 	{
-		// The panel reflects the CURRENT recipe's structural validity, never an operation
-		// outcome. A failed analysis (e.g. a loaded recipe with loop nesting beyond the limit)
-		// is an operation failure surfaced transiently by the initiating VM, so its IError
-		// reasons must not leak into the panel even though the failed snapshot is the current one.
+		// Panel shows the current recipe's validity, not operation outcomes; failed-analysis errors
+		// are surfaced transiently by the initiating VM and must not leak here.
 		IEnumerable<IReason> reasons = _session.Snapshot.IsSuccess
 			? _session.Snapshot.Reasons
 			: Array.Empty<IReason>();

--- a/SemiStep/SemiStep.UI/Program.cs
+++ b/SemiStep/SemiStep.UI/Program.cs
@@ -28,14 +28,10 @@ public static class Program
 
 		try
 		{
-			// Phase 1: pre-flight validation. Anything that can fail BEFORE Avalonia is
-			// initialised runs here. The outcome decides which window (and only one) is shown.
 			var outcome = ValidateStartup(options.ConfigDir);
 
-			// Phase 2: launch exactly one window. Both branches call BuildAvaloniaApp()
-			// exactly once; the catch below intentionally does NOT fall back to RunErrorWindow,
-			// because by the time App.Run can throw, Avalonia has already been initialised
-			// and a second BuildAvaloniaApp() would throw "Application has already been initialized".
+			// The catch must not re-launch: once App.Run has initialised Avalonia, a second
+			// BuildAvaloniaApp() would throw "Application has already been initialized".
 			if (outcome.Errors is not null)
 			{
 				App.RunErrorWindow(outcome.Errors);

--- a/SemiStep/SemiStep.UI/Styles/ExecutionPaletteInstaller.cs
+++ b/SemiStep/SemiStep.UI/Styles/ExecutionPaletteInstaller.cs
@@ -21,10 +21,7 @@ internal static class ExecutionPaletteInstaller
 		ArgumentNullException.ThrowIfNull(resources);
 		ArgumentNullException.ThrowIfNull(gridStyle);
 
-		// `ExecRowDepth0Brush` (and its `Past` counterpart) represent the "outside any loop"
-		// tint. No selector currently consumes them — the brush is reserved for future explicit
-		// styling of non-loop rows. Keeping the resource installed lets us add that selector
-		// without revisiting the configuration model.
+		// Depth0 brushes (the "outside any loop" tint) are installed but not yet consumed by any selector.
 		resources[ExecRowDepth0BrushKey] = PaletteBrushFactory.From(gridStyle.ExecutionDepth0Color);
 		resources[ExecRowDepth1BrushKey] = PaletteBrushFactory.From(gridStyle.ExecutionDepth1Color);
 		resources[ExecRowDepth2BrushKey] = PaletteBrushFactory.From(gridStyle.ExecutionDepth2Color);


### PR DESCRIPTION
Removes comments that restate the code, narrate test setup, echo a signature, or carry process/changelog notes across Core, UI and Tests. A handful of over-long inline rationales are condensed to a single local why.

No behaviour changes. Build and `dotnet format --verify-no-changes` are clean.

16 files changed, ~100 lines of comment noise removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)