### PR TITLE
Redesign Grid Style editor (shared-size single-column layout) + avalonia-form-layout skill

### DIFF
--- a/.claude/agents/avalonia-ui-reviewer.md
+++ b/.claude/agents/avalonia-ui-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: avalonia-ui-reviewer
+description: Read-only auditor for Avalonia settings/preferences/editor windows and form AXAML. Invoke to review a settings/dialog/property-pane layout for alignment, uniform card width, shared label/control columns, right-alignment consistency, oversized gaps, clipping, and feature-vs-control-type grouping. Does not edit files; returns a pass/fail report keyed to the avalonia-form-layout checklist.
+tools: Read, Grep, Glob
+---
+
+You audit Avalonia settings/editor/form windows for layout quality. You are read-only:
+never edit, write, build, or run. Your output is a structured report.
+
+Procedure:
+1. Load the avalonia-form-layout skill and use its Review checklist as your rubric.
+   Confirm the project targets Avalonia 12+ before applying shared-size guidance;
+   if 11.x, say the scheme does not apply and stop.
+2. Read the target AXAML (and its code-behind/styles if alignment depends on them).
+   Use Grep to locate: Width="*", IsSharedSizeScope, SharedSizeGroup, HorizontalAlignment="Left"
+   on cards, ColumnDefinitions="Auto,Auto", TextAlignment="Right", CanResize, SizeToContent,
+   MinHeight, per-child Margin on rows, NumericUpDown/ColorPicker/ComboBox widths.
+3. Walk every checklist item. Mark PASS / FAIL / NEEDS-RUNTIME.
+   - NEEDS-RUNTIME for anything only provable in a rendered window: arrows on one line,
+     no clipping or dead space at 125%/150% scaling, real card-width equality.
+   - For NEEDS-RUNTIME items, state the exact thing to look at in a screenshot.
+4. For each FAIL: cite the file:line, name the exact failure mode in the user's terms
+   (ragged card width / misaligned control column / inconsistent right-alignment /
+   oversized gap / clipping / grouped by control-type), and give the one-line AXAML fix
+   from the skill (e.g. "Width='*' label col at line N -> Width='Auto' SharedSizeGroup='SettingLabel'").
+
+Rules:
+- Be opinionated and concrete; cite line numbers. No fluff, no praise.
+- Do not invent problems to fill the checklist; PASS is a valid verdict.
+- Distinguish what you proved from AXAML vs what needs a runtime screenshot.
+- Output: (1) one-line verdict, (2) the checklist as a PASS/FAIL/NEEDS-RUNTIME table,
+  (3) a prioritized fix list (must-fix first), (4) the runtime-verification list.

