### PR TITLE
Keep the changed-cell signal visible on a selected row (#80)

### DIFF
--- a/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
+++ b/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
@@ -212,6 +212,13 @@
         <Setter Property="TextElement.Foreground" Value="{DynamicResource SelectionForegroundBrush}" />
     </Style>
 
+    <!-- Changed + selected: keep the selection background legible and signal the change with an orange
+         border instead, so both read at once (issue #80). Border, not Background, is what survives selection. -->
+    <Style Selector="DataGridRow:selected DataGridCell[(rg|InapplicableCellTheme.IsChanged)=True]">
+        <Setter Property="BorderBrush" Value="{DynamicResource CellChangedBrush}" />
+        <Setter Property="BorderThickness" Value="2" />
+    </Style>
+
     <Style Selector="DataGridRow.current-step DataGridCell.step-number-column">
         <Setter Property="Background" Value="{DynamicResource CurrentStepMarkerBrush}" />
     </Style>


### PR DESCRIPTION
Closes #80.

## Problem
The orange "changed cell" highlight (#63) is a cell `Background`, and the `:selected` rule overrides it via last-match-wins. Right after an action change the grid keeps the affected row selected, so the operator saw only the selection background — the change signal was invisible exactly when it mattered, and only appeared after clicking away.

## Fix
Add a `DataGridRow:selected DataGridCell[IsChanged=True]` rule that keeps the selection background (so selection stays legible) and signals the change with an orange **border** — the existing `CellChangedBrush`, reused, no new color. Both "this row is selected" and "these cells changed" now read at once (issue option 2).

Purely a `DataGridStyles.axaml` cascade addition; no new state, no new config.

## Verification
- Rendered MOCVD with row 0 (changed) selected via the headless screenshot harness: selection background present, changed cell shows the orange border.
- `Component=UI` suite 283/283; `dotnet format --verify-no-changes` clean.

Note: making `CellChangedColor` config-driven (it is currently the one hardcoded cell-state color, in `ColorPalette.axaml`) is intentionally a separate follow-up under #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)