### PR TITLE
fix: clearing a string cell to empty now commits

### DIFF
--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/PropertyTimeEditingConverterTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/PropertyTimeEditingConverterTests.cs
@@ -1,0 +1,57 @@
+﻿using System.Globalization;
+
+using Avalonia.Data;
+
+using FluentAssertions;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+/// <summary>
+/// Exercises <see cref="PropertyTimeEditingConverter.ConvertBack"/> around empty input. A cleared
+/// string cell must commit an empty value; a cleared numeric/time cell must leave the source
+/// untouched so an unparseable empty never overwrites the prior value.
+/// </summary>
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Unit")]
+public sealed class PropertyTimeEditingConverterTests
+{
+	[Fact]
+	public void ConvertBack_EmptyText_StringColumn_CommitsEmptyString()
+	{
+		var converter = new PropertyTimeEditingConverter(TimeFormatHelper.DefaultFormatKind, allowsEmpty: true);
+
+		var result = ConvertBack(converter, string.Empty);
+
+		result.Should().Be(string.Empty);
+	}
+
+	[Fact]
+	public void ConvertBack_WhitespaceText_StringColumn_CommitsEmptyString()
+	{
+		var converter = new PropertyTimeEditingConverter(TimeFormatHelper.DefaultFormatKind, allowsEmpty: true);
+
+		var result = ConvertBack(converter, "   ");
+
+		result.Should().Be(string.Empty);
+	}
+
+	[Fact]
+	public void ConvertBack_EmptyText_NumericColumn_LeavesSourceUntouched()
+	{
+		var converter = new PropertyTimeEditingConverter(TimeFormatHelper.DefaultFormatKind, allowsEmpty: false);
+
+		var result = ConvertBack(converter, string.Empty);
+
+		result.Should().Be(BindingOperations.DoNothing);
+	}
+
+	private static object? ConvertBack(PropertyTimeEditingConverter converter, string? value)
+	{
+		return converter.ConvertBack(value, typeof(object), parameter: null, CultureInfo.InvariantCulture);
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeEditingConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeEditingConverter.cs
@@ -5,7 +5,7 @@ using Avalonia.Data.Converters;
 
 namespace SemiStep.UI.RecipeGrid;
 
-internal sealed class PropertyTimeEditingConverter(string formatKind) : IValueConverter
+internal sealed class PropertyTimeEditingConverter(string formatKind, bool allowsEmpty) : IValueConverter
 {
 	public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 	{
@@ -28,7 +28,7 @@ internal sealed class PropertyTimeEditingConverter(string formatKind) : IValueCo
 		var text = value?.ToString()?.Trim();
 		if (string.IsNullOrEmpty(text))
 		{
-			return BindingOperations.DoNothing;
+			return allowsEmpty ? string.Empty : BindingOperations.DoNothing;
 		}
 
 		var parsed = TimeFormatHelper.ParseValue(text);

--- a/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/TextCellFactory.cs
@@ -121,7 +121,7 @@ internal sealed class TextCellFactory(GridStyleOptions gridStyle)
 			var formatKind = row?.ColumnFormatKinds.GetValueOrDefault(columnKey)
 				?? TimeFormatHelper.DefaultFormatKind;
 
-			var editingConverter = new PropertyTimeEditingConverter(formatKind);
+			var editingConverter = new PropertyTimeEditingConverter(formatKind, allowsEmpty: maxLength.HasValue);
 
 			var textBox = new TextBox
 			{


### PR DESCRIPTION
## Problem

Clearing a comment (string) cell to empty and pressing Enter left the old text in place. Only replacing with other non-empty content worked; a non-empty value could never be cleared.

## Cause

`PropertyTimeEditingConverter.ConvertBack` returned `BindingOperations.DoNothing` for empty or whitespace input, so the binding never wrote back to the source. The model kept its previous value; `PropertyValueChanged` never fired. Core accepts an empty string fine — the edit simply never reached it.

The guard is correct for numeric/time columns, where an empty string is unparseable and must not overwrite the prior value. It is wrong for string columns, where empty is a legitimate value.

## Fix

Thread an `allowsEmpty` flag into the converter, keyed off the existing string-column signal (`maxLength.HasValue`, which `ColumnBuilder.ResolveMaxLength` sets only for string types). String cells commit an empty string; numeric/time cells keep the `DoNothing` guard.

## Tests

- New `PropertyTimeEditingConverterTests`: empty and whitespace on a string column commit `""`; empty on a numeric/time column returns `DoNothing`.
- RecipeGrid area suite: 125/125 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)