### PR TITLE
Visual design refresh toward IntelliJ look: Semi.Avalonia + native Segoe (#74)

### DIFF
--- a/.claude/skills/avalonia-form-layout/SKILL.md
+++ b/.claude/skills/avalonia-form-layout/SKILL.md
@@ -7,6 +7,8 @@ description: Use when building or reviewing Avalonia settings, preferences, opti
 
 How to design and audit desktop settings/editor windows in Avalonia so labels and controls form clean vertical scan lines, cards are uniform width, and nothing clips under DPI scaling.
 
+This skill is about **layout and alignment within one form**. For the visual *theme* — colors, fonts, corner radius, dark mode, the JetBrains/IntelliJ look via Semi.Avalonia + design tokens — use the companion `avalonia-visual-style` skill. They compose: visual-style picks the palette and control chrome; form-layout arranges the rows.
+
 **Version assumption:** Avalonia 12 (verified on 12.0.4: `IsSharedSizeScopeProperty`, `SharedSizeGroupProperty`, `Grid.ColumnSpacing`/`RowSpacing` all present). On Avalonia 11.x there is no shared-size mechanism and this entire scheme changes — do not apply it there.
 
 ## Core mechanism in one sentence

--- a/.claude/skills/avalonia-visual-style/SKILL.md
+++ b/.claude/skills/avalonia-visual-style/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: avalonia-visual-style
+description: Use when theming or restyling an Avalonia desktop app toward a JetBrains/IntelliJ "New UI" look (flat, dense, neutral grays, one restrained blue accent, light+dark). Covers the JetBrains Int UI design tokens (color ramps, typography, dimensions, radii), and how to realize them in Avalonia 12 via Semi.Avalonia + token overrides + Inter/JetBrains Mono + theme variants. Triggers on theme/palette/dark-mode/accent/font/corner-radius/design-token work. Distinct from avalonia-form-layout (which is about alignment/spacing inside a single form).
+---
+
+# Avalonia visual style — JetBrains/IntelliJ "New UI" look
+
+How to give an Avalonia 12 desktop app the IntelliJ "New UI" aesthetic: flat surfaces, neutral gray ramps, one restrained blue accent, dense fixed control sizing, small uniform rounding, Inter UI font + JetBrains Mono, with a clean path to dark mode. Layout/alignment of an individual form is the separate `avalonia-form-layout` skill — use both together when building a settings window.
+
+**Version assumption:** Avalonia 12.0.x, Semi.Avalonia 12.0.x. Token resolution relies on `ThemeDictionaries` + `{DynamicResource}`, which exist in Avalonia 11+, but the package/key names here are verified on Avalonia 12.0.4 / Semi.Avalonia 12.0.3.
+
+## The two-layer model
+
+1. **Design tokens** — JetBrains' own values (below), grouped as a named palette → semantic roles → component usage. Never hardcode a hex at a control; map it to a role.
+2. **Avalonia realization** — a vendor base theme (Semi.Avalonia) supplies control templates; you retint it by **overriding the `DynamicResource` keys its ControlThemes consume**, per theme variant. You do not fork or retemplate to recolor.
+
+## JetBrains Int UI design tokens
+
+All hex below are from JetBrains' own `expUI_light.theme.json` / `expUI_dark.theme.json` (intellij-community) and component metrics from Jewel (`IntUiGlobalMetrics.kt`, `IntUiGlobalColors.kt`). They are the real values, not an approximation.
+
+### Accent — one blue, restrained
+
+`#3574F0` in **both** light and dark (the ramp shifts so the mid index lands on the same hex). Pressed: light `#315FBD`, dark `#375FAD`. Blue is used **only** for: the single default/primary action, focus rings, links, selection. Everything else is neutral gray. One accent button per dialog.
+
+### Neutral gray ramp (the backbone)
+
+| Role | Light | Dark |
+|---|---|---|
+| primary text | `#000000` | `#DFE1E5` |
+| secondary / caption text | `#818594` | `#6F737A` |
+| disabled text | `#A8ADBD` | `#5A5D63` |
+| default border | `#EBECF0` | `#1E1F22` |
+| divider / hairline | `#EBECF0` | `#393B40` |
+| input background / surface | `#FFFFFF` | `#2B2D30` |
+| panel / tool-window background | `#F7F8FA` | `#2B2D30` |
+| editor / content background | `#FFFFFF` | `#1E1F22` |
+| input border (rest) | `#C9CCD6` | `#43454A` |
+| window chrome | `#F0F1F5` | `#35363B` |
+
+Key dark surfaces to remember: editor `#1E1F22`, panel `#2B2D30`, primary text `#DFE1E5`, border `#1E1F22`.
+
+### Semantic colors (light / dark)
+
+| Role | Light | Dark |
+|---|---|---|
+| error text | `#DB3B4B` | `#DB5C5C` |
+| success | `#208A3C` | `#5FAD65` |
+| warning | `#FFAF0F` | `#F2C55C` |
+| link / focus ring | `#3574F0` | `#3574F0` |
+
+### Typography
+
+- **UI font: Inter**, base size **13** on every OS. Define all other sizes relative to 13: H1 = +5 (≈18), H2 = +3 (≈16), help/caption = −1 (≈12). **Semibold (600)** for dialog/popup/section headers, regular for body.
+- **Editor font: JetBrains Mono**; line numbers −1.
+- Both are **SIL OFL 1.1** — free to embed and ship commercially; keep the OFL.txt beside the bundled files.
+- Never hardcode a size; express as 13 ± constant.
+
+### Dimensions & density (dp ≈ px @100%)
+
+- **List/tree/combo row height = 24.** This is the density unit.
+- **Button** min `72×28`, padding h12 v6, border 1.
+- **Text field** min `144×28`, padding h9.
+- **Combo box** min `49×24`, padding h6 v2.
+- **Checkbox** touch `24×24`, visible box `16×16`.
+- **Focus outline width = 2.**
+- **Corner radius = 4, uniform** across button / text field / combo / dropdown. Checkbox box 3 (unchecked) → 4.5 (checked). Borders 1. This is the whole "flat, slightly rounded" feel.
+
+### Five principles (the soul, not the hex)
+
+1. **One named palette drives everything** — discrete Gray/Blue/Red/Green/Yellow ramps, separate Light/Dark, reached through semantic roles, never a literal color at a control. (platform-theme-colors)
+2. **Restrained single accent `#3574F0`** — blue only for the one primary action, focus, links, selection; all else neutral gray.
+3. **Dense, fixed control sizing** — 24px rows, 28px controls, small even paddings (6/9/12), 4px radius. Not airy, not cramped.
+4. **Settings = master-detail** — left category tree + right pane, left-aligned labels, ≤2 input columns, grouping by inset whitespace (see `avalonia-form-layout` for the right-pane mechanics).
+5. **Flat sections, not bordered cards** — separation is whitespace + a muted title-case header (~13px, secondary gray `#818594`), not a `Border` box. The "Islands" direction (default since 2025.3) adds *larger container radii (~8–12px) and more padding around major regions*, keeping the flat palette — but inside a dialog, sections stay flat and header-only.
+
+## Avalonia realization
+
+### Base theme — Semi.Avalonia
+
+Semi.Avalonia is the closest mainstream Avalonia theme to an IDE look (flat, neutral, small radii, one blue accent). It is not a JetBrains clone, but Semi + token overrides + Inter/JetBrains Mono gets visually close. **No ready-made JetBrains/IntelliJ Avalonia theme exists** — you assemble it.
+
+Packages (keep every `Semi.Avalonia*` on the same 12.0.x line; Semi 12.0.3 requires Avalonia ≥12.0.3, so 12.0.4 is fine):
+
+| Package | Purpose |
+|---|---|
+| `Semi.Avalonia` | base theme — replaces `<FluentTheme/>` |
+| `Semi.Avalonia.DataGrid` | replaces the Fluent DataGrid include |
+| `Semi.Avalonia.ColorPicker` | replaces the Fluent ColorPicker include |
+| `Avalonia.Fonts.Inter` | Inter UI font via `.WithInterFont()` |
+| (embed) JetBrains Mono `.ttf` | mono cells |
+
+`App.axaml` — drop the Fluent theme + Fluent control-theme includes, add Semi (app's own `DataGridStyles.axaml` stays **after** the Semi DataGrid theme so its Style setters win):
+
+```xml
+<Application xmlns:semi="https://irihi.tech/semi"
+             RequestedThemeVariant="Light">
+  <Application.Styles>
+    <semi:SemiTheme />
+    <semi:ColorPickerSemiTheme />
+    <semi:DataGridSemiTheme />
+    <!-- app overrides + DataGridStyles.axaml come after -->
+  </Application.Styles>
+</Application>
+```
+
+Semi ships Light + Dark (plus four custom variants); `RequestedThemeVariant="Light"|"Dark"` selects the standard two.
+
+### Token override — the retint mechanism
+
+Semi assigns brushes/dimensions via `{DynamicResource <Key>}` in its ControlThemes. Override by **redefining the same key at a higher scope** — live, no retemplate.
+
+Dimensions (single value) go straight in `Application.Resources`:
+
+```xml
+<Application.Resources>
+  <CornerRadius x:Key="ButtonCornerRadius">4</CornerRadius>
+</Application.Resources>
+```
+
+Colors go **per variant** in `ThemeDictionaries` (so light/dark stay correct), consumed via `DynamicResource`:
+
+```xml
+<Application.Resources>
+  <ResourceDictionary>
+    <ResourceDictionary.ThemeDictionaries>
+      <ResourceDictionary x:Key="Light">
+        <SolidColorBrush x:Key="SemiColorPrimary" Color="#3574F0"/>
+      </ResourceDictionary>
+      <ResourceDictionary x:Key="Dark">
+        <SolidColorBrush x:Key="SemiColorPrimary" Color="#3574F0"/>
+      </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+  </ResourceDictionary>
+</Application.Resources>
+```
+
+Semi's keys are three tiers; **retarget the semantic tier** for a whole-app shift:
+
+- Raw palette: `Semi{Color}{0..9}` (e.g. `SemiBlue3`).
+- **Semantic (retarget these):** `SemiColorPrimary`, `SemiColorText0..3`, `SemiColorFill0..2`, `SemiColorBackground0..3`, `SemiColorBorder`, `SemiColorDisabledText`, `SemiShadowElevated`.
+- Control keys: `ButtonCornerRadius`, `ButtonDefaultPrimaryForeground`, and DataGrid keys `DataGridCellBackground`, `DataGridCellMinHeight`, `DataGridRowBackground`, `DataGridRowSelectedBackground`, `DataGridRowPointeroverBackground`, `DataGridCellCurrentBorderBrush`, `DataGridCellFocusBorderBrush`.
+
+To find the exact key a control property uses, read that control's AXAML in the Semi repo (`/src/Semi.Avalonia/Controls/<Control>.axaml` for the setter; `/src/Semi.Avalonia/Themes/Shared/...` for the default value).
+
+**JetBrains → Semi semantic mapping (the core retint):**
+
+| JetBrains role | Semi key | Light | Dark |
+|---|---|---|---|
+| accent | `SemiColorPrimary` | `#3574F0` | `#3574F0` |
+| content bg | `SemiColorBackground0` | `#FFFFFF` | `#1E1F22` |
+| panel bg | `SemiColorBackground1` | `#F7F8FA` | `#2B2D30` |
+| primary text | `SemiColorText0` | `#000000` | `#DFE1E5` |
+| secondary text | `SemiColorText2` | `#818594` | `#6F737A` |
+| disabled text | `SemiColorDisabledText` | `#A8ADBD` | `#5A5D63` |
+| divider/border | `SemiColorBorder` | `#EBECF0` | `#393B40` |
+| radius (all) | `*CornerRadius` | `4` | `4` |
+
+(Verify each `SemiColorBackground*`/`Fill*` index against the shipped value before overriding — the index→surface mapping is Semi's, read it from the Palette demo or the variant token files in `Semi.Avalonia.Tokens.Palette`.)
+
+### Fonts
+
+URI is always `avares://Assembly/Path#Internal Family Name` — the `#name` is the font's **internal** metadata name, not the filename; omit it and the font silently falls back. Mark files `<AvaloniaResource Include="Assets/Fonts/*"/>`.
+
+- **Inter**: `dotnet add package Avalonia.Fonts.Inter`, `.WithInterFont()` in `BuildAvaloniaApp()`, reference `avares://Avalonia.Fonts.Inter/Assets#Inter` (a full `avares://` URI into the package — no XML-namespace prefix is declared for fonts).
+- **JetBrains Mono**: embed `JetBrainsMono-*.ttf` under `Assets/Fonts/`, declare inside `MergedDictionaries` (the documented workaround for fonts failing when declared bare in `Application.Resources`):
+  ```xml
+  <FontFamily x:Key="MonoFont">avares://YourApp/Assets/Fonts#JetBrains Mono</FontFamily>
+  ```
+- **App-wide default Inter** via the inherited `FontFamily` on a base `Window` style (`FontFamily` inherits down the tree):
+  ```xml
+  <Style Selector="Window"><Setter Property="FontFamily" Value="avares://Avalonia.Fonts.Inter/Assets#Inter"/></Style>
+  ```
+  Optionally also set `FontManagerOptions.DefaultFamilyName` for the framework's ultimate fallback. For grid numerics, `FontFeatures="+tnum"` gives tabular figures.
+
+### Dark mode
+
+- `RequestedThemeVariant` (on Application/Window/`ThemeVariantScope`) is the knob; `ActualThemeVariant` (inherited) is what styling resolves against. `"Default"` follows the OS.
+- Variant brushes live in `ThemeDictionaries` keyed `Light`/`Dark` and resolve **only via `{DynamicResource}`** — `{StaticResource}` throws unless the key also exists outside a theme dictionary. This is the cooperation rule.
+- To add dark later: flip `RequestedThemeVariant`, and split every app-owned token (the custom `ColorPalette.axaml` brushes) into Light/Dark `ThemeDictionaries`. Any override of Semi's own keys must likewise supply both variants. A config-driven palette tuned in light hex needs a parallel dark palette (or a derived darkening) — budget for it.
+
+### ControlTheme precedence (why overrides, not forks)
+
+Value precedence high→low: local/inline > **Style setter** (`Application.Styles`/`Window.Styles`, selector-gated) > **ControlTheme setter** (vendor default) > inherited > default. So a Style setter always beats a vendor ControlTheme setter for the same property. Three override options, least invasive first:
+
+1. Override the `DynamicResource` keys the vendor ControlTheme consumes (color/dimension) — smallest blast radius, preferred.
+2. Add a Style selector that sets the property directly — wins over the ControlTheme setter (how bespoke DataGrid cell theming survives a base-theme swap).
+3. Replace the whole ControlTheme (retemplate) — only when structure must change.
+
+### DataGrid reconciliation (when the app has bespoke cell theming)
+
+Swapping Fluent→Semi DataGrid is low-risk: Semi's `DataGridCell` ControlTheme sets `Background` to `DataGridCellBackground` as a **ControlTheme setter** and paints the cell visual with `Background="{TemplateBinding Background}"`. An app that sets cell `Background` via **Style** setters therefore still wins (same contract Fluent gives). Re-verify after the swap:
+
+- Row-level selection/hover (`DataGridRowSelectedBackground`, `DataGridRowPointeroverBackground`) is painted on a row `Border` beneath cells — it only shows through cells left at default background; opaque app cell backgrounds cover it. Neutralize those keys if a fully app-controlled look is wanted.
+- Current/focus is drawn as overlay Rectangles (`DataGridCellCurrentBorderBrush`, `DataGridCellFocusBorderBrush`); confirm they render cleanly at the configured row height (`DataGridCellMinHeight` now replaces the Fluent MinHeight floor).
+- Grid-line and MinHeight Style setters at `DataGrid` level survive; confirm Semi's denser default padding/borders don't double up.
+
+## Pitfalls
+
+- **`ThemeDictionaries` + `StaticResource` = runtime throw.** Variant brushes must be consumed with `DynamicResource`.
+- **Font without `#FamilyName` silently falls back.** Use the internal family name; wrap bare `Application.Resources` font declarations in `MergedDictionaries`.
+- **Semi's GitHub README version table is stale** (stops ~11.3.7). NuGet is the source of truth — pin all `Semi.Avalonia*` to one 12.0.x line.
+- **Don't fork the vendor theme to recolor.** Tokens + targeted Styles cover the retint; forking inherits maintenance of the whole template.
+- **Don't scatter hex at controls.** Map every color to a semantic key so dark mode is a dictionary swap, not a hunt.
+- **One accent only.** Resist coloring secondary actions; JetBrains' restraint is the look.
+
+## References
+
+- JetBrains tokens (authoritative): `intellij-community` `platform/platform-resources/src/themes/expUI/expUI_light.theme.json` / `expUI_dark.theme.json`; Jewel (`github.com/JetBrains/jewel`, Apache-2.0) for metrics/color mappings.
+- JetBrains guidelines: typography `plugins.jetbrains.com/docs/intellij/typography.html`; layout `…/layout.html`; theme colors `…/platform-theme-colors.html`; New UI `jetbrains.com/help/idea/new-ui.html`; Islands `blog.jetbrains.com/platform/2025/12/meet-the-islands-theme-…`.
+- Semi.Avalonia: `github.com/irihitech/Semi.Avalonia`; docs `docs.irihi.tech/semi`; resource customization `…/docs/basic/resource-customization` + `…/advanced/resource-customization`; NuGet `nuget.org/packages/Semi.Avalonia`.
+- Avalonia: themes `docs.avaloniaui.net/docs/styling/themes`; theme variants `…/theme-variants`; custom fonts `…/custom-fonts`.
+- Fonts: Inter `github.com/rsms/inter` (OFL-1.1); JetBrains Mono `jetbrains.com/lp/mono` (OFL-1.1).

--- a/Docs/architecture/grid-style-configuration.md
+++ b/Docs/architecture/grid-style-configuration.md
@@ -12,6 +12,26 @@ This file is the styling counterpart of `recipe-grid-column-sizing.md`: the sizi
 column's width is computed; this one explains where the style values (including the font sizes that
 feed that computation) come from and how they reach the screen.
 
+## Visual theme vs config palette (the theming contract)
+
+The app chrome (buttons, scrollbars, inputs, window surfaces) is themed by **Semi.Avalonia**, retinted
+toward JetBrains/IntelliJ "New UI" tokens — **Light variant only**. The retint is applied by overriding
+Semi's semantic-token keys (`SemiColorPrimary`, `SemiColorText0..3`, `SemiColorBackground0..3`,
+`SemiColorBorder`, `SemiColorDisabledText`, the `*CornerRadius` keys → 4) plus the static tokens in
+`Styles/ColorPalette.axaml`, all in `App.axaml`. The UI font is the native system Segoe UI (set via
+`ChromeFontFamily` in `Styles/ColorPalette.axaml`); the grid uses that same Segoe family with OpenType
+tabular figures (`+tnum`) so digit columns align without a monospaced font. There are no embedded fonts
+(no `Assets/Fonts`).
+
+The boundary between that fixed theme and per-equipment config is exact: **the brush keys the two
+installers push from `grid_style.yaml`** (`CellPaletteInstaller`, `ExecutionPaletteInstaller`, listed in
+"Resources projection" below) are the config-driven palette — cell states, selection, execution tints,
+status bar, and app chrome. Everything else is the Semi-plus-overrides theme. Together those two — the
+installer brush keys and the Semi semantic-token overrides in `App.axaml` — are the theming contract: a
+config file restyles the grid/chrome palette through the installer keys without touching the base theme,
+and the base theme governs every control the installers do not reach. Dark mode is deferred; styles
+consume tokens via `DynamicResource` to stay dark-ready.
+
 ## YAML is the single source of truth
 
 `grid_style.yaml` is the only style file. The other config sections (`actions/`, `columns/`,
@@ -82,10 +102,11 @@ two timer roles, so the caption and the countdown can carry independent fonts. W
 the label renders at 14 and the value at 24 — they no longer share one size.
 
 - **Family** is a single `string` on the record (`GridStyleOptions.FontFamily`). The default is `""`,
-  meaning "theme default": consumers leave `FontFamily` unset so the Fluent theme's bundled font
-  (Inter) stays in place. A non-empty value sets the family for every role. The editor offers
-  `FontManager.Current.SystemFonts`; an unknown saved family falls back to the theme default rather
-  than failing.
+  meaning "grid default": consumers fall back to `GridFonts.DefaultFamily`
+  (`"Segoe UI Variable Text, Segoe UI"`, the same proportional Segoe as the app chrome) and render with
+  `GridFonts.TabularFigures` (the `tnum` feature) so digit columns stay aligned. A non-empty value sets
+  the family for every role. The editor offers `FontManager.Current.SystemFonts`; an unknown saved
+  family falls back to that Segoe default rather than failing.
 - **Weight** is stored as an `int` (100–900) in the record and YAML — culture-free and easy to
   validate. Consumers cast it to Avalonia's `FontWeight` enum.
 - **Italic** is a `bool`; consumers convert it to `FontStyle.Italic` / `FontStyle.Normal`.
@@ -110,14 +131,16 @@ roles set directly on the four timer `TextBlock`s):
 | `StatusBarTimerValueFontWeight` | `FontWeight` | `status_bar.timer_value_weight` |
 | `StatusBarTimerValueFontStyle` | `FontStyle` | `status_bar.timer_value_italic` |
 
-The grid roles are **code-assigned**, not resources: `ColumnBuilder`, `TextCellFactory`, and
-`ComboBoxCellFactory` set `FontFamily` / `FontWeight` / `FontStyle` / `FontSize` directly from the
-injected `GridStyleOptions` (the header's old hard-coded `FontWeight.Bold` is now
-`HeaderFontWeight`). When the family is empty they leave `FontFamily` unset. `ColumnWidthCalculator`
-builds its measuring `Typeface` from the same configured family/weight/italic so the measured width
-matches the rendered typeface (empty family → `FontFamily.Default` for measurement). The grid font
-keys are read in C# (see "Why the typed record cannot be replaced by raw resources"), so they have no
-resource projection.
+The grid roles are **code-assigned**, not resources: `GridFontApplier` (used by `ColumnBuilder`,
+`TextCellFactory`, and `ComboBoxCellFactory`) sets `FontFamily` / `FontWeight` / `FontStyle` /
+`FontSize` directly from the injected `GridStyleOptions` (the header's old hard-coded `FontWeight.Bold`
+is now `HeaderFontWeight`) and also sets `TextElement.FontFeaturesProperty` to `GridFonts.TabularFigures`.
+`ColumnBuilder` additionally sets that feature grid-wide so it reaches the `DataGridTextColumn`
+numbering cells through inheritance. When the family is empty they fall back to `GridFonts.DefaultFamily`.
+`ColumnWidthCalculator` builds its measuring `Typeface` from the same configured family/weight/italic and
+calls `FormattedText.SetFontFeatures(GridFonts.TabularFigures)` so the measured width matches the
+rendered cell (empty family → `GridFonts.DefaultFamily` for measurement). The grid font keys are read in
+C# (see "Why the typed record cannot be replaced by raw resources"), so they have no resource projection.
 
 ### YAML keys
 
@@ -191,7 +214,7 @@ restart is the simplest correct behavior for v1.
   `current-step` / `past-step` / `for-depth-1..3`, and depth-0 already renders default white
   (`#FFFFFF`), so a selector would be a no-op. The brush is installed; no selector is added.
 - **Removed fields.** Grid-line thickness, alternating-row background, and normal-row background were
-  dropped from the model, DTOs, mapper, and shipped configs. Avalonia's Fluent `DataGrid` exposes no
+  dropped from the model, DTOs, mapper, and shipped configs. Semi's `DataGrid` exposes no
   inner-gridline-thickness or alternating-row-background property, so they had no wire target.
 
 ## Known gap

--- a/SemiStep/Directory.Packages.props
+++ b/SemiStep/Directory.Packages.props
@@ -12,7 +12,6 @@
     <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.4"/>
     <PackageVersion Include="Avalonia.Headless" Version="12.0.4"/>
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.4"/>
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.4"/>
     <PackageVersion Include="Avalonia.Win32" Version="12.0.4"/>
     <PackageVersion Include="CsvHelper" Version="33.1.0"/>
     <PackageVersion Include="FluentAssertions" Version="8.10.0"/>
@@ -25,6 +24,9 @@
     <PackageVersion Include="NCalcSync" Version="5.12.0"/>
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.1"/>
     <PackageVersion Include="S7netplus" Version="0.20.0"/>
+    <PackageVersion Include="Semi.Avalonia" Version="12.0.3"/>
+    <PackageVersion Include="Semi.Avalonia.ColorPicker" Version="12.0.3"/>
+    <PackageVersion Include="Semi.Avalonia.DataGrid" Version="12.0.0"/>
     <PackageVersion Include="Serilog" Version="4.3.1"/>
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0"/>
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1"/>

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/ColumnWidthCalculatorTests.cs
@@ -427,7 +427,7 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 		var expectedDelta = (int)(ComboBoxChromeWidth - ContentChrome);
 
 		delta.Should().BeGreaterThan(0,
-			"the combo path budgets the wider Fluent ComboBox chrome, so the combo column exceeds the content column");
+			"the combo path budgets the wider Semi ComboBox chrome, so the combo column exceeds the content column");
 		delta.Should().Be(expectedDelta,
 			"the width gap between the two real outputs equals the chevron budget (ComboBoxChromeWidth - ContentChrome): "
 			+ "both chrome terms are integers and the two content measurements are identical, so there is no rounding divergence");