--- a/.claude/skills/avalonia-form-layout/SKILL.md
+++ b/.claude/skills/avalonia-form-layout/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: avalonia-form-layout
+description: Use when building or reviewing Avalonia settings, preferences, options, or editor windows, forms, dialogs, property panes, or any AXAML where labels and controls must align across groups. Triggers on control alignment, ragged card widths, shared label/control columns, right-alignment consistency, numeric-input alignment, and dialog sizing/clipping. Avalonia 12+ (uses Grid shared-size scope + ColumnSpacing/RowSpacing).
+---
+
+# Avalonia form & settings-window layout
+
+How to design and audit desktop settings/editor windows in Avalonia so labels and controls form clean vertical scan lines, cards are uniform width, and nothing clips under DPI scaling.
+
+**Version assumption:** Avalonia 12 (verified on 12.0.4: `IsSharedSizeScopeProperty`, `SharedSizeGroupProperty`, `Grid.ColumnSpacing`/`RowSpacing` all present). On Avalonia 11.x there is no shared-size mechanism and this entire scheme changes — do not apply it there.
+
+## Core mechanism in one sentence
+
+Independent row `Grid`s align their columns to one shared width **only** when they sit inside a `Grid.IsSharedSizeScope="True"` boundary and their `ColumnDefinition`s carry a matching `SharedSizeGroup` on `Width="Auto"` (never `Width="*"`). That single fact resolves ragged labels, drifting controls and stranded font-size selectors at once.
+
+## Core rules
+
+Must:
+
+- **One scope per co-visible surface** — put `Grid.IsSharedSizeScope="True"` on the single container that holds all rows that must align; one scope for a single scroll, one per tab if tabbed (cross-surface alignment is impossible and pointless once surfaces are not co-visible).
+- **One column grammar, reused verbatim** in every row grid: `[Auto SettingLabel] [Auto SettingControl] [Auto WeightCol] [Auto ItalicCol] [* spacer]`; simple rows fill cols 0–1, unused Auto cols collapse to zero (one grammar is what makes label/control/right-alignment complaints collapse into a single fix).
+- **Label columns are `Width="Auto"` with `SharedSizeGroup`, never `Width="*"`** — `SharedSizeGroup` is silently ignored on Star columns, so a Star label column resolves per-card and that *is* the misalignment.
+- **Cards stretch to one constrained container, not shrink-wrap** — `HorizontalAlignment="Stretch"` inside a `MaxWidth`-limited single-column container; remove any `HorizontalAlignment="Left"` on cards and abolish `Auto,Auto` masonry (shrink-wrapped cards have different right edges, which no shared-size group can bridge; uniform width is owned by the container).
+- **Every primary control shares the `SettingControl` column** — standalone `NumericUpDown`, `ColorPicker`, font-family `ComboBox`, *and* the font-table Size `NumericUpDown` all sit in col 1; Weight/Italic extend rightward (this is what puts the font Size selector directly under every other numeric).
+- **Left-anchor controls in their shared columns with fixed widths** — `HorizontalAlignment="Left"` + fixed `Width`; push slack into the trailing Star spacer (pinning to a card's right edge re-creates the ragged-edge bug; a shared left edge gives one predictable scan line).
+- **Fixed `Width` on every control type** — `NumericUpDown` 116 + `HorizontalContentAlignment="Right"`, `ColorPicker` ~200, Weight `ComboBox` 120, font-family `ComboBox` 220, Italic `CheckBox` auto; never auto-size to content (a value of 8 vs 1000 must not move the column). Note: the `SettingControl` column resolves to the **widest** member — with these numbers that is the 220 font-family combo, so set all primaries to one width if you want the column driven by a specific control.
+- **Alignment via `HorizontalAlignment`/`HorizontalContentAlignment`, not `TextBlock TextAlignment="Right"`** inside a shared column; verify in the running app, not the previewer (a reported Avalonia bug — issue #13777, treat as unverified — makes `TextAlignment="Right"` fail at runtime inside a shared-size column; the element-alignment guidance is correct regardless).
+- **Never put `Padding` on the `ScrollViewer`; put the inset on the scrollable child** (`Margin`/`Padding` on the inner `StackPanel`). `ScrollViewer.Padding` pads the content visually but is excluded from the scroll extent, so the last `Padding`-worth of content cannot be scrolled into view and the final row stays clipped behind a docked footer (confirmed Avalonia bug #12182, reproduces on 12.0.4). This bites silently: a top-anchored or non-scrolling render looks fine — only scrolling to the very end exposes it, so verify at the end of scroll, not just at the top.
+
+Should:
+
+- **Primary shape: one vertical, importance-ordered column of full-width cards.** It is strictly best for cross-feature Size alignment because both font sub-tables stay co-visible on one shared control line. Tabs/left-nav are an option for height relief, but tabs *dissolve* the cross-feature Size-alignment intent by hiding one table, they do not satisfy it — so only adopt tabs if the user accepts that.
+- **Resizable window, modest minimums** — `CanResize="True"`, `MinWidth` near design width, `MinHeight` ~480–600 (NOT the design height — a ~900 MinHeight itself clips a 150%-scaled laptop), `VerticalScrollBarVisibility="Auto"`, `HorizontalScrollBarVisibility="Disabled"`. Do **not** use `SizeToContent` here — with an inner vertical ScrollViewer it measures to infinity, the scroll never engages and the window can exceed the screen.
+- **Label column = longest label in scope + ~8–12px `ColumnSpacing`**; accept that short labels then sit further from their control (the documented cost of left-aligned labels). If a dense color table looks too sparse, switch those rows to top-aligned labels (gap zero) rather than stretching controls across the void.
+- **Pick scope breadth deliberately** — window-wide scope aligns the two font tables' Size selectors but inflates short-label gaps to the window's longest label; per-tab/per-card scope tightens gaps but drops cross-surface alignment.
+- **Centralize spacing as resources on an 8px module** (`x:Double`/`Thickness` keys) applied via `ColumnSpacing`/`RowSpacing`/`StackPanel.Spacing`, not scattered per-child `Margin`; intra-card spacing must be visibly tighter than inter-card spacing or grouping reads ambiguously.
+- **Group by feature, sub-sections as plain sub-headers** — keep one bordered card per feature; render Dimensions/Fonts/Cell-states as text sub-headers, not nested bordered cards-in-cards; rename generic headers like "Global" to what they theme ("Application theme" / "Shared colors").
+- **Restructure long flat color lists into a matrix** — e.g. Read-only/Disabled/Execution rows become a `Depth × {Current, Past}` grid instead of 20+ stacked single rows; this halves dialog height and is the main dead-space fix.
+- **Provide a Reset-to-defaults affordance** (per-section or global) — standard for a ~50-value settings editor.
+- **Define vertical alignment and tab order** — labels `VerticalAlignment="Center"` against taller `ColorPicker` rows; keep center/baseline consistent and decide how a top-aligned-label exception coexists with center-aligned neighbours in the same scope; set keyboard focus order to follow the new visual order.
+
+May:
+
+- **Accessibility (out of core complaint scope):** hit targets ≥24px, keep focus visuals, never encode state by color alone. For a dialog whose purpose is picking arbitrary theme colors, do not enforce a hard 4.5:1/3:1 rule — *warn/preview* contrast instead. (`tnum=1` tabular figures on numerics is cosmetic-only and does not reliably inherit into the inner TextBox — skip it; fixed width + right alignment already pin the arrows.)
+
+## Layout recipe for a settings window
+
+**Shape (primary).** One `ScrollViewer` (`HorizontalScrollBarVisibility="Disabled"`) over a single vertical `StackPanel` of full-width feature cards, importance-ordered. The panel carries `Grid.IsSharedSizeScope="True"`. Cap content width with a `MaxWidth` (~480–520px) container so label+gap+control fills the line; remaining window width is margin. A docked Save/Cancel/Reset footer sits in a separate `Grid.Row` below the scroll.
+
+*(Option — tabs)* `TabControl`, one pane per feature, each pane its own `ScrollViewer` + `Grid.IsSharedSizeScope="True"`. Use only if height relief outweighs losing cross-feature Size alignment.
+
+**Window:**
+
+```xml
+<Window CanResize="True"
+        MinWidth="860" MinHeight="560"
+        Width="900" Height="700">
+```
+
+**Scope placement** (the attached property goes on the parent once). The window inset lives on the inner `StackPanel`'s `Margin`, **not** on `ScrollViewer.Padding` (bug #12182 — padding on the ScrollViewer clips the last row at end-of-scroll):
+
+```xml
+<ScrollViewer HorizontalScrollBarVisibility="Disabled"
+              VerticalScrollBarVisibility="Auto">
+    <StackPanel Grid.IsSharedSizeScope="True"
+                Spacing="{StaticResource CardGap}"
+                Margin="20,16,20,20"
+                MaxWidth="520"
+                HorizontalAlignment="Stretch">
+        <!-- feature cards here -->
+    </StackPanel>
+</ScrollViewer>
+```
+
+**The canonical column grammar** — `SharedSizeGroup` requires long-form `ColumnDefinition`s (the `ColumnDefinitions="Auto,Auto,*"` shorthand cannot carry it). Reuse this verbatim in every row grid:
+
+```xml
+<Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}">
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel"/>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl"/>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol"/>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol"/>
+        <ColumnDefinition Width="*"/>
+    </Grid.ColumnDefinitions>
+
+    <!-- simple row: label + one control, cols 2-3 collapse to zero -->
+    <TextBlock Grid.Column="0" Text="Row height"
+               VerticalAlignment="Center"/>
+    <NumericUpDown Grid.Column="1" Width="{StaticResource ControlWidth}"
+                   HorizontalAlignment="Left"
+                   HorizontalContentAlignment="Right"/>
+</Grid>
+```
+
+**Font sub-table** — same grammar, the cluster extends rightward; Size stays in `SettingControl` so it lines up with every simple numeric:
+
+```xml
+<Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}">
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel"/>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl"/>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol"/>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol"/>
+        <ColumnDefinition Width="*"/>
+    </Grid.ColumnDefinitions>
+
+    <TextBlock Grid.Column="0" Text="Header font" VerticalAlignment="Center"/>
+    <NumericUpDown Grid.Column="1" Width="{StaticResource ControlWidth}"
+                   HorizontalAlignment="Left" HorizontalContentAlignment="Right"/>
+    <ComboBox Grid.Column="2" Width="{StaticResource WeightWidth}"
+              HorizontalAlignment="Left"/>
+    <CheckBox Grid.Column="3" Content="Italic" HorizontalAlignment="Left"/>
+</Grid>
+```
+
+**Spacing & width tokens** (centralize the magic numbers, 8px module):
+
+```xml
+<x:Double x:Key="ControlWidth">116</x:Double>
+<x:Double x:Key="ColorWidth">200</x:Double>
+<x:Double x:Key="WeightWidth">120</x:Double>
+<x:Double x:Key="FontFamilyWidth">220</x:Double>
+<x:Double x:Key="LabelGap">12</x:Double>
+<x:Double x:Key="RowGap">6</x:Double>
+<x:Double x:Key="CardGap">14</x:Double>
+```
+
+**Card style** — stretch, no shrink-wrap, no nested cards:
+
+```xml
+<Style Selector="Border.section-card">
+    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+    <Setter Property="Padding" Value="16"/>
+    <!-- sub-sections inside are plain TextBlock sub-headers, not Borders -->
+</Style>
+```
+
+**Color list → matrix** (replaces long flat row stacks): a single grid with one `SharedSizeGroup` label column on the left and `{Current, Past}` (or state) columns of fixed-width `ColorPicker`s, so 20 stacked rows become ~10 and pickers align in two clean columns.
+
+## Review checklist
+
+Audit an existing settings window against these. Each line is pass/fail; verify in the **running app** under 100/125/150% Windows scaling, not the previewer.
+
+Structure & width:
+- [ ] No `Auto,Auto` (or any masonry) outer grid; sections are one vertical column (or tabs).
+- [ ] No card has `HorizontalAlignment="Left"`; all cards `Stretch` to one `MaxWidth` container — **all card widths equal**.
+- [ ] No nested bordered cards-in-cards; sub-sections are plain sub-headers.
+- [ ] Grouping is by feature, not by control type; no generic "General"/"Global" headers.
+
+Shared columns:
+- [ ] Exactly one `Grid.IsSharedSizeScope="True"` per co-visible surface.
+- [ ] No label column uses `Width="*"`; all are `Width="Auto"` + `SharedSizeGroup`.
+- [ ] Every row grid uses the identical column grammar / group names.
+- [ ] All labels sit on one vertical line; all primary controls' left edges on one vertical line.
+
+Controls:
+- [ ] Every control has a fixed `Width` (no auto-to-content); numerics 116 + right content alignment.
+- [ ] Controls are `HorizontalAlignment="Left"` in their shared column, **not** pinned to the card's right edge.
+- [ ] Every numeric spinner arrow — including the font-table **Size** — lands on one vertical line.
+- [ ] Color-picker right edges aligned in their own column/matrix.
+- [ ] No `TextBlock TextAlignment="Right"` inside a shared-size column.
+
+Spacing & alignment:
+- [ ] Intra-card spacing visibly tighter than inter-card gap.
+- [ ] Label↔control gap minimal at the longest label; no oversized voids except the accepted short-label cost (or top-aligned labels in dense tables).
+- [ ] Spacing/widths come from shared resources, not scattered per-child `Margin`.
+- [ ] Labels vertically centered against taller (color-picker) rows; consistent baseline.
+
+Window & sizing:
+- [ ] `CanResize="True"`; `MinHeight` modest (~480–600), **not** the design height.
+- [ ] No `SizeToContent` combined with an inner vertical scroll.
+- [ ] No `Padding` on the `ScrollViewer` — inset is on the inner content's `Margin` (bug #12182); confirm the **last row scrolls fully clear of the footer**, checked at end-of-scroll.
+- [ ] Horizontal scroll disabled; vertical auto.
+- [ ] **No horizontal clipping and no large dead space at 125% and 150% scaling.**
+- [ ] Footer (Save/Cancel/Reset) stays docked below the scroll; a Reset-to-defaults affordance exists.
+
+Long lists & extras:
+- [ ] Long flat color/state lists restructured into a matrix where applicable.
+- [ ] Keyboard tab order follows the new visual order.
+- [ ] Color state never conveyed by color alone; contrast warned/previewed (not hard-blocked).
+
+## References
+
+- Avalonia `SharedSizeGroup` / `IsSharedSizeScope` docs; Avalonia issue #13777 (TextAlignment-in-shared-column, unverified); Avalonia ScrollViewer infinite-width pitfall (issue #5020); Avalonia issue #12182 (ScrollViewer.Padding clips content / not scrollable to end — put inset on the child).
+- WPF Shared Size Group model (same semantics).
+- JetBrains UI Guidelines: groups of controls, align right borders of inputs, ">2 dialog heights → tabs", group headers (avoid "General"/"Global").
+- WinUI settings (single column, scrollable if necessary); macOS preferences panes; GNOME Boxed Lists; KDE settings sidebar.
+- NN/g Common Region & proximity; Penzo / UXmatters eye-tracking on label alignment; Wroblewski label-alignment tradeoffs; Kontur 8px module & false-relationships.
+- WCAG 2.2 SC 2.5.8 (target size), 2.4.11 (focus visible).

--- a/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml
+++ b/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml
@@ -4,14 +4,16 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:styleEditor="clr-namespace:SemiStep.UI.StyleEditor"
         mc:Ignorable="d"
-        d:DesignWidth="860"
-        d:DesignHeight="820"
+        d:DesignWidth="720"
+        d:DesignHeight="780"
         x:Class="SemiStep.UI.StyleEditor.GridStyleEditorWindow"
         x:DataType="styleEditor:GridStyleEditorViewModel"
         Title="Grid Style Settings"
-        Width="880"
-        Height="900"
-        CanResize="False"
+        MinWidth="680"
+        MinHeight="520"
+        Width="720"
+        Height="780"
+        CanResize="True"
         WindowStartupLocation="CenterOwner">
 
     <Window.Resources>
@@ -21,6 +23,14 @@
         <DataTemplate x:Key="FontFamilyItemTemplate" x:DataType="styleEditor:FontFamilyOption">
             <TextBlock Text="{Binding Name}" />
         </DataTemplate>
+
+        <x:Double x:Key="ControlWidth">116</x:Double>
+        <x:Double x:Key="ColorWidth">200</x:Double>
+        <x:Double x:Key="WeightWidth">120</x:Double>
+        <x:Double x:Key="FontFamilyWidth">200</x:Double>
+        <x:Double x:Key="LabelGap">12</x:Double>
+        <x:Double x:Key="RowGap">6</x:Double>
+        <x:Double x:Key="CardGap">14</x:Double>
     </Window.Resources>
 
     <Window.Styles>
@@ -28,438 +38,499 @@
             <Setter Property="BorderBrush" Value="{DynamicResource SubtleBorderBrush}" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="6" />
-            <Setter Property="Padding" Value="14,10,14,12" />
-            <Setter Property="Margin" Value="0,0,0,14" />
+            <Setter Property="Padding" Value="16" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}" />
         </Style>
         <Style Selector="TextBlock.card-header">
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="FontSize" Value="14" />
-            <Setter Property="Margin" Value="0,0,0,8" />
+            <Setter Property="FontSize" Value="15" />
+        </Style>
+        <Style Selector="TextBlock.sub-header">
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Margin" Value="0,4,0,0" />
         </Style>
         <Style Selector="TextBlock.field-label">
             <Setter Property="VerticalAlignment" Value="Center" />
-            <Setter Property="Margin" Value="0,3,12,3" />
-        </Style>
-        <Style Selector="ColorPicker">
-            <Setter Property="HorizontalAlignment" Value="Left" />
-            <Setter Property="Margin" Value="0,2,0,2" />
-        </Style>
-        <Style Selector="NumericUpDown">
-            <Setter Property="HorizontalAlignment" Value="Left" />
-            <Setter Property="MinWidth" Value="90" />
-            <Setter Property="Margin" Value="0,2,0,2" />
         </Style>
         <Style Selector="TextBlock.col-head">
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="Margin" Value="0,0,0,6" />
             <Setter Property="VerticalAlignment" Value="Bottom" />
         </Style>
+        <Style Selector="NumericUpDown">
+            <Setter Property="Width" Value="{StaticResource ControlWidth}" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="HorizontalContentAlignment" Value="Right" />
+        </Style>
+        <Style Selector="ColorPicker">
+            <Setter Property="Width" Value="{StaticResource ColorWidth}" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+        </Style>
         <Style Selector="ComboBox.weight-picker">
-            <Setter Property="MinWidth" Value="120" />
-            <Setter Property="Margin" Value="10,2,0,2" />
+            <Setter Property="Width" Value="{StaticResource WeightWidth}" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
         </Style>
         <Style Selector="CheckBox.italic-check">
             <Setter Property="VerticalAlignment" Value="Center" />
-            <Setter Property="Margin" Value="14,0,0,0" />
         </Style>
     </Window.Styles>
 
     <Grid RowDefinitions="*,Auto">
 
-        <ScrollViewer Grid.Row="0" Padding="16,14,16,14" HorizontalScrollBarVisibility="Disabled">
-            <Grid ColumnDefinitions="*,*" Grid.IsSharedSizeScope="True">
+        <ScrollViewer Grid.Row="0"
+                      HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Auto">
+            <StackPanel Grid.IsSharedSizeScope="True"
+                        Spacing="{StaticResource CardGap}"
+                        Margin="20,16,20,20"
+                        MaxWidth="640"
+                        HorizontalAlignment="Stretch">
 
-                <!-- ===== Left column ===== -->
-                <StackPanel Grid.Column="0" Margin="0,0,7,0" Orientation="Vertical">
+                <!-- ===== Card 1 — Recipe grid ===== -->
+                <Border Classes="section-card">
+                    <StackPanel Spacing="8">
+                        <TextBlock Classes="card-header" Text="Recipe grid" />
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Fonts" />
-                            <Grid RowDefinitions="Auto" Margin="0,0,0,10">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FontLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Classes="field-label" Text="Font family" />
-                                <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
-                                          ItemsSource="{Binding AvailableFontFamilies}"
-                                          ItemTemplate="{StaticResource FontFamilyItemTemplate}"
-                                          SelectedValueBinding="{Binding Value}"
-                                          SelectedValue="{Binding FontFamily}" />
-                            </Grid>
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FontLabel" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
-                                <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Margin="10,0,0,6" Text="Weight" />
-                                <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Margin="14,0,0,6" Text="Italic" />
+                        <!-- Dimensions -->
+                        <TextBlock Classes="sub-header" Text="Dimensions" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Row height" />
+                            <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="12" Maximum="400" Increment="1"
+                                           Value="{Binding RowHeight}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Cell padding left" />
+                            <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                           Value="{Binding CellPaddingLeft}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Cell padding top" />
+                            <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                           Value="{Binding CellPaddingTop}" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Cell padding right" />
+                            <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                           Value="{Binding CellPaddingRight}" />
+                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Cell padding bottom" />
+                            <NumericUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                           Value="{Binding CellPaddingBottom}" />
+                        </Grid>
 
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid header" />
-                                <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                               Value="{Binding HeaderFontSize}" />
-                                <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
-                                          ItemsSource="{Binding AvailableFontWeights}"
-                                          ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                          SelectedValueBinding="{Binding Value}"
-                                          SelectedValue="{Binding HeaderFontWeight}" />
-                                <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
-                                          IsChecked="{Binding HeaderItalic}" />
+                        <!-- Fonts -->
+                        <TextBlock Classes="sub-header" Text="Fonts" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SizeCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
+                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Weight" />
+                            <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="Italic" />
 
-                                <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid cell" />
-                                <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                               Value="{Binding CellFontSize}" />
-                                <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
-                                          ItemsSource="{Binding AvailableFontWeights}"
-                                          ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                          SelectedValueBinding="{Binding Value}"
-                                          SelectedValue="{Binding CellFontWeight}" />
-                                <CheckBox Grid.Row="2" Grid.Column="3" Classes="italic-check"
-                                          IsChecked="{Binding CellItalic}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid header" />
+                            <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                           Value="{Binding HeaderFontSize}" />
+                            <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
+                                      ItemsSource="{Binding AvailableFontWeights}"
+                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      SelectedValue="{Binding HeaderFontWeight}" />
+                            <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
+                                      IsChecked="{Binding HeaderItalic}" />
 
-                                <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Status bar text" />
-                                <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                               Value="{Binding StatusBarFontSize}" />
-                                <ComboBox Grid.Row="3" Grid.Column="2" Classes="weight-picker"
-                                          ItemsSource="{Binding AvailableFontWeights}"
-                                          ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                          SelectedValueBinding="{Binding Value}"
-                                          SelectedValue="{Binding StatusBarFontWeight}" />
-                                <CheckBox Grid.Row="3" Grid.Column="3" Classes="italic-check"
-                                          IsChecked="{Binding StatusBarItalic}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid cell" />
+                            <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                           Value="{Binding CellFontSize}" />
+                            <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
+                                      ItemsSource="{Binding AvailableFontWeights}"
+                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      SelectedValue="{Binding CellFontWeight}" />
+                            <CheckBox Grid.Row="2" Grid.Column="3" Classes="italic-check"
+                                      IsChecked="{Binding CellItalic}" />
+                        </Grid>
 
-                                <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Timer label" />
-                                <NumericUpDown Grid.Row="4" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                               Value="{Binding StatusBarTimerLabelFontSize}" />
-                                <ComboBox Grid.Row="4" Grid.Column="2" Classes="weight-picker"
-                                          ItemsSource="{Binding AvailableFontWeights}"
-                                          ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                          SelectedValueBinding="{Binding Value}"
-                                          SelectedValue="{Binding StatusBarTimerLabelFontWeight}" />
-                                <CheckBox Grid.Row="4" Grid.Column="3" Classes="italic-check"
-                                          IsChecked="{Binding StatusBarTimerLabelItalic}" />
+                        <!-- Colors -->
+                        <TextBlock Classes="sub-header" Text="Colors" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Grid background" />
+                            <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding GridBackground}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid border" />
+                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding GridBorder}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid line" />
+                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding GridLine}" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Header foreground" />
+                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding HeaderForeground}" />
+                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Selection background" />
+                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding SelectionBackground}" />
+                            <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selection foreground" />
+                            <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding SelectionForeground}" />
+                            <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Changed" />
+                            <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding CellChanged}" />
+                            <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Changed (selected)" />
+                            <ColorPicker Grid.Row="7" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding CellChangedSelected}" />
+                        </Grid>
 