@@ -543,7 +543,7 @@ public sealed class ColumnWidthCalculatorTests : IAsyncLifetime
 
 	private static double MeasureText(string text, double fontSize, FontWeight fontWeight)
 	{
-		var typeface = new Typeface(FontFamily.Default, FontStyle.Normal, fontWeight);
+		var typeface = new Typeface(GridFonts.DefaultFamily, FontStyle.Normal, fontWeight);
 		var formattedText = new FormattedText(
 			text,
 			CultureInfo.CurrentCulture,

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/GridFactoryFontTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/GridFactoryFontTests.cs
@@ -63,14 +63,14 @@ public sealed class GridFactoryFontTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void NumberingColumn_EmptyFamily_LeavesFontFamilyUnset()
+	public void NumberingColumn_EmptyFamily_UsesChromeFontDefault()
 	{
 		var grid = BuildGrid(GridStyleOptions.Default with { FontFamily = "" });
 
 		var numberingColumn = (DataGridTextColumn)grid.Columns[0];
 
-		numberingColumn.FontFamily.Should().Be(FontFamily.Default,
-			"an empty family must leave the numbering column's FontFamily unset so the theme default applies");
+		numberingColumn.FontFamily.Should().Be(GridFonts.DefaultFamily,
+			"an empty family must fall back to the chrome font for the numbering column");
 	}
 
 	[AvaloniaFact]
@@ -110,7 +110,7 @@ public sealed class GridFactoryFontTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void EmptyFamily_LeavesFontFamilyUnset()
+	public void EmptyFamily_UsesChromeFontDefault()
 	{
 		var factory = new TextCellFactory(GridStyleOptions.Default with { FontFamily = "" });
 		var columnDef = _fixture.RecipeMetadataRegistry.GetColumn("task").Value;
@@ -119,8 +119,8 @@ public sealed class GridFactoryFontTests : IAsyncLifetime
 
 		var displayCell = (TextBlock)column.CellTemplate!.Build(null)!;
 
-		displayCell.IsSet(TextBlock.FontFamilyProperty).Should().BeFalse(
-			"an empty family must leave FontFamily unset so the theme default applies");
+		displayCell.FontFamily.Should().Be(GridFonts.DefaultFamily,
+			"an empty family must fall back to the chrome font for grid cells");
 	}
 
 	private GridStyleOptions NonDefaultStyle()

--- a/SemiStep/SemiStep.UI/App.axaml
+++ b/SemiStep/SemiStep.UI/App.axaml
@@ -1,18 +1,74 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:semi="https://irihi.tech/semi"
              x:Class="SemiStep.UI.App"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceInclude Source="avares://Semistep/Styles/ColorPalette.axaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <!-- Uniform 4px rounding on interactive controls. Semi's component radius keys alias
+                 SemiBorderRadiusSmall (3) via StaticResource, so the primitive cannot be retargeted;
+                 the component keys are overridden directly and consumed by templates via DynamicResource. -->
+            <CornerRadius x:Key="ButtonCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="TextBoxDefaultCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="ComboBoxSelectorCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="NumericUpDownCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="CheckBoxBoxCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="MenuItemCornerRadius">4</CornerRadius>
+
+            <!-- Kill Semi's row pointer-over "halo": its DataGridRow template paints an inset, rounded
+                 Border#BackgroundBorder with DataGridRowPointeroverBackground. The app paints cell
+                 backgrounds itself, so flatten the row corner radius to 0 (brushes neutralized in the
+                 Light ThemeDictionary below). -->
+            <CornerRadius x:Key="DataGridRowCornerRadius">0</CornerRadius>
+
+            <!-- JetBrains Int UI (Light) retint of Semi semantic tokens. Light variant only;
+                 the app runs RequestedThemeVariant="Light". Background0 = content/window surface,
+                 Background1 = the panel surface (the one role the app tints off white). -->
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="SemiColorPrimary" Color="#3574F0" />
+                    <SolidColorBrush x:Key="SemiColorText0" Color="#000000" />
+                    <SolidColorBrush x:Key="SemiColorText1" Color="#000000" Opacity="0.8" />
+                    <SolidColorBrush x:Key="SemiColorText2" Color="#818594" />
+                    <SolidColorBrush x:Key="SemiColorText3" Color="#A8ADBD" />
+                    <SolidColorBrush x:Key="SemiColorBackground1" Color="#F7F8FA" />
+                    <SolidColorBrush x:Key="SemiColorBorder" Color="#EBECF0" />
+                    <SolidColorBrush x:Key="SemiColorDisabledText" Color="#A8ADBD" />
+
+                    <!-- Neutralize Semi's row pointer-over highlight (the inset "halo"). Selection is
+                         painted at cell level by CellPaletteInstaller, so the selected-on-hover variant
+                         can also go transparent without losing the selection look. -->
+                    <SolidColorBrush x:Key="DataGridRowPointeroverBackground" Color="Transparent" />
+                    <SolidColorBrush x:Key="DataGridRowSelectedPointeroverBackground" Color="Transparent" />
+
+                    <!-- Black frame on the current/focused cell. Semi draws the CurrencyVisual/FocusVisual
+                         rectangles (Stroke = DataGridCellCurrentBorderBrush / DataGridCellFocusBorderBrush)
+                         in a light brush that does not read; retint black. -->
+                    <SolidColorBrush x:Key="DataGridCellCurrentBorderBrush" Color="#000000" />
+                    <SolidColorBrush x:Key="DataGridCellFocusBorderBrush" Color="#000000" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </Application.Resources>
     <Application.Styles>
-        <FluentTheme />
-        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
-        <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
+        <semi:SemiTheme />
+        <semi:ColorPickerSemiTheme />
+        <semi:DataGridSemiTheme />
+        <!-- Chrome input density. Placed before the DataGrid style include so DataGrid cell ComboBoxes
+             keep their own padding (set in DataGridStyles.axaml) under last-match-wins. -->
+        <Style Selector="ComboBox, NumericUpDown, TextBox">
+            <Setter Property="MinHeight" Value="26" />
+            <Setter Property="Padding" Value="8,3" />
+        </Style>
         <StyleInclude Source="avares://Semistep/Styles/DataGridStyles.axaml" />
+        <StyleInclude Source="avares://Semistep/Styles/Buttons.axaml" />
+        <Style Selector="Window">
+            <Setter Property="FontFamily" Value="{DynamicResource ChromeFontFamily}" />
+            <Setter Property="FontSize" Value="12" />
+        </Style>
     </Application.Styles>
 </Application>

--- a/SemiStep/SemiStep.UI/Dialogs/ErrorWindow.axaml
+++ b/SemiStep/SemiStep.UI/Dialogs/ErrorWindow.axaml
@@ -34,7 +34,7 @@
 
         <Button Grid.Row="2"
                 Content="Выход"
-                Width="80"
+                Classes="primary"
                 HorizontalAlignment="Right"
                 Margin="0,16,0,0"
                 Click="OnExitClick"

--- a/SemiStep/SemiStep.UI/Dialogs/MessageDialog.axaml
+++ b/SemiStep/SemiStep.UI/Dialogs/MessageDialog.axaml
@@ -25,7 +25,7 @@
 
         <Button Grid.Row="1"
                 Content="OK"
-                Width="80"
+                Classes="primary"
                 HorizontalAlignment="Right"
                 Margin="0,20,0,0"
                 Click="OnOkClick"

--- a/SemiStep/SemiStep.UI/Plc/PlcConflictDialog.axaml
+++ b/SemiStep/SemiStep.UI/Plc/PlcConflictDialog.axaml
@@ -38,10 +38,10 @@
                     Spacing="10"
                     Margin="0,20,0,0">
             <Button Content="Keep local"
-                    Width="100"
+                    Classes="primary"
                     Click="OnKeepLocalClick" />
             <Button Content="Load from PLC"
-                    Width="110"
+                    Classes="secondary"
                     Click="OnLoadFromPlcClick" />
         </StackPanel>
     </Grid>

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Layout;
@@ -29,6 +30,9 @@ public sealed class ColumnBuilder(
 	public void BuildColumns(DataGrid grid)
 	{
 		grid.RowHeight = gridStyle.RowHeight;
+		// The numbering column is a DataGridTextColumn with no FontFeatures property; tabular figures
+		// reach its generated cells through the inherited grid-level value set here.
+		grid.SetValue(TextElement.FontFeaturesProperty, GridFonts.TabularFigures);
 		grid.Columns.Clear();
 		AddNumberingColumn(grid);
 
@@ -54,10 +58,9 @@ public sealed class ColumnBuilder(
 			MinWidth = _widthCalculator.MinColumnWidth,
 			CanUserSort = false
 		};
-		if (!string.IsNullOrWhiteSpace(gridStyle.FontFamily))
-		{
-			column.FontFamily = new FontFamily(gridStyle.FontFamily);
-		}
+		column.FontFamily = string.IsNullOrWhiteSpace(gridStyle.FontFamily)
+			? GridFonts.DefaultFamily
+			: new FontFamily(gridStyle.FontFamily);
 
 		column.CellStyleClasses.Add(StepNumberColumnClass);
 		grid.Columns.Add(column);

--- a/SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ColumnWidthCalculator.cs
@@ -195,10 +195,10 @@ public sealed class ColumnWidthCalculator(
 		}
 	}
 
-	// Empty family means "theme default": measure with FontFamily.Default so the width matches the
-	// rendered cell, which also leaves its FontFamily unset.
+	// Empty family means "grid default": measure with the chrome font so the width matches the
+	// rendered cell, which also falls back to the chrome font.
 	private FontFamily MeasureFontFamily =>
-		string.IsNullOrWhiteSpace(gridStyle.FontFamily) ? FontFamily.Default : new FontFamily(gridStyle.FontFamily);
+		string.IsNullOrWhiteSpace(gridStyle.FontFamily) ? GridFonts.DefaultFamily : new FontFamily(gridStyle.FontFamily);
 
 	// The single typeface the cell-role measurement uses, threading the configured family, weight, and
 	// italic so the measured width tracks the rendered cell. Exposed for the measurement-threading test.
@@ -232,6 +232,10 @@ public sealed class ColumnWidthCalculator(
 			typeface,
 			fontSize,
 			Brushes.Black);
+
+		// Cells render with tabular figures (GridFontApplier/ColumnBuilder set tnum); measure with the
+		// same feature so digit-column auto-width matches the rendered advances.
+		formattedText.SetFontFeatures(GridFonts.TabularFigures);
 
 		return formattedText.WidthIncludingTrailingWhitespace;
 	}

--- a/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/ComboBoxCellFactory.cs
@@ -110,7 +110,7 @@ internal sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataR
 		}, supportsRecycling: true);
 	}
 
-	// FontSize explicit: the Fluent ComboBox selection box does not inherit the grid font, so without it
+	// FontSize explicit: the Semi ComboBox selection box does not inherit the grid font, so without it
 	// the text renders at the theme default and the chevron clips it. See Docs/architecture/recipe-grid-column-sizing.md.
 	private ComboBox CreateStyledComboBox()
 	{
@@ -119,6 +119,7 @@ internal sealed class ComboBoxCellFactory(RecipeMetadataRegistry recipeMetadataR
 			DisplayMemberBinding = new Binding(nameof(ComboBoxItemViewModel.DisplayText)),
 			HorizontalAlignment = HorizontalAlignment.Stretch,
 			VerticalAlignment = VerticalAlignment.Center,
+			MinHeight = 0,
 		};
 		GridFontApplier.ApplyCellFont(comboBox, gridStyle);
 

--- a/SemiStep/SemiStep.UI/RecipeGrid/GridFontApplier.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/GridFontApplier.cs
@@ -27,10 +27,12 @@ internal static class GridFontApplier
 		control.SetValue(TextElement.FontWeightProperty, (FontWeight)fontWeight);
 		control.SetValue(TextElement.FontStyleProperty, italic ? FontStyle.Italic : FontStyle.Normal);
 
-		// Empty family means "theme default": leave FontFamily unset so the Fluent default applies.
-		if (!string.IsNullOrWhiteSpace(fontFamily))
-		{
-			control.SetValue(TextElement.FontFamilyProperty, new FontFamily(fontFamily));
-		}
+		// Empty family means "grid default": fall back to the chrome font (system Segoe).
+		control.SetValue(
+			TextElement.FontFamilyProperty,
+			string.IsNullOrWhiteSpace(fontFamily) ? GridFonts.DefaultFamily : new FontFamily(fontFamily));
+
+		// Tabular figures so digit columns align under the proportional chrome font.
+		control.SetValue(TextElement.FontFeaturesProperty, GridFonts.TabularFigures);
 	}
 }