-                                <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Timer value" />
-                                <NumericUpDown Grid.Row="5" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                               Value="{Binding StatusBarTimerValueFontSize}" />
-                                <ComboBox Grid.Row="5" Grid.Column="2" Classes="weight-picker"
-                                          ItemsSource="{Binding AvailableFontWeights}"
-                                          ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                          SelectedValueBinding="{Binding Value}"
-                                          SelectedValue="{Binding StatusBarTimerValueFontWeight}" />
-                                <CheckBox Grid.Row="5" Grid.Column="3" Classes="italic-check"
-                                          IsChecked="{Binding StatusBarTimerValueItalic}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                        <!-- Read-only cells -->
+                        <TextBlock Classes="sub-header" Text="Read-only cells" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
+                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Layout" />
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Row height" />
-                                <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="12" Maximum="400" Increment="1"
-                                               Value="{Binding RowHeight}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Cell padding left" />
-                                <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                               Value="{Binding CellPaddingLeft}" />
-                                <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Cell padding top" />
-                                <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                               Value="{Binding CellPaddingTop}" />
-                                <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Cell padding right" />
-                                <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                               Value="{Binding CellPaddingRight}" />
-                                <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Cell padding bottom" />
-                                <NumericUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                               Value="{Binding CellPaddingBottom}" />
-                                <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Status bar padding" />
-                                <NumericUpDown Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                               Value="{Binding StatusBarPadding}" />
-                                <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Status bar item spacing" />
-                                <NumericUpDown Grid.Row="6" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                               Value="{Binding StatusBarItemSpacing}" />
-                                <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Validation panel max height" />
-                                <NumericUpDown Grid.Row="7" Grid.Column="1" Minimum="20" Maximum="2000" Increment="10"
-                                               Value="{Binding ValidationPanelMaxHeight}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellDepth0}" />
+                            <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellDepth0Past}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellDepth1}" />
+                            <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellDepth1Past}" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellDepth2}" />
+                            <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellDepth2Past}" />
+                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellDepth3}" />
+                            <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellDepth3Past}" />
+                            <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selected" />
+                            <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellSelected}" />
+                            <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                            <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ReadOnlyCellForeground}" />
+                        </Grid>
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Disabled Cell Palette" />
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Depth 0" />
-                                <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellDepth0}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 1" />
-                                <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellDepth1}" />
-                                <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 2" />
-                                <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellDepth2}" />
-                                <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 3" />
-                                <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellDepth3}" />
-                                <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 0 (past)" />
-                                <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellDepth0Past}" />
-                                <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Depth 1 (past)" />
-                                <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellDepth1Past}" />
-                                <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Depth 2 (past)" />
-                                <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellDepth2Past}" />
-                                <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Depth 3 (past)" />
-                                <ColorPicker Grid.Row="7" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellDepth3Past}" />
-                                <TextBlock Grid.Row="8" Grid.Column="0" Classes="field-label" Text="Selected" />
-                                <ColorPicker Grid.Row="8" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellSelected}" />
-                                <TextBlock Grid.Row="9" Grid.Column="0" Classes="field-label" Text="Foreground" />
-                                <ColorPicker Grid.Row="9" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding DisabledCellForeground}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                        <!-- Disabled cells -->
+                        <TextBlock Classes="sub-header" Text="Disabled cells" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
+                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Read-Only Cell Palette" />
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Depth 0" />
-                                <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellDepth0}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 1" />
-                                <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellDepth1}" />
-                                <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 2" />
-                                <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellDepth2}" />
-                                <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 3" />
-                                <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellDepth3}" />
-                                <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 0 (past)" />
-                                <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellDepth0Past}" />
-                                <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Depth 1 (past)" />
-                                <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellDepth1Past}" />
-                                <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Depth 2 (past)" />
-                                <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellDepth2Past}" />
-                                <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Depth 3 (past)" />
-                                <ColorPicker Grid.Row="7" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellDepth3Past}" />
-                                <TextBlock Grid.Row="8" Grid.Column="0" Classes="field-label" Text="Selected" />
-                                <ColorPicker Grid.Row="8" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellSelected}" />
-                                <TextBlock Grid.Row="9" Grid.Column="0" Classes="field-label" Text="Foreground" />
-                                <ColorPicker Grid.Row="9" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ReadOnlyCellForeground}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellDepth0}" />
+                            <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellDepth0Past}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellDepth1}" />
+                            <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellDepth1Past}" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellDepth2}" />
+                            <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellDepth2Past}" />
+                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellDepth3}" />
+                            <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellDepth3Past}" />
+                            <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selected" />
+                            <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellSelected}" />
+                            <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                            <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding DisabledCellForeground}" />
+                        </Grid>
 