--- a/SemiStep/SemiStep.UI/RecipeGrid/GridFonts.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/GridFonts.cs
@@ -1,0 +1,15 @@
+﻿using Avalonia.Media;
+
+namespace SemiStep.UI.RecipeGrid;
+
+internal static class GridFonts
+{
+	// The recipe grid defaults to the chrome font (system Segoe), matching the rest of the app.
+	// A non-empty configured family from grid style options overrides this default.
+	public static readonly FontFamily DefaultFamily =
+		new("Segoe UI Variable Text, Segoe UI");
+
+	// Tabular figures (OpenType tnum) keep digit columns vertically aligned without a monospaced font.
+	public static readonly FontFeatureCollection TabularFigures =
+		new() { new FontFeature { Tag = "tnum", Value = 1 } };
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
@@ -128,7 +128,7 @@ internal sealed class TextCellFactory(GridStyleOptions gridStyle)
 				VerticalAlignment = VerticalAlignment.Center,
 				VerticalContentAlignment = VerticalAlignment.Center,
 				HorizontalAlignment = HorizontalAlignment.Stretch,
-				// The Fluent TextBox theme floors MinHeight at 32; on a shorter configured row that
+				// The Semi TextBox theme floors MinHeight at 32; on a shorter configured row that
 				// inflates the editing cell and pushes the text above the display position. Size to the row.
 				MinHeight = 0,
 				BorderThickness = new Thickness(0),

--- a/SemiStep/SemiStep.UI/SemiStep.UI.csproj
+++ b/SemiStep/SemiStep.UI/SemiStep.UI.csproj
@@ -16,7 +16,9 @@
     <PackageReference Include="Avalonia"/>
     <PackageReference Include="Avalonia.HarfBuzz"/>
     <PackageReference Include="Avalonia.Desktop"/>
-    <PackageReference Include="Avalonia.Themes.Fluent"/>
+    <PackageReference Include="Semi.Avalonia"/>
+    <PackageReference Include="Semi.Avalonia.DataGrid"/>
+    <PackageReference Include="Semi.Avalonia.ColorPicker"/>
     <PackageReference Include="ReactiveUI.Avalonia"/>
     <PackageReference Include="Avalonia.Controls.DataGrid"/>
     <PackageReference Include="Avalonia.Controls.ColorPicker"/>

--- a/SemiStep/SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml
+++ b/SemiStep/SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml
@@ -28,13 +28,13 @@
                     Spacing="10"
                     Margin="0,20,0,0">
             <Button Content="Save"
-                    Width="80"
+                    Classes="primary"
                     Click="OnSaveClick" />
             <Button Content="Don't Save"
-                    Width="90"
+                    Classes="secondary"
                     Click="OnDontSaveClick" />
             <Button Content="Cancel"
-                    Width="80"
+                    Classes="secondary"
                     Click="OnCancelClick"
                     IsCancel="True" />
         </StackPanel>

--- a/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml
+++ b/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml
@@ -24,30 +24,23 @@
             <TextBlock Text="{Binding Name}" />
         </DataTemplate>
 
-        <x:Double x:Key="ControlWidth">116</x:Double>
+        <x:Double x:Key="ControlWidth">72</x:Double>
         <x:Double x:Key="ColorWidth">200</x:Double>
         <x:Double x:Key="WeightWidth">120</x:Double>
         <x:Double x:Key="FontFamilyWidth">200</x:Double>
         <x:Double x:Key="LabelGap">12</x:Double>
         <x:Double x:Key="RowGap">6</x:Double>
-        <x:Double x:Key="CardGap">14</x:Double>
+        <x:Double x:Key="SectionGap">24</x:Double>
     </Window.Resources>
 
     <Window.Styles>
-        <Style Selector="Border.section-card">
-            <Setter Property="BorderBrush" Value="{DynamicResource SubtleBorderBrush}" />
-            <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="CornerRadius" Value="6" />
-            <Setter Property="Padding" Value="16" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}" />
-        </Style>
-        <Style Selector="TextBlock.card-header">
+        <Style Selector="TextBlock.section-header">
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="FontSize" Value="15" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{DynamicResource SemiColorText2}" />
         </Style>
         <Style Selector="TextBlock.sub-header">
-            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontWeight" Value="Medium" />
             <Setter Property="Margin" Value="0,4,0,0" />
         </Style>
         <Style Selector="TextBlock.field-label">
@@ -65,13 +58,30 @@
         <Style Selector="ColorPicker">
             <Setter Property="Width" Value="{StaticResource ColorWidth}" />
             <Setter Property="HorizontalAlignment" Value="Left" />
+            <!-- Semi's default ColorPicker swatch forces Width = Height, collapsing to a tiny square.
+                 Replace the content with a full-width color bar (checkered alpha base + color overlay). -->
+            <Setter Property="Content">
+                <Template>
+                    <Panel>
+                        <Border Margin="1" CornerRadius="{Binding $parent[ColorPicker].CornerRadius}"
+                                Background="{DynamicResource ColorControlCheckeredBackgroundBrush}" />
+                        <Border Margin="1" CornerRadius="{Binding $parent[ColorPicker].CornerRadius}">
+                            <Border.Background>
+                                <SolidColorBrush Color="{Binding $parent[ColorPicker].Color}" />
+                            </Border.Background>
+                        </Border>
+                    </Panel>
+                </Template>
+            </Setter>
         </Style>
         <Style Selector="ComboBox.weight-picker">
             <Setter Property="Width" Value="{StaticResource WeightWidth}" />
             <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
         <Style Selector="CheckBox.italic-check">
             <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
         </Style>
     </Window.Styles>
 
@@ -81,447 +91,423 @@
                       HorizontalScrollBarVisibility="Disabled"
                       VerticalScrollBarVisibility="Auto">
             <StackPanel Grid.IsSharedSizeScope="True"