-                    <Border Height="32" />
+                        <!-- Execution highlight -->
+                        <TextBlock Classes="sub-header" Text="Execution highlight" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
+                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
 
-                </StackPanel>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionDepth0}" />
+                            <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionDepth0Past}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionDepth1}" />
+                            <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionDepth1Past}" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionDepth2}" />
+                            <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionDepth2Past}" />
+                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionDepth3}" />
+                            <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionDepth3Past}" />
+                            <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Current step marker" />
+                            <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ExecutionCurrentStepMarker}" />
+                        </Grid>
+                    </StackPanel>
+                </Border>
 
-                <!-- ===== Right column ===== -->
-                <StackPanel Grid.Column="1" Margin="7,0,0,0" Orientation="Vertical">
+                <!-- ===== Card 2 — Status bar ===== -->
+                <Border Classes="section-card">
+                    <StackPanel Spacing="8">
+                        <TextBlock Classes="card-header" Text="Status bar" />
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Selection" />
-                            <Grid RowDefinitions="Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Selection background" />
-                                <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding SelectionBackground}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Selection foreground" />
-                                <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding SelectionForeground}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                        <!-- Dimensions -->
+                        <TextBlock Classes="sub-header" Text="Dimensions" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Padding" />
+                            <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                           Value="{Binding StatusBarPadding}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Item spacing" />
+                            <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                           Value="{Binding StatusBarItemSpacing}" />
+                        </Grid>
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Changed Cells" />
-                            <Grid RowDefinitions="Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Changed" />
-                                <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding CellChanged}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Changed (selected)" />
-                                <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding CellChangedSelected}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                        <!-- Fonts -->
+                        <TextBlock Classes="sub-header" Text="Fonts" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SizeCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
+                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Weight" />
+                            <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="Italic" />
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Execution Palette" />
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Depth 0" />
-                                <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionDepth0}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 1" />
-                                <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionDepth1}" />
-                                <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 2" />
-                                <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionDepth2}" />
-                                <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 3" />
-                                <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionDepth3}" />
-                                <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 0 (past)" />
-                                <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionDepth0Past}" />
-                                <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Depth 1 (past)" />
-                                <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionDepth1Past}" />
-                                <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Depth 2 (past)" />
-                                <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionDepth2Past}" />
-                                <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Depth 3 (past)" />
-                                <ColorPicker Grid.Row="7" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionDepth3Past}" />
-                                <TextBlock Grid.Row="8" Grid.Column="0" Classes="field-label" Text="Current step marker" />
-                                <ColorPicker Grid.Row="8" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ExecutionCurrentStepMarker}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Text" />
+                            <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                           Value="{Binding StatusBarFontSize}" />
+                            <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
+                                      ItemsSource="{Binding AvailableFontWeights}"
+                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      SelectedValue="{Binding StatusBarFontWeight}" />
+                            <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
+                                      IsChecked="{Binding StatusBarItalic}" />
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Grid Lines and Status Bar" />
-                            <Grid RowDefinitions="Auto,Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Grid line" />
-                                <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding GridLine}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Status bar background" />
-                                <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding StatusBarBackground}" />
-                                <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Status bar foreground" />
-                                <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding StatusBarForeground}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Timer label" />
+                            <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                           Value="{Binding StatusBarTimerLabelFontSize}" />
+                            <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
+                                      ItemsSource="{Binding AvailableFontWeights}"
+                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      SelectedValue="{Binding StatusBarTimerLabelFontWeight}" />
+                            <CheckBox Grid.Row="2" Grid.Column="3" Classes="italic-check"
+                                      IsChecked="{Binding StatusBarTimerLabelItalic}" />
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Validation Panel" />
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
-                                <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ValidationPanelBackground}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
-                                <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ValidationPanelForeground}" />
-                                <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Error severity" />
-                                <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ValidationPanelError}" />
-                                <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Warning severity" />
-                                <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding ValidationPanelWarning}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Timer value" />
+                            <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                           Value="{Binding StatusBarTimerValueFontSize}" />
+                            <ComboBox Grid.Row="3" Grid.Column="2" Classes="weight-picker"
+                                      ItemsSource="{Binding AvailableFontWeights}"
+                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      SelectedValue="{Binding StatusBarTimerValueFontWeight}" />
+                            <CheckBox Grid.Row="3" Grid.Column="3" Classes="italic-check"
+                                      IsChecked="{Binding StatusBarTimerValueItalic}" />
+                        </Grid>
 