-                        Spacing="{StaticResource CardGap}"
+                        Spacing="{StaticResource SectionGap}"
                         Margin="20,16,20,20"
                         MaxWidth="640"
                         HorizontalAlignment="Stretch">
 
-                <!-- ===== Card 1 — Recipe grid ===== -->
-                <Border Classes="section-card">
-                    <StackPanel Spacing="8">
-                        <TextBlock Classes="card-header" Text="Recipe grid" />
+                <StackPanel Spacing="8">
+                    <TextBlock Classes="section-header" Text="Recipe Grid" />
 
-                        <!-- Dimensions -->
-                        <TextBlock Classes="sub-header" Text="Dimensions" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Row height" />
-                            <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="12" Maximum="400" Increment="1"
-                                           Value="{Binding RowHeight}" />
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Cell padding left" />
-                            <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                           Value="{Binding CellPaddingLeft}" />
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Cell padding top" />
-                            <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                           Value="{Binding CellPaddingTop}" />
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Cell padding right" />
-                            <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                           Value="{Binding CellPaddingRight}" />
-                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Cell padding bottom" />
-                            <NumericUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                           Value="{Binding CellPaddingBottom}" />
-                        </Grid>
+                    <TextBlock Classes="sub-header" Text="Dimensions" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Row height" />
+                        <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="12" Maximum="400" Increment="1"
+                                       Value="{Binding RowHeight}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Cell padding left" />
+                        <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                       Value="{Binding CellPaddingLeft}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Cell padding top" />
+                        <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                       Value="{Binding CellPaddingTop}" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Cell padding right" />
+                        <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                       Value="{Binding CellPaddingRight}" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Cell padding bottom" />
+                        <NumericUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                       Value="{Binding CellPaddingBottom}" />
+                    </Grid>
 
-                        <!-- Fonts -->
-                        <TextBlock Classes="sub-header" Text="Fonts" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SizeCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
-                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Weight" />
-                            <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="Italic" />
+                    <TextBlock Classes="sub-header" Text="Fonts" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SizeCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Weight" />
+                        <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="Italic" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid header" />
-                            <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                           Value="{Binding HeaderFontSize}" />
-                            <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
-                                      ItemsSource="{Binding AvailableFontWeights}"
-                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                      SelectedValueBinding="{Binding Value}"
-                                      SelectedValue="{Binding HeaderFontWeight}" />
-                            <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
-                                      IsChecked="{Binding HeaderItalic}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid header" />
+                        <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                       Value="{Binding HeaderFontSize}" />
+                        <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
+                                  ItemsSource="{Binding AvailableFontWeights}"
+                                  ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  SelectedValue="{Binding HeaderFontWeight}" />
+                        <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
+                                  IsChecked="{Binding HeaderItalic}" />
 
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid cell" />
-                            <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                           Value="{Binding CellFontSize}" />
-                            <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
-                                      ItemsSource="{Binding AvailableFontWeights}"
-                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                      SelectedValueBinding="{Binding Value}"
-                                      SelectedValue="{Binding CellFontWeight}" />
-                            <CheckBox Grid.Row="2" Grid.Column="3" Classes="italic-check"
-                                      IsChecked="{Binding CellItalic}" />
-                        </Grid>
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid cell" />
+                        <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                       Value="{Binding CellFontSize}" />
+                        <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
+                                  ItemsSource="{Binding AvailableFontWeights}"
+                                  ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  SelectedValue="{Binding CellFontWeight}" />
+                        <CheckBox Grid.Row="2" Grid.Column="3" Classes="italic-check"
+                                  IsChecked="{Binding CellItalic}" />
+                    </Grid>
 
-                        <!-- Colors -->
-                        <TextBlock Classes="sub-header" Text="Colors" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Grid background" />
-                            <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding GridBackground}" />
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid border" />
-                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding GridBorder}" />
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid line" />
-                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding GridLine}" />
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Header foreground" />
-                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding HeaderForeground}" />
-                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Selection background" />
-                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding SelectionBackground}" />
-                            <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selection foreground" />
-                            <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding SelectionForeground}" />
-                            <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Changed" />
-                            <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding CellChanged}" />
-                            <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Changed (selected)" />
-                            <ColorPicker Grid.Row="7" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding CellChangedSelected}" />
-                        </Grid>
+                    <TextBlock Classes="sub-header" Text="Colors" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Grid background" />
+                        <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding GridBackground}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid border" />
+                        <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding GridBorder}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid line" />
+                        <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding GridLine}" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Header foreground" />
+                        <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding HeaderForeground}" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Selection background" />
+                        <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding SelectionBackground}" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selection foreground" />
+                        <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding SelectionForeground}" />
+                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Changed" />
+                        <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding CellChanged}" />
+                        <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Changed (selected)" />
+                        <ColorPicker Grid.Row="7" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding CellChangedSelected}" />
+                    </Grid>
 
-                        <!-- Read-only cells -->
-                        <TextBlock Classes="sub-header" Text="Read-only cells" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
-                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
+                    <TextBlock Classes="sub-header" Text="Read-only cells" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
-                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellDepth0}" />
-                            <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellDepth0Past}" />
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
-                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellDepth1}" />
-                            <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellDepth1Past}" />
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
-                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellDepth2}" />
-                            <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellDepth2Past}" />
-                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
-                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellDepth3}" />
-                            <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellDepth3Past}" />
-                            <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selected" />
-                            <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellSelected}" />
-                            <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Foreground" />
-                            <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ReadOnlyCellForeground}" />
-                        </Grid>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                        <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellDepth0}" />
+                        <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellDepth0Past}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                        <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellDepth1}" />
+                        <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellDepth1Past}" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                        <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellDepth2}" />
+                        <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellDepth2Past}" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                        <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellDepth3}" />
+                        <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellDepth3Past}" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selected" />
+                        <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellSelected}" />
+                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                        <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ReadOnlyCellForeground}" />
+                    </Grid>
 
-                        <!-- Disabled cells -->
-                        <TextBlock Classes="sub-header" Text="Disabled cells" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
-                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
+                    <TextBlock Classes="sub-header" Text="Disabled cells" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
-                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellDepth0}" />
-                            <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellDepth0Past}" />
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
-                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellDepth1}" />
-                            <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellDepth1Past}" />
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
-                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellDepth2}" />
-                            <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellDepth2Past}" />
-                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
-                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellDepth3}" />
-                            <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellDepth3Past}" />
-                            <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selected" />
-                            <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellSelected}" />
-                            <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Foreground" />
-                            <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding DisabledCellForeground}" />
-                        </Grid>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                        <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellDepth0}" />
+                        <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellDepth0Past}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                        <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellDepth1}" />
+                        <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellDepth1Past}" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                        <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellDepth2}" />
+                        <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellDepth2Past}" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                        <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellDepth3}" />
+                        <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellDepth3Past}" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selected" />
+                        <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellSelected}" />
+                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                        <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding DisabledCellForeground}" />
+                    </Grid>
 
-                        <!-- Execution highlight -->
-                        <TextBlock Classes="sub-header" Text="Execution highlight" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
-                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
+                    <TextBlock Classes="sub-header" Text="Execution highlight" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
-                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionDepth0}" />
-                            <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionDepth0Past}" />
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
-                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionDepth1}" />
-                            <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionDepth1Past}" />
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
-                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionDepth2}" />
-                            <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionDepth2Past}" />
-                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
-                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionDepth3}" />
-                            <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionDepth3Past}" />
-                            <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Current step marker" />
-                            <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ExecutionCurrentStepMarker}" />
-                        </Grid>
-                    </StackPanel>
-                </Border>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                        <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionDepth0}" />
+                        <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionDepth0Past}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                        <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionDepth1}" />
+                        <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionDepth1Past}" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                        <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionDepth2}" />
+                        <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionDepth2Past}" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                        <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionDepth3}" />
+                        <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionDepth3Past}" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Current step marker" />
+                        <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ExecutionCurrentStepMarker}" />
+                    </Grid>
+                </StackPanel>
 
-                <!-- ===== Card 2 — Status bar ===== -->
-                <Border Classes="section-card">
-                    <StackPanel Spacing="8">
-                        <TextBlock Classes="card-header" Text="Status bar" />
+                <StackPanel Spacing="8">
+                    <TextBlock Classes="section-header" Text="Status Bar" />
 
-                        <!-- Dimensions -->
-                        <TextBlock Classes="sub-header" Text="Dimensions" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Padding" />
-                            <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                           Value="{Binding StatusBarPadding}" />
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Item spacing" />
-                            <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
-                                           Value="{Binding StatusBarItemSpacing}" />
-                        </Grid>
+                    <TextBlock Classes="sub-header" Text="Dimensions" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Padding" />
+                        <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                       Value="{Binding StatusBarPadding}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Item spacing" />
+                        <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
+                                       Value="{Binding StatusBarItemSpacing}" />
+                    </Grid>
 
-                        <!-- Fonts -->
-                        <TextBlock Classes="sub-header" Text="Fonts" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SizeCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
-                            <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Weight" />
-                            <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="Italic" />
+                    <TextBlock Classes="sub-header" Text="Fonts" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SizeCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Weight" />
+                        <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="Italic" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Text" />
-                            <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                           Value="{Binding StatusBarFontSize}" />
-                            <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
-                                      ItemsSource="{Binding AvailableFontWeights}"
-                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                      SelectedValueBinding="{Binding Value}"
-                                      SelectedValue="{Binding StatusBarFontWeight}" />
-                            <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
-                                      IsChecked="{Binding StatusBarItalic}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Text" />
+                        <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                       Value="{Binding StatusBarFontSize}" />
+                        <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
+                                  ItemsSource="{Binding AvailableFontWeights}"
+                                  ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  SelectedValue="{Binding StatusBarFontWeight}" />
+                        <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
+                                  IsChecked="{Binding StatusBarItalic}" />
 
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Timer label" />
-                            <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                           Value="{Binding StatusBarTimerLabelFontSize}" />
-                            <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
-                                      ItemsSource="{Binding AvailableFontWeights}"
-                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                      SelectedValueBinding="{Binding Value}"
-                                      SelectedValue="{Binding StatusBarTimerLabelFontWeight}" />
-                            <CheckBox Grid.Row="2" Grid.Column="3" Classes="italic-check"
-                                      IsChecked="{Binding StatusBarTimerLabelItalic}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Timer label" />
+                        <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                       Value="{Binding StatusBarTimerLabelFontSize}" />
+                        <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
+                                  ItemsSource="{Binding AvailableFontWeights}"
+                                  ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  SelectedValue="{Binding StatusBarTimerLabelFontWeight}" />
+                        <CheckBox Grid.Row="2" Grid.Column="3" Classes="italic-check"
+                                  IsChecked="{Binding StatusBarTimerLabelItalic}" />
 
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Timer value" />
-                            <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
-                                           Value="{Binding StatusBarTimerValueFontSize}" />
-                            <ComboBox Grid.Row="3" Grid.Column="2" Classes="weight-picker"
-                                      ItemsSource="{Binding AvailableFontWeights}"
-                                      ItemTemplate="{StaticResource FontWeightItemTemplate}"
-                                      SelectedValueBinding="{Binding Value}"
-                                      SelectedValue="{Binding StatusBarTimerValueFontWeight}" />
-                            <CheckBox Grid.Row="3" Grid.Column="3" Classes="italic-check"
-                                      IsChecked="{Binding StatusBarTimerValueItalic}" />
-                        </Grid>
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Timer value" />
+                        <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
+                                       Value="{Binding StatusBarTimerValueFontSize}" />
+                        <ComboBox Grid.Row="3" Grid.Column="2" Classes="weight-picker"
+                                  ItemsSource="{Binding AvailableFontWeights}"
+                                  ItemTemplate="{StaticResource FontWeightItemTemplate}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  SelectedValue="{Binding StatusBarTimerValueFontWeight}" />
+                        <CheckBox Grid.Row="3" Grid.Column="3" Classes="italic-check"
+                                  IsChecked="{Binding StatusBarTimerValueItalic}" />
+                    </Grid>
 
-                        <!-- Colors -->
-                        <TextBlock Classes="sub-header" Text="Colors" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
-                            <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding StatusBarBackground}" />
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
-                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding StatusBarForeground}" />
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Connected" />
-                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding Connected}" />
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Disconnected" />
-                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding Disconnected}" />
-                        </Grid>
-                    </StackPanel>
-                </Border>
+                    <TextBlock Classes="sub-header" Text="Colors" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
+                        <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding StatusBarBackground}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                        <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding StatusBarForeground}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Connected" />
+                        <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding Connected}" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Disconnected" />
+                        <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding Disconnected}" />
+                    </Grid>
+                </StackPanel>
 
-                <!-- ===== Card 3 — Notification panel ===== -->
-                <Border Classes="section-card">
-                    <StackPanel Spacing="8">
-                        <TextBlock Classes="card-header" Text="Notification panel" />
+                <StackPanel Spacing="8">
+                    <TextBlock Classes="section-header" Text="Notification Panel" />
 
-                        <!-- Dimensions -->
-                        <TextBlock Classes="sub-header" Text="Dimensions" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Max height" />
-                            <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="20" Maximum="2000" Increment="10"
-                                           Value="{Binding ValidationPanelMaxHeight}" />
-                        </Grid>
+                    <TextBlock Classes="sub-header" Text="Dimensions" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Max height" />
+                        <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="20" Maximum="2000" Increment="10"
+                                       Value="{Binding ValidationPanelMaxHeight}" />
+                    </Grid>
 
-                        <!-- Colors -->
-                        <TextBlock Classes="sub-header" Text="Colors" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
-                            <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ValidationPanelBackground}" />
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
-                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ValidationPanelForeground}" />
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Info severity" />
-                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding Info}" />
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Error severity" />
-                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ValidationPanelError}" />
-                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Warning severity" />
-                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding ValidationPanelWarning}" />
-                        </Grid>
-                    </StackPanel>
-                </Border>
+                    <TextBlock Classes="sub-header" Text="Colors" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
+                        <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ValidationPanelBackground}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                        <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ValidationPanelForeground}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Info severity" />
+                        <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding Info}" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Error severity" />
+                        <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ValidationPanelError}" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Warning severity" />
+                        <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding ValidationPanelWarning}" />
+                    </Grid>
+                </StackPanel>
 
-                <!-- ===== Card 4 — Application theme ===== -->
-                <Border Classes="section-card">
-                    <StackPanel Spacing="8">
-                        <TextBlock Classes="card-header" Text="Application theme" />
+                <StackPanel Spacing="8">
+                    <TextBlock Classes="section-header" Text="Application Theme" />
 
-                        <!-- Typography -->
-                        <TextBlock Classes="sub-header" Text="Typography" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Font family" />
-                            <ComboBox Grid.Row="0" Grid.Column="1"
-                                      Width="{StaticResource FontFamilyWidth}"
-                                      HorizontalAlignment="Left"
-                                      ItemsSource="{Binding AvailableFontFamilies}"
-                                      ItemTemplate="{StaticResource FontFamilyItemTemplate}"
-                                      SelectedValueBinding="{Binding Value}"
-                                      SelectedValue="{Binding FontFamily}" />
-                        </Grid>
+                    <TextBlock Classes="sub-header" Text="Typography" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Font family" />
+                        <ComboBox Grid.Row="0" Grid.Column="1"
+                                  Width="{StaticResource FontFamilyWidth}"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  ItemsSource="{Binding AvailableFontFamilies}"
+                                  ItemTemplate="{StaticResource FontFamilyItemTemplate}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  SelectedValue="{Binding FontFamily}" />
+                    </Grid>
 
-                        <!-- Shared colors -->
-                        <TextBlock Classes="sub-header" Text="Shared colors" />
-                        <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
-                              RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Panel background" />
-                            <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding PanelBackground}" />
-                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Panel header background" />
-                            <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding PanelHeaderBackground}" />
-                            <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Subtle border" />
-                            <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding SubtleBorder}" />
-                            <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Separator" />
-                            <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding Separator}" />
-                            <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Secondary foreground" />
-                            <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
-                                         Color="{Binding SecondaryForeground}" />
-                        </Grid>
-                    </StackPanel>
-                </Border>
+                    <TextBlock Classes="sub-header" Text="Shared colors" />
+                    <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingLabel" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingControl" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="WeightCol" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Panel background" />
+                        <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding PanelBackground}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Panel header background" />
+                        <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding PanelHeaderBackground}" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Subtle border" />
+                        <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding SubtleBorder}" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Separator" />
+                        <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding Separator}" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Secondary foreground" />
+                        <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
+                                     Color="{Binding SecondaryForeground}" />
+                    </Grid>
+                </StackPanel>
 
             </StackPanel>
         </ScrollViewer>
@@ -543,11 +529,11 @@
                             HorizontalAlignment="Right"
                             Spacing="10">
                     <Button Content="Save"
-                            Width="90"
+                            Classes="primary"
                             IsDefault="True"
                             Command="{Binding SaveCommand}" />
                     <Button Content="Cancel"
-                            Width="90"
+                            Classes="secondary"
                             IsCancel="True"
                             Click="OnCancelClick" />
                 </StackPanel>

--- a/SemiStep/SemiStep.UI/StyleEditor/RestartPromptDialog.axaml
+++ b/SemiStep/SemiStep.UI/StyleEditor/RestartPromptDialog.axaml
@@ -28,10 +28,10 @@
                     Spacing="10"
                     Margin="0,20,0,0">
             <Button Content="Exit Now"