-                    <Border Classes="section-card">
-                        <StackPanel>
-                            <TextBlock Classes="card-header" Text="Application Chrome" />
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FieldLabel" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Info" />
-                                <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding Info}" />
-                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Connected" />
-                                <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding Connected}" />
-                                <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Disconnected" />
-                                <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding Disconnected}" />
-                                <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Panel background" />
-                                <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding PanelBackground}" />
-                                <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Panel header background" />
-                                <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding PanelHeaderBackground}" />
-                                <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Subtle border" />
-                                <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding SubtleBorder}" />
-                                <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Separator" />
-                                <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding Separator}" />
-                                <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Secondary foreground" />
-                                <ColorPicker Grid.Row="7" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding SecondaryForeground}" />
-                                <TextBlock Grid.Row="8" Grid.Column="0" Classes="field-label" Text="Grid border" />
-                                <ColorPicker Grid.Row="8" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding GridBorder}" />
-                                <TextBlock Grid.Row="9" Grid.Column="0" Classes="field-label" Text="Grid background" />
-                                <ColorPicker Grid.Row="9" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding GridBackground}" />
-                                <TextBlock Grid.Row="10" Grid.Column="0" Classes="field-label" Text="Header foreground" />
-                                <ColorPicker Grid.Row="10" Grid.Column="1" IsHexInputVisible="True"
-                                             Color="{Binding HeaderForeground}" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
+                        <!-- Colors -->
+                        <TextBlock Classes="sub-header" Text="Colors" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
+                            <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding StatusBarBackground}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding StatusBarForeground}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Connected" />
+                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding Connected}" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Disconnected" />
+                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding Disconnected}" />
+                        </Grid>
+                    </StackPanel>
+                </Border>
 
-                    <Border Height="32" />
+                <!-- ===== Card 3 — Notification panel ===== -->
+                <Border Classes="section-card">
+                    <StackPanel Spacing="8">
+                        <TextBlock Classes="card-header" Text="Notification panel" />
 
-                </StackPanel>
+                        <!-- Dimensions -->
+                        <TextBlock Classes="sub-header" Text="Dimensions" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Max height" />
+                            <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="20" Maximum="2000" Increment="10"
+                                           Value="{Binding ValidationPanelMaxHeight}" />
+                        </Grid>
 
-            </Grid>
+                        <!-- Colors -->
+                        <TextBlock Classes="sub-header" Text="Colors" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
+                            <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ValidationPanelBackground}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ValidationPanelForeground}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Info severity" />
+                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding Info}" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Error severity" />
+                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ValidationPanelError}" />
+                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Warning severity" />
+                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding ValidationPanelWarning}" />
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+                <!-- ===== Card 4 — Application theme ===== -->
+                <Border Classes="section-card">
+                    <StackPanel Spacing="8">
+                        <TextBlock Classes="card-header" Text="Application theme" />
+
+                        <!-- Typography -->
+                        <TextBlock Classes="sub-header" Text="Typography" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Font family" />
+                            <ComboBox Grid.Row="0" Grid.Column="1"
+                                      Width="{StaticResource FontFamilyWidth}"
+                                      HorizontalAlignment="Left"
+                                      ItemsSource="{Binding AvailableFontFamilies}"
+                                      ItemTemplate="{StaticResource FontFamilyItemTemplate}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      SelectedValue="{Binding FontFamily}" />
+                        </Grid>
+
+                        <!-- Shared colors -->
+                        <TextBlock Classes="sub-header" Text="Shared colors" />
+                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                              RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Panel background" />
+                            <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding PanelBackground}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Panel header background" />
+                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding PanelHeaderBackground}" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Subtle border" />
+                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding SubtleBorder}" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Separator" />
+                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding Separator}" />
+                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Secondary foreground" />
+                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                         Color="{Binding SecondaryForeground}" />
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+            </StackPanel>
         </ScrollViewer>
 
         <Border Grid.Row="1"
                 BorderThickness="0,1,0,0"
                 BorderBrush="{DynamicResource SubtleBorderBrush}"
-                Padding="16,10,16,12">
+                Background="{DynamicResource PanelBackgroundBrush}"
+                Padding="20,14,20,14">
             <Grid ColumnDefinitions="*,Auto">
                 <TextBlock Grid.Column="0"
                            Text="{Binding ErrorMessage}"


### PR DESCRIPTION
## Summary

Two related changes ship together: a principled redesign of the **Grid Style Settings** editor window, and the reusable **avalonia-form-layout** skill (plus a read-only reviewer agent) that the redesign was derived from and validated against.

### Editor redesign (`GridStyleEditorWindow.axaml`)
The old window used a two-column masonry of type-grouped cards with ragged widths, per-card right-pinned selectors, drifting numeric columns, and a fixed non-resizable size that clipped under DPI scaling. It is now:

- **One resizable, scrollable vertical column** of equal-width feature cards — *Recipe grid*, *Status bar*, *Notification panel*, *Application theme* — grouped by feature, with plain sub-headers (Dimensions / Fonts / Colors) instead of nested cards.
- **One `Grid.IsSharedSizeScope`** with a single column grammar, so every label sits on one left scan line and every primary control on one second scan line.
- **Color matrices**: Read-only / Disabled / Execution palettes are now `Depth × {Current, Past}` grids instead of 20+ stacked single rows.
- **Tight font rows**: the Size spinner uses a dedicated `SizeCol` group so the Weight dropdown sits directly after it, with no void, while the color pickers keep their width.
- **Resizable window** (`CanResize`, modest `MinHeight`, vertical scroll auto, horizontal disabled, no `SizeToContent`).
- The window inset lives on the inner panel `Margin`, **not** `ScrollViewer.Padding`, to avoid Avalonia [#12182](https://github.com/AvaloniaUI/Avalonia/issues/12182) (last row clipped and not scrollable to the end).

Layout-only change: every binding, both `DataTemplate`s, the footer, and the code-behind are preserved. 36/36 editor tests pass; verified by rendering the window (including scrolled to the end) under the local screenshot harness.

### `avalonia-form-layout` skill + `avalonia-ui-reviewer` agent
A research-backed, Avalonia-12-specific ruleset for settings/editor windows: the shared-size column grammar, single-column card shape, feature grouping, long-list-to-matrix restructuring, resizable-window sizing, and the `ScrollViewer.Padding` pitfall — with a checklist and a read-only auditor agent that applies it.

## Test plan
- `dotnet build SemiStep/SemiStep.UI/SemiStep.UI.csproj` — clean.
- `dotnet test --filter "FullyQualifiedName~GridStyleEditor"` — 36 passed.
- `dotnet format` (pre-commit) — clean.
- Visual: rendered top and end-of-scroll; uniform card widths, aligned scan lines, aligned matrix columns, last row clears the docked footer, no clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)