-                    Width="90"
+                    Classes="secondary"
                     Click="OnExitNowClick" />
             <Button Content="Restart Later"
-                    Width="110"
+                    Classes="primary"
                     Click="OnRestartLaterClick"
                     IsDefault="True"
                     IsCancel="True" />

--- a/SemiStep/SemiStep.UI/Styles/Buttons.axaml
+++ b/SemiStep/SemiStep.UI/Styles/Buttons.axaml
@@ -1,0 +1,23 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style Selector="Button">
+        <Setter Property="MinHeight" Value="26" />
+        <Setter Property="Padding" Value="12,4" />
+    </Style>
+
+    <!-- primary → Semi SolidButton (retinted SemiColorPrimary). MinWidth here, not on the global
+         Button selector, so the compact recipe-toolbar buttons stay narrow. -->
+    <Style Selector="Button.primary">
+        <Setter Property="Theme" Value="{DynamicResource SolidButton}" />
+        <Setter Property="MinWidth" Value="75" />
+    </Style>
+
+    <!-- secondary → Semi OutlineButton. -->
+    <Style Selector="Button.secondary">
+        <Setter Property="Theme" Value="{DynamicResource OutlineButton}" />
+        <Setter Property="Foreground" Value="{DynamicResource SemiColorText0}" />
+        <Setter Property="MinWidth" Value="75" />
+    </Style>
+
+</Styles>

--- a/SemiStep/SemiStep.UI/Styles/ColorPalette.axaml
+++ b/SemiStep/SemiStep.UI/Styles/ColorPalette.axaml
@@ -1,13 +1,11 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- Accent -->
-    <Color x:Key="AccentColor">#0078D7</Color>
-    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
-
-    <!-- Override the Fluent DataGrid sort-glyph reserve (default 32px) to 0: sorting is disabled
-         on every column, so the reserved column otherwise just crowds the header text. -->
-    <x:Double x:Key="DataGridSortIconMinWidth">0</x:Double>
+    <!-- The system Segoe chrome font, applied to top-level Windows via the Window style in App.axaml.
+         Keep this string in sync with GridFonts.DefaultFamily (the grid's empty-family fallback).
+         Note: controls that set their own FontFamily (e.g. AppStatusBar binds AppFontFamily) do not
+         inherit this, so it is not a single source for every glyph in the app. -->
+    <FontFamily x:Key="ChromeFontFamily">Segoe UI Variable Text, Segoe UI</FontFamily>
 
     <!-- Config-driven brushes (cell state, selection, grid lines) are installed at startup by
          CellPaletteInstaller from GridStyleOptions. See CellPaletteInstaller for the full key

--- a/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
+++ b/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
@@ -11,7 +11,7 @@
         <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource GridLineBrush}" />
     </Style>
 
-    <!-- The Fluent DataGridCell/DataGridRow themes hard-code MinHeight=32. Without this override that
+    <!-- The Semi DataGridCell/DataGridRow themes hard-code MinHeight=32. Without this override that
          floor fights the config-driven RowHeight (set in ColumnBuilder): the cell measures at 32 but is
          arranged into the shorter row, clipping the Stretch-aligned focus/current Rectangle into a broken
          box. Binding MinHeight to the same config value lets the focus/current border render cleanly on a
@@ -21,9 +21,10 @@
     </Style>
     <Style Selector="DataGridCell">
         <Setter Property="MinHeight" Value="{DynamicResource GridRowHeight}" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
-    <!-- Stretch is load-bearing: the Fluent header panel aligns by it, and only Stretch gives the
+    <!-- Stretch is load-bearing: the Semi header panel aligns by it, and only Stretch gives the
          wrapping header TextBlock the column width it needs. See Docs/architecture/recipe-grid-column-sizing.md. -->
     <Style Selector="DataGridColumnHeader">
         <Setter Property="Foreground" Value="{DynamicResource HeaderForegroundBrush}" />
@@ -45,7 +46,24 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <!-- left padding 6 to match the ComboBoxChromeWidth budget. See Docs/architecture/recipe-grid-column-sizing.md -->
-        <Setter Property="Padding" Value="6,5,0,7" />
+        <Setter Property="Padding" Value="6,0,0,0" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
+    <!-- Cell ComboBoxes must stay chrome-less in every interaction state. Semi's :pointerover/:focus/:pressed
+         paint a rounded selector Background + BorderBrush (ComboBoxSelectorPointeroverBackground etc.), which
+         shows as a "halo" frame inside the colored cell. Neutralize those states for combos inside the grid
+         only — editor combos (weight/font-family pickers) keep their normal hover. -->
+    <Style Selector="DataGrid ComboBox:pointerover, DataGrid ComboBox:focus, DataGrid ComboBox:pressed">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+    </Style>
+
+    <!-- Every recipe column is non-sortable, but Semi's header template always reserves a ~24px sort-icon
+         column. That floor overflows the header-width calc and Avalonia breaks the longest word mid-word
+         ("Начальн/ое"). Collapsing the icon frees the width so the longest word fits on one line. -->
+    <Style Selector="DataGridColumnHeader /template/ PathIcon#SortIcon">
+        <Setter Property="IsVisible" Value="False" />
     </Style>
 
     <!-- ============================================== -->
@@ -201,8 +219,7 @@
     <!-- selectors so it wins on every cell, but before the current-step marker -->
     <!-- so the marker still shows on the step-number column when the current -->
     <!-- step is also user-selected. Selection bg/fg come from the dedicated -->
-    <!-- SelectionBackgroundBrush/SelectionForegroundBrush (config-driven), -->
-    <!-- decoupled from AccentBrush. -->
+    <!-- config-driven SelectionBackgroundBrush/SelectionForegroundBrush. -->
     <Style Selector="DataGridRow:selected DataGridCell">
         <Setter Property="Background" Value="{DynamicResource SelectionBackgroundBrush}" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource SelectionForegroundBrush}" />


### PR DESCRIPTION
Closes part of #74 (the visual-design refresh).

## Summary

Re-themes the app toward a flat, neutral, IDE-like look while staying native on Windows. Theme engine swapped from Fluent to **Semi.Avalonia**, retinted to JetBrains Int UI tokens; UI font is the **native Segoe UI** (no embedded fonts); the Grid Style editor goes flat; and the Semi DataGrid is reconciled with the app's bespoke cell theming.

### Theme & tokens
- Replace `FluentTheme` with **Semi.Avalonia** (+ Semi DataGrid/ColorPicker), pinned `RequestedThemeVariant="Light"`.
- Retint Semi's semantic tokens to JetBrains Int UI values (accent `#3574F0`, neutral grays, severities) via `ThemeDictionaries`; uniform **4px** corner radius.
- Filled-accent **primary** / ghost **secondary** button styles across the editor and all dialogs.

### Typography
- UI font is **Segoe UI Variable Text → Segoe UI** at **12px**, behind a single `ChromeFontFamily` resource key. The recipe grid uses the same Segoe with **tabular figures (`+tnum`)** for digit-column alignment — applied to both rendering and the column-width *measurement* so they match. **No embedded fonts.**

### Grid Style editor
- Flat sections with muted title-case headers (no bordered cards); the shared-size column grammar, the `Depth × {Current, Past}` color matrices, and the scroll inset are preserved.

### Semi DataGrid reconciliation
- App cell theming (read-only / disabled / changed / selection / execution tints) preserved on top of Semi.
- Cell content vertically centered; column headers no longer wrap mid-word (Semi's always-reserved sort icon collapsed); color pickers fill the field; row/combo hover "halo" neutralized; the black current-cell frame restored.

### Tooling / docs
- Adds the **`avalonia-visual-style`** skill (JetBrains design tokens + the Semi.Avalonia theming mechanism) and a cross-reference from `avalonia-form-layout`. (The `avalonia-ui-reviewer` agent it pairs with already landed via #93.)
- Documents the config-driven palette + theming contract in `Docs/architecture/grid-style-configuration.md`.

## Test plan
- `dotnet build SemiStep/SemiStep.slnx` — clean.
- `dotnet test SemiStep/SemiStep.Tests` — **976/976** pass.
- `dotnet format` — clean.
- Visual: rendered the editor, recipe grid, status bar, and dialogs via the local screenshot harness; manual desktop QA confirmed the dialogs, the current-cell frame, hover behavior, and DPI.

## Reviews
Branch reviewed for correctness, comment noise, and over-engineering; findings addressed (stale font docs corrected, tnum measurement aligned to render, duplicate styles/tokens pruned).

## Notes
- Light theme only; dark mode is deferred (architecture stays dark-ready via `DynamicResource`).
- Issue #74's other items (dialog chrome / dead UI-YAML / MOCVD selection) were already resolved on `master` before this branch and are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)