### PR TITLE
Russify UI with multi-language support (#69)

### DIFF
--- a/Docs/architecture/ui-localization.md
+++ b/Docs/architecture/ui-localization.md
@@ -1,0 +1,101 @@
+# UI Localization
+
+## Overview
+
+The static application chrome (menus, toolbar, status-bar labels, dialogs, view-model literals) is
+localized through .NET `.resx` resources selected by a `locale` setting read from the equipment YAML
+config. Two languages ship: Russian (default) and English. Domain text (column headers, action names,
+group items) comes from YAML `ui_name` and is not part of this mechanism; logs, diagnostics, and
+number/date formatting stay English/invariant.
+
+## The `locale` setting
+
+Locale lives in its own equipment-config file, `{configDir}/ui/app.yaml`, a sibling of
+`grid_style.yaml` in the `ui/` folder. One key:
+
+```yaml
+locale: ru   # or en; absent/invalid -> ru
+```
+
+It is loaded as its own config section, mirroring the `GridStyle` pattern:
+`AppUiOptionsLoader` reads the file, `AppUiOptionsMapper` maps the DTO to the immutable
+`AppUiOptions(string Locale)` record, and `ConfigFacade` bundles it onto `AppConfiguration.Ui`.
+
+Unlike `GridStyleLoader`, which fails when its file is absent, `AppUiOptionsLoader` returns
+`Ok(null)` when `ui/app.yaml` or the `ui/` directory is missing — the file is optional and its
+absence does not fail the config load; the mapper converts null to `AppUiOptions.Default`. The mapper
+also returns `Default` (locale `ru`) when the DTO or the `locale` value is null or blank; it does not
+validate the culture. An invalid-but-present culture is caught later in `UiCultureSelector.Resolve`,
+which falls back to `ru`. So the default UI language is `ru` whenever the file, the key, or a valid
+value is missing.
+
+## The resx model: English is the neutral fallback
+
+Two resource files live in `SemiStep.UI/Localization`:
+
+- `Resources.resx` — the neutral/invariant set, holding **English** values. English is the fallback
+  because it aligns with the English logs, so a missing satellite degrades to English rather than to
+  a partial mix.
+- `Resources.ru.resx` — the Russian set, compiled into the `ru/Semistep.resources.dll` satellite
+  assembly (the entry assembly name is `Semistep`).
+
+Resources are referenced from AXAML via `{x:Static l:Resources.Key}` (with
+`xmlns:l="clr-namespace:SemiStep.UI.Localization"`) and from C# via `Resources.Key`. Composite labels
+that need plural-neutral Russian phrasing or invariant-culture number formatting (`Шагов: {0}`,
+`Ошибок: {0}`, last-sync elapsed text) are folded into view-model properties rather than formatted in
+XAML.
+
+## Gotcha: the accessor is a committed source file, not build-time-generated
+
+The strongly-typed accessor is a **committed** source file,
+`SemiStep.UI/Localization/Resources.Designer.cs` — a hand-authored public partial class in the
+standard auto-generated shape (lazy `ResourceManager` on base name
+`SemiStep.UI.Localization.Resources`, a public static `Culture`, one `public static string Key => ...`
+property per key). It is deliberately **not** produced by MSBuild `EmbeddedResource`
+`StronglyType*` metadata.
+
+The reason is a build-ordering race. Build-time generation emits the `Resources` class too late: on a
+**cold** build the class does not exist when the Avalonia XAML compiler (XamlIl) runs, so every
+`{x:Static l:Resources.*}` reference fails with `AVLN2000: Unable to resolve "Resources.X"`.
+`App.axaml` then fails to precompile, and at test time `App.Initialize()` throws `XamlLoadException`,
+killing the shared headless dispatcher — so every `[AvaloniaFact]` deadlocks. A committed `.cs` file
+is visible to both the C# compiler and XamlIl before their passes, so the reference resolves on a cold
+build.
+
+**Consequence for contributors.** Adding a localized string means editing **three** files in sync:
+
+1. `Resources.resx` — the English (neutral) value.
+2. `Resources.ru.resx` — the Russian value.
+3. `Resources.Designer.cs` — a new `public static string Key => ...` property.
+
+Miss the third and XAML/C# cannot reference the key; miss either resx and one language falls back to
+the other (or to the key-less default).
+
+## Culture wiring: only UICulture changes
+
+Config is loaded on a worker thread (`Program.cs` `StartupAsync`), which sets the process-global
+`CultureInfo.DefaultThreadCurrentUICulture` and `Resources.Culture` from
+`UiCultureSelector.Resolve(config.Ui.Locale)` after a successful load. `UiCultureSelector.Resolve`
+returns the requested culture, or `ru` on null/blank input, on `CultureNotFoundException`, and on
+ICU's synthesized custom-culture LCID `0x1000` (which ICU produces for structurally-valid but unknown
+tags instead of throwing).
+
+`CurrentCulture` is **never** assigned. Resource lookup keys off `UICulture`; number/date formatting
+and Serilog timestamps key off `CurrentCulture` and stay invariant/English. So `{elapsed:0.0}`, step
+counts, and log timestamps stay invariant regardless of UI language — the surrounding words localize,
+the numbers do not. Log message templates and notification-panel diagnostic strings (which carry
+exception text) stay hardcoded English by design.
+
+## `ErrorWindow` is deliberately hardcoded English
+
+`Dialogs/ErrorWindow.axaml` is hardcoded English and is **not** routed through resx (no `xmlns:l`, no
+`{x:Static}`). It renders only when config load fails — the point at which locale is unknown by
+construction and can never be data-driven. Its body is already English `error.Message` text matching
+the English logs, and it is a diagnostic screen for the integrator, not the operator. Keeping it
+resx-free also keeps this fail-safe path free of any resx/culture-init dependency.
+
+## Domain text stays outside resx
+
+Column headers, action names, and group items come from YAML `ui_name`; logs, diagnostics, and
+number/date formatting stay English/invariant. Font-weight names in the grid-style editor's weight
+picker (`Light`, `Normal`, `SemiBold`, …) are kept in English as conventional typographic tokens.

--- a/Docs/plans/completed/20260701-russify-ui-multilang.md
+++ b/Docs/plans/completed/20260701-russify-ui-multilang.md
@@ -1,0 +1,372 @@
+# Russify UI with multi-language support (resx, locale from ui/app.yaml, default ru)
+
+Closes #69.
+
+## Overview
+
+Localize the static application chrome (menus, dialogs, buttons, status-bar labels,
+view-model literals) via .NET `.resx` resources selected by a `locale` setting read
+from the equipment YAML config. Neutral/invariant resources are **English** (fallback,
+aligns with English logs); `Resources.ru.resx` is **Russian**. Default UI language is
+`ru`.
+
+Domain text (column headers, action names, group items) is already Russian, comes from
+YAML `ui_name`, and stays there — out of scope. Log message templates stay hardcoded
+English — out of scope.
+
+**Explicitly out of scope (stays English this PR, keeps it one logical change):**
+- `SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml` (~90 labels) and
+  `SemiStep.UI/StyleEditor/RestartPromptDialog.axaml` — the grid-style settings editor and
+  its restart prompt, reachable only via the "Grid Style Settings…" menu item. The menu
+  item itself is localized; the editor window is a follow-up.
+- Notification-panel `ReportError` diagnostic strings carrying exception text.
+
+**`ErrorWindow` is deliberately English, hardcoded, NOT routed through resx.** It renders
+only when config load fails, so locale is unknown by construction and can never be
+data-driven. Its body (the error list) is already English `error.Message` text matching
+the English logs; a Russian frame around English errors is incoherent. It is a diagnostic
+screen for the integrator/engineer, not the operator. Hardcoding also keeps this fail-safe
+path free of resx/culture-init dependencies. Action: translate its current Russian chrome
+("Ошибка загрузки конфигурации", header, "Выход") to English. No `ru` values, no `x:Static`.
+
+**In scope beyond the issue's original list** (default-visible chrome the issue missed):
+`SemiStep.UI/MainWindow/RecipeToolBar.axaml` (toolbar buttons + tooltips, visible by
+default) and the Error/Warning count strings in
+`SemiStep.UI/MessageService/MessagePanelViewModel.cs` (rendered in the in-scope status
+bar) plus `MessagePanel.axaml` `Close` tooltip.
+
+**Deviation from issue text:** the issue says set the custom tool to
+`PublicResXFileCodeGenerator`. That tool is Visual-Studio-only, but the artifact it
+implies — a committed public `Resources` accessor checked into source — is the correct
+approach, and that is what we ship: a hand-authored `Localization/Resources.Designer.cs`
+committed alongside the resx. Build-time generation via MSBuild `EmbeddedResource`
+`StronglyType*` metadata was tried and is wrong: on a cold build the accessor does not
+exist when the Avalonia XAML compiler (XamlIl) runs, so every `{x:Static l:Resources.*}`
+fails with `AVLN2000`, `App.axaml` is not precompiled, and at test time `App.Initialize()`
+throws `XamlLoadException`, killing the headless dispatcher so every `[AvaloniaFact]`
+hangs. A committed source file is visible to both the C# and XamlIl passes, so it resolves.
+
+Key design decision from discussion: `locale` lives in its own equipment-config file
+`ui/app.yaml` (a dedicated `AppUiOptions` section on `AppConfiguration`), **not** inside
+`GridStyleOptions` (that record is purely grid styling; adding language there mixes
+responsibilities). A user-writable `%APPDATA%` preferences store is explicitly a
+separate, future concern — not this issue.
+
+## Context (from discovery)
+
+Files/areas involved:
+- Startup/culture: `SemiStep.UI/Program.cs` (loads config before `App.Run`; logs already
+  pinned to `CultureInfo.InvariantCulture`), `SemiStep.UI/StartupOptions.cs`.
+- Config layer: `SemiStep.Core/Configuration/Facade/ConfigFacade.cs`
+  (`LoadAllSectionsAsync`, `MapToDomain`, `LoadedSections`),
+  `SemiStep.Core/Configuration/AppConfiguration.cs`,
+  loader pattern `SemiStep.Core/Configuration/Loaders/GridStyleLoader.cs` (~30 lines,
+  generic YAML deserialize — the template to copy).
+- Chrome AXAML: `MainWindow/RecipeMenuBar.axaml`, `MainWindow/MainWindow.axaml`
+  (Title binding + DataGrid context menu), `MainWindow/AppStatusBar.axaml`,
+  `Dialogs/ErrorWindow.axaml` (already hardcoded Russian), `Dialogs/MessageDialog.axaml`,
+  `Plc/PlcConflictDialog.axaml`, `ShutdownService/ExitConfirmationDialog.axaml`.
+- Chrome C#: `MainWindow/MainWindowViewModel.cs` (`MapSyncStatus`, `FormatLastSyncTime`,
+  `BuildWindowTitle`).
+- Project: `SemiStep.UI/SemiStep.UI.csproj` (SDK-style; will host the resx).
+
+Patterns observed:
+- Each config section = a static loader + a DTO + entry in `LoadedSections` + mapping in
+  `MapToDomain` + a field on `AppConfiguration`. FluentResults for load/validate.
+- Config `ui/` folder currently holds only `grid_style.yaml`; `ui/app.yaml` is a natural
+  sibling.
+- Status bar already has Russian literals (`Шаг:`, `Рецепт:`) hardcoded — these move to
+  resources too so both languages are covered from one source.
+
+Dependencies: YamlDotNet (already used), Avalonia XAML `{x:Static}` (no new package).
+
+## Development Approach
+
+- **Testing approach**: Regular (code first, then tests). Most of the work is mechanical
+  string extraction; tests target the parts with real logic: locale loading/defaulting,
+  culture selection, and resource resolution (a known key differs between `en` and `ru`).
+- Complete each task fully before the next; run tests after each; keep this plan in sync.
+- **Every task with logic includes tests.** Pure XAML-literal extraction (Task 5) is
+  verified by a build + a headless smoke test rather than per-string unit tests.
+
+## Testing Strategy
+
+- **Unit tests**: locale DTO/loader/mapper defaulting (`Component=Config`); culture
+  selection helper (`Component=UI`); a resource-resolution smoke test asserting a chosen
+  key resolves to the English neutral value under `en` and the Russian value under `ru`.
+- **Headless UI test** (`[AvaloniaFact]`): with culture `ru`, a menu/dialog control's
+  localized text equals the `ru` resource value — proves `{x:Static}` wiring renders.
+- No e2e framework in this project; headless Avalonia tests are the ceiling.
+
+## Solution Overview
+
+- Add `AppUiOptions(string Locale)` to the domain, loaded from `ui/app.yaml`
+  (`locale:` key), default `ru` when the file/key is absent or the value is not a valid
+  culture. Surface it as `AppConfiguration.Ui`.
+- Set the default UI culture to `ru` at the very start of `Main` (before config load), so
+  the failure path (`ErrorWindow`, shown when config load fails and locale is unknown)
+  already renders in the default language. After a successful load, override
+  `CultureInfo.DefaultThreadCurrentUICulture` and `Resources.Culture` from
+  `config.Ui.Locale`, before `App.Run`.
+- Change **only `UICulture`**, never `CurrentCulture`. Resource lookup keys off UICulture;
+  number/date formatting and logs key off CurrentCulture and must stay invariant/English.
+- Add `Resources.resx` (English neutral) + `Resources.ru.resx` (Russian) in
+  `SemiStep.UI/Localization`, generator `PublicResXFileCodeGenerator` (public class so the
+  Avalonia XAML compiler can reference it via `{x:Static}`).
+- Replace chrome literals: XAML via `{x:Static l:Resources.Key}`; C# via `Resources.Key`.
+
+## Technical Details
+
+- Culture set-up helper (pure, testable): `string -> CultureInfo` with `ru` fallback on
+  null/blank/invalid (`CultureNotFoundException`).
+- `ui/app.yaml` shape:
+  ```yaml
+  locale: ru   # or en; absent/invalid -> ru
+  ```
+- Resource-key naming: group by area, `PascalCase`, e.g. `MenuFile`, `MenuFileNewRecipe`,
+  `StatusSyncOn`, `StatusSyncOff`, `StatusConnecting`, `DialogExitUnsavedMessage`,
+  `ButtonSave`, `ButtonCancel`, `WindowTitleNewRecipe`, `ErrorWindowTitle`, etc.
+- **StringFormat wrinkle**: you cannot embed `{x:Static}` *inside* a literal
+  `StringFormat` string, but you **can** set `StringFormat="{x:Static l:Resources.Key}"`
+  on the binding. For the composite labels (`Last sync: {0}`, `Local: {0} steps`,
+  `PLC: {0} steps`, `{elapsed:0.0} s ago`) we still fold formatting into the source
+  view-model property, because they also need Russian plural/word handling and the
+  elapsed number must stay `InvariantCulture` while the words localize. Bind the property
+  directly. Applies to `AppStatusBar` last-sync and `PlcConflictDialog` step counts.
+- **Russian plurals**: `{0} steps`, `Error/Errors`, `Warning/Warnings` have no single
+  correct Russian form (шаг/шага/шагов, ошибка/ошибки/ошибок). To avoid a pluralization
+  engine (YAGNI), use plural-neutral phrasing: label-then-count, e.g. `Шагов: {0}`,
+  `Ошибок: {0}`, `Предупреждений: {0}`. Record this wording choice in the resx.
+- **Number/format culture**: keep `{elapsed:0.0}` and step counts formatted with
+  `CultureInfo.InvariantCulture` explicitly; only surrounding words come from resx. This
+  is consistent with "only UICulture changes".
+- **Menu mnemonics**: `_File`, `E_xit`, etc. — assign Russian access keys in the `ru`
+  values (e.g. `_Файл`, `В_ыход`, `_Открыть рецепт…`). Keep `InputGesture` bindings as-is.
+
+## Progress Tracking
+
+- Mark completed items `[x]` immediately. New tasks get `➕`; blockers get `⚠️`.
+
+## What Goes Where
+
+- Implementation Steps (checkboxes): config field, culture wiring, resx, extraction, tests.
+- Post-Completion (no checkboxes): deploying `ui/app.yaml` into real `C:\DISTR\Config\...`
+  equipment configs; visual proofreading of Russian wording by a native reviewer.
+
+## Implementation Steps
+
+### Task 1: Add `locale` to the equipment config (`ui/app.yaml`)
+
+**Files:**
+- Create: `SemiStep.Core/Configuration/Dto/AppUiOptionsDto.cs`
+- Create: `SemiStep.Core/Configuration/AppUiOptions.cs`
+- Create: `SemiStep.Core/Configuration/Loaders/AppUiOptionsLoader.cs`
+- Create: `SemiStep.Core/Configuration/Mapping/AppUiOptionsMapper.cs`
+- Modify: `SemiStep.Core/Configuration/AppConfiguration.cs`
+- Modify: `SemiStep.Core/Configuration/Facade/ConfigFacade.cs` (deconstruction `:32`,
+  `LoadedSections` record + ctor `:173-179`/`:115-121`, `MapToDomain` signature+call
+  `:52`/`:126`, `AppUiOptionsLoader` call + `Result.Merge` in `LoadAllSectionsAsync`)
+- Modify: all `new AppConfiguration(...)` call sites — 14 test files incl.
+  `SemiStep.Tests/Helpers/TestRecipeMetadataRegistryFactory.cs`, S7 tests, Core unit/
+  integration tests, `UI/GroupComboBoxRecyclingTests.cs`
+- Modify: `SemiStep.Tests/YamlConfigs/Standard/ui/app.yaml` (create) and other test config
+  roots as needed
+- Create: `SemiStep.Tests/Core/Configuration/AppUiOptionsLoaderTests.cs`
+
+- [x] add `AppUiOptionsDto` with `[YamlMember(Alias = "locale")] string? Locale`
+- [x] add domain record `AppUiOptions(string Locale)` with `public static AppUiOptions Default { get; }` = `ru`
+- [x] add `AppUiOptionsLoader.LoadAsync` adapting the `GridStyleLoader` pattern, reading
+      `ui/app.yaml`. **Intentional deviation**: return `Ok(Default)` when the file/`ui` dir
+      is absent (optional file), unlike `GridStyleLoader` which fails on absent — do not
+      "fix" this back to fail-on-absent
+- [x] add `AppUiOptionsMapper.Map` returning `Default` when DTO/locale is null or blank
+- [x] thread `Ui` through `ConfigFacade`: deconstruction site, `LoadedSections` record and
+      ctor, `MapToDomain` signature and call, the merge in `LoadAllSectionsAsync`
+- [x] add `Ui` as the 7th param on `AppConfiguration`; update every `new AppConfiguration(`
+      call site (helper factory + 13 test files) so the solution compiles
+- [x] add `ui/app.yaml` (`locale: ru`) to the `Standard` test config; confirm other config
+      roots still load (absent file -> default)
+- [x] write tests: present `en`, present `ru`, absent file, blank/garbage value -> all
+      resolve to expected locale (garbage -> `ru`)
+- [x] run tests - must pass before next task
+
+### Task 2: Select UI culture at startup
+
+**Files:**
+- Create: `SemiStep.UI/Localization/UiCultureSelector.cs`
+- Modify: `SemiStep.UI/Program.cs`
+- Create: `SemiStep.Tests/UI/Localization/UiCultureSelectorTests.cs`
+
+Seam note: config is loaded on a worker thread (`Task.Run(() => StartupAsync(...))`) and
+`Main` receives only a `StartupOutcome` exposing `Provider`, not the `AppConfiguration`.
+So the locale-driven override happens **inside `StartupAsync`** after a successful load
+(both `DefaultThreadCurrentUICulture` and `Resources.Culture` are process-global, so
+setting them from the worker thread is fine). No early culture set-up is required for the
+`ErrorWindow` path: that window is hardcoded English and does not depend on culture/resx.
+
+- [x] add `UiCultureSelector.Resolve(string? locale) : CultureInfo` returning `ru` on
+      null/blank/`CultureNotFoundException`. **Note**: ICU does not throw for structurally
+      valid but unknown tags (e.g. `zz-ZZ-garbage`); it synthesises a custom culture with
+      LCID `0x1000`. The helper also treats that LCID as invalid and falls back to `ru`.
+- [x] in `StartupAsync`, after a successful load, set `DefaultThreadCurrentUICulture` from
+      `UiCultureSelector.Resolve(config.Ui.Locale)`. **Deferred**: the `Resources.Culture`
+      assignment is wired in Task 3, once the generated `Resources` class exists (a
+      single clearly-marked note marks the seam in `Program.cs`).
+- [x] set the same `ru` default once at process start as a harmless baseline (optional;
+      not relied on by any pre-config UI)
+- [x] do not touch `CurrentCulture` (keep number/date formatting and logs invariant)
+- [x] write tests for `Resolve`: `en`, `ru`, null, blank, invalid tag
+- [x] run tests - must pass before next task
+
+### Task 3: Create the resx infrastructure
+
+**Files:**
+- Create: `SemiStep.UI/Localization/Resources.resx` (English neutral)
+- Create: `SemiStep.UI/Localization/Resources.ru.resx` (Russian)
+- Modify: `SemiStep.UI/SemiStep.UI.csproj` (strongly-typed accessor via MSBuild metadata)
+- Create: `SemiStep.Tests/UI/Localization/ResourceResolutionTests.cs`
+
+Mechanism: the strongly-typed accessor is a **committed** source file,
+`SemiStep.UI/Localization/Resources.Designer.cs`, hand-authored in the standard
+auto-generated shape (public partial class `Resources`, lazy `ResourceManager` on base
+name `SemiStep.UI.Localization.Resources`, public static `Culture`, one static property per
+key). It is a normal `.cs` file, so it is visible to both the C# compiler and XamlIl before
+their passes; `{x:Static l:Resources.*}` resolves on a cold build. Build-time
+`StronglyType*` generation was rejected: it produces the accessor too late for XamlIl,
+causing cold-build `AVLN2000` and headless `[AvaloniaFact]` hangs (App.axaml fails to
+precompile). The two resx files stay `EmbeddedResource` (SDK auto-include); `Resources.resx`
+is the neutral English set and `Resources.ru.resx` compiles into the
+`ru/Semistep.resources.dll` satellite.
+
+- [x] add both resx files with one seed key pair to validate wiring (`TestGreeting`:
+      en `Hello`, ru `Привет`)
+- [x] commit a hand-authored `Localization/Resources.Designer.cs` (public partial class
+      `Resources`) so the accessor is a source file reachable from XAML `{x:Static}` on a
+      cold build. **Accessor mechanism used**: committed public `Resources.Designer.cs`.
+      The earlier build-time `StronglyType*` metadata approach was reverted — it emitted
+      the class after XamlIl needed it, producing 58 cold-build `AVLN2000` errors and
+      `[AvaloniaFact]` hangs. Base name resolves to `SemiStep.UI.Localization.Resources`.
+- [x] build to confirm the designer class and the `ru` satellite assembly are produced
+      (`obj/.../Resources.Designer.cs`, `bin/.../ru/Semistep.resources.dll`)
+- [x] write a smoke test: seed key resolves to the English value under `en` culture and
+      the Russian value under `ru` culture (asserts the `ru` satellite is copied to test bin)
+- [x] run tests - must pass before next task
+
+### Task 4: Extract AXAML chrome literals
+
+**Files:**
+- Modify: `SemiStep.UI/MainWindow/RecipeMenuBar.axaml` (File/Edit/View/Help + items,
+  incl. `_` mnemonics — give the `ru` values their own access keys)
+- Modify: `SemiStep.UI/MainWindow/RecipeToolBar.axaml` (button text + tooltips; visible by
+  default)
+- Modify: `SemiStep.UI/MainWindow/MainWindow.axaml` (DataGrid context menu; Title stays a
+  binding, localized in Task 5)
+- Modify: `SemiStep.UI/MainWindow/AppStatusBar.axaml` (`Sync ON/OFF`, `Connecting`,
+  `Шаг:`, `Рецепт:`, `FOR:`; last-sync via VM per StringFormat wrinkle)
+- Modify: `SemiStep.UI/MessageService/MessagePanel.axaml` (`Close` tooltip)
+- Modify: `SemiStep.UI/Dialogs/ErrorWindow.axaml` (translate the hardcoded Russian chrome
+  — Title, header, `Выход` — to English; hardcoded, NOT via resx; see Overview rationale)
+- Modify: `SemiStep.UI/Dialogs/MessageDialog.axaml` (`Message` title, `OK`)
+- Modify: `SemiStep.UI/Plc/PlcConflictDialog.axaml` (title, **both** prompt lines — "The
+  PLC contains a different recipe." and "Which version do you want to keep?" — buttons;
+  step-count labels via VM per StringFormat wrinkle)
+- Modify: `SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml` (title, message,
+  `Save`/`Don't Save`/`Cancel`)
+- Modify: `SemiStep.UI/Localization/Resources.resx`, `Resources.ru.resx` (add all keys)
+- Create: `SemiStep.Tests/UI/Localization/ChromeLocalizationTests.cs`
+
+- [x] add `xmlns:l="clr-namespace:SemiStep.UI.Localization"` and replace each literal with
+      `{x:Static l:Resources.Key}` across the listed AXAML
+- [x] give Russian menu items their own `_`-mnemonic letters
+- [x] add every English neutral value and its Russian counterpart to both resx files
+- [x] keep `InputGesture`/shortcuts and brand tokens (`SemiStep`) unlocalized
+- [x] write an `[AvaloniaFact]` under culture `ru` asserting a menu header and a dialog
+      button render their `ru` resource values
+- [x] run tests - must pass before next task
+
+### Task 5: Extract view-model literals and fold StringFormat prefixes
+
+**Files:**
+- Modify: `SemiStep.UI/MainWindow/MainWindowViewModel.cs` (`MapSyncStatus`,
+  `FormatLastSyncTime` — `Never` **and** the `" s ago"` suffix, `BuildWindowTitle`
+  `New Recipe`; expose fully localized `LastSyncTimeText`)
+- Modify: `SemiStep.UI/Plc/PlcConflictDialogViewModel.cs` (expose localized step-count
+  strings)
+- Modify: `SemiStep.UI/MessageService/MessagePanelViewModel.cs` (`ErrorCountText`,
+  `WarningCountText` — currently `$"{c} {(c==1?"Error":"Errors")}"`, lines 57/62)
+- Modify: `SemiStep.UI/Localization/Resources.resx`, `Resources.ru.resx`
+- Modify/Create: `SemiStep.Tests/UI/...` view-model tests
+
+- [x] replace VM literals with `Resources.Key`; `MapSyncStatus` states, `Never`,
+      `New Recipe`
+- [x] localize `FormatLastSyncTime`: `Never` key + an elapsed format key; keep
+      `{elapsed:0.0}` formatted with `InvariantCulture`, only the words from resx
+- [x] fold `Last sync: {0}`, step counts, and Error/Warning counts into VM properties
+      using plural-neutral Russian phrasing (`Шагов: {0}`, `Ошибок: {0}`,
+      `Предупреждений: {0}`); format numbers with `InvariantCulture`
+- [x] add the corresponding keys to both resx files
+- [x] write/adjust tests asserting these VM properties return the `ru` text under `ru`
+      (incl. count strings at 0/1/many)
+- [x] run tests - must pass before next task
+
+### Task 6: Confirm logs and diagnostics stay English
+
+**Files:**
+- Modify (if needed): none expected
+- Reference: `SemiStep.UI/Program.cs`, `MainWindowViewModel.cs` `ReportError` sites
+
+- [x] grep for `Log.` / `_logger.` templates and confirm none are routed through resources
+      — `grep -rnE "Log(ger)?\.|_logger\.|LogInformation|LogWarning|LogError|ForContext"
+      SemiStep.UI SemiStep.Core --include=*.cs | grep -i "Resources\."` returns nothing.
+      All Serilog templates (e.g. `Program.cs:81` `"Application startup failed: ..."`) are
+      hardcoded English literals.
+- [x] decision: notification-panel `ReportError` diagnostic strings (e.g. `Sync toggle
+      failed: {ex.Message}`, `Failed to show PLC conflict dialog`, `Style editor failed:
+      {ex.Message}`) stay **English** — they carry exception text and are diagnostic, not
+      chrome. Verified: all `ReportError` sites (MainWindowViewModel, ClipboardViewModel,
+      RecipeFileViewModel, RecipeGridViewModel) use English interpolated literals, none
+      route through `Resources`. Revisit only if the user wants the log panel localized.
+- [x] confirm `CurrentCulture` untouched so `{elapsed:0.0}` and log timestamps stay
+      invariant — `grep -rn "CurrentCulture" SemiStep.UI` shows only a `Program.cs` comment,
+      the `DefaultThreadCurrentUICulture` assignment (`Program.cs:90`, UI culture only), and a
+      read of `CultureInfo.CurrentCulture` for text measurement (`ColumnWidthCalculator.cs:230`).
+      No `CurrentCulture` or `DefaultThreadCurrentCulture` is ever assigned; only `*UICulture`
+      and `Resources.Culture` are set. `ErrorWindow.axaml` is hardcoded English (no `xmlns:l`,
+      no `{x:Static}`).
+
+### Task 7: Verify acceptance criteria
+
+- [x] main-window chrome (menu, toolbar, status bar incl. Error/Warning counts, context
+      menu, dialogs) renders in Russian by default (`ui/app.yaml` absent or `locale: ru`);
+      the settings editor + restart prompt are the known, documented English exclusions —
+      verified via ChromeLocalizationTests headless [AvaloniaFact] under ru culture (full
+      manual app run not automatable here)
+- [x] switching `ui/app.yaml` to `locale: en` renders English chrome — covered by resx
+      neutral-English fallback + UiCultureSelector tests (manual app run not automatable here)
+- [x] config-load-failure `ErrorWindow` renders in English — ErrorWindow is hardcoded
+      English (verified Task 6)
+- [x] run full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 0 failed,
+      1039 passed, 0 skipped (41 s, --blame-hang 60000ms)
+- [x] run `dotnet format SemiStep/SemiStep.slnx` — no changes (already formatted)
+- [x] build entry exe: `dotnet build SemiStep/SemiStep.UI/SemiStep.UI.csproj` — 0 AVLN2000,
+      0 errors, build succeeded
+
+### Task 8: Documentation
+
+**Files:**
+- Create: `Docs/architecture/ui-localization.md`
+- Modify (if a config reference exists): equipment-config docs mentioning the `ui/` folder
+
+- [x] document the `ui/app.yaml` `locale` key, the en-neutral/ru model, default `ru`, and
+      the "logs and CurrentCulture stay English" rule
+- [x] moved to `Docs/plans/completed/` after review + finalize phases
+
+## Post-Completion
+
+**Manual verification**:
+- Native-speaker proofread of all Russian resource values for wording/context.
+- Smoke-run the packaged app against a real `C:\DISTR\Config\Semistep\MBE` config.
+
+**External system updates**:
+- Add `ui/app.yaml` (with the intended `locale`) to each deployed equipment config root;
+  absent file falls back to `ru`, so this is optional per site.

--- a/SemiStep/SemiStep.Core/Configuration/AppConfiguration.cs
+++ b/SemiStep/SemiStep.Core/Configuration/AppConfiguration.cs
@@ -9,4 +9,5 @@ public sealed record AppConfiguration(
 	IReadOnlyDictionary<string, GroupDefinition> Groups,
 	IReadOnlyDictionary<int, ActionDefinition> Actions,
 	GridStyleOptions GridStyle,
-	PlcConfiguration PlcConfiguration);
+	PlcConfiguration PlcConfiguration,
+	AppUiOptions Ui);

--- a/SemiStep/SemiStep.Core/Configuration/AppUiOptions.cs
+++ b/SemiStep/SemiStep.Core/Configuration/AppUiOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace SemiStep.Core.Configuration;
+
+public sealed record AppUiOptions(string Locale)
+{
+	public const string DefaultLocale = "ru";
+
+	public static AppUiOptions Default { get; } = new(DefaultLocale);
+}

--- a/SemiStep/SemiStep.Core/Configuration/Dto/AppUiOptionsDto.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Dto/AppUiOptionsDto.cs
@@ -1,0 +1,8 @@
+﻿using YamlDotNet.Serialization;
+
+namespace SemiStep.Core.Configuration.Dto;
+
+internal sealed class AppUiOptionsDto
+{
+	[YamlMember(Alias = "locale")] public string? Locale { get; set; }
+}

--- a/SemiStep/SemiStep.Core/Configuration/Facade/ConfigFacade.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Facade/ConfigFacade.cs
@@ -29,7 +29,7 @@ public static class ConfigFacade
 			return LogAndPropagate(loadResult);
 		}
 
-		var (properties, columns, groups, actions, gridStyle, connection) = loadResult.Value;
+		var (properties, columns, groups, actions, gridStyle, connection, appUi) = loadResult.Value;
 
 		var gridStyleResult = GridStyleValidator.Validate(gridStyle);
 		if (gridStyleResult.IsFailed)
@@ -49,7 +49,7 @@ public static class ConfigFacade
 			return LogAndPropagate(defaultsResult, loadResult, xrefResult);
 		}
 
-		var mapResult = MapToDomain(properties, columns, groups, actions, gridStyle, connection);
+		var mapResult = MapToDomain(properties, columns, groups, actions, gridStyle, connection, appUi);
 
 		if (mapResult.IsFailed)
 		{
@@ -98,6 +98,7 @@ public static class ConfigFacade
 		var actionsResult = await ActionsSectionLoader.LoadAsync(configDirectory);
 		var gridStyleResult = await GridStyleLoader.LoadAsync(configDirectory);
 		var connectionResult = await ConnectionLoader.LoadAsync(configDirectory);
+		var appUiResult = await AppUiOptionsLoader.LoadAsync(configDirectory);
 
 		var merged = Result.Merge(
 			propertiesResult.ToResult(),
@@ -105,7 +106,8 @@ public static class ConfigFacade
 			groupsResult.ToResult(),
 			actionsResult.ToResult(),
 			gridStyleResult.ToResult(),
-			connectionResult.ToResult());
+			connectionResult.ToResult(),
+			appUiResult.ToResult());
 
 		if (merged.IsFailed)
 		{
@@ -118,7 +120,8 @@ public static class ConfigFacade
 			groupsResult.Value,
 			actionsResult.Value,
 			gridStyleResult.Value,
-			connectionResult.Value);
+			connectionResult.Value,
+			appUiResult.Value);
 
 		return Result.Ok(sections).WithReasons(merged.Reasons);
 	}
@@ -129,7 +132,8 @@ public static class ConfigFacade
 		Dictionary<string, Dictionary<int, string>> groups,
 		List<Dto.ActionDto> actions,
 		Dto.GridStyleOptionsDto? gridStyle,
-		Dto.ConnectionDto? connection)
+		Dto.ConnectionDto? connection,
+		Dto.AppUiOptionsDto? appUi)
 	{
 		var mappedProperties = PropertyMapper.MapMany(properties)
 			.ToDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase);
@@ -165,9 +169,11 @@ public static class ConfigFacade
 
 		var plcConfiguration = ConnectionMapper.Map(connection);
 
+		var appUiOptions = AppUiOptionsMapper.Map(appUi);
+
 		return Result.Ok(new AppConfiguration(
 			mappedProperties, mappedColumns, mappedGroups,
-			mappedActions, mappedGridStyle, plcConfiguration));
+			mappedActions, mappedGridStyle, plcConfiguration, appUiOptions));
 	}
 
 	private sealed record LoadedSections(
@@ -176,5 +182,6 @@ public static class ConfigFacade
 		Dictionary<string, Dictionary<int, string>> Groups,
 		List<Dto.ActionDto> Actions,
 		Dto.GridStyleOptionsDto? GridStyle,
-		Dto.ConnectionDto? Connection);
+		Dto.ConnectionDto? Connection,
+		Dto.AppUiOptionsDto? AppUi);
 }

--- a/SemiStep/SemiStep.Core/Configuration/Loaders/AppUiOptionsLoader.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Loaders/AppUiOptionsLoader.cs
@@ -1,0 +1,38 @@
+﻿using FluentResults;
+
+using SemiStep.Core.Configuration.Dto;
+
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SemiStep.Core.Configuration.Loaders;
+
+internal static class AppUiOptionsLoader
+{
+	private static readonly IDeserializer _deserializer = new DeserializerBuilder()
+		.WithNamingConvention(UnderscoredNamingConvention.Instance)
+		.IgnoreUnmatchedProperties()
+		.Build();
+
+	public static async Task<Result<AppUiOptionsDto?>> LoadAsync(string configDirectory)
+	{
+		var filePath = Path.Combine(configDirectory, "ui", "app.yaml");
+
+		// Optional file: absence yields defaults, unlike the required grid_style.yaml.
+		if (!File.Exists(filePath))
+		{
+			return Result.Ok<AppUiOptionsDto?>(null);
+		}
+
+		try
+		{
+			var content = await File.ReadAllTextAsync(filePath);
+
+			return Result.Ok(_deserializer.Deserialize<AppUiOptionsDto?>(content));
+		}
+		catch (Exception ex)
+		{
+			return Result.Fail($"Failed to load {Path.GetFileName(filePath)}: {ex.Message}");
+		}
+	}
+}

--- a/SemiStep/SemiStep.Core/Configuration/Mapping/AppUiOptionsMapper.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Mapping/AppUiOptionsMapper.cs
@@ -1,0 +1,16 @@
+﻿using SemiStep.Core.Configuration.Dto;
+
+namespace SemiStep.Core.Configuration.Mapping;
+
+internal static class AppUiOptionsMapper
+{
+	public static AppUiOptions Map(AppUiOptionsDto? dto)
+	{
+		if (dto?.Locale is not { } locale || string.IsNullOrWhiteSpace(locale))
+		{
+			return AppUiOptions.Default;
+		}
+
+		return new AppUiOptions(locale.Trim());
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Configuration/AppUiOptionsLoaderTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Configuration/AppUiOptionsLoaderTests.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+
+using SemiStep.Core.Configuration;
+using SemiStep.Core.Configuration.Loaders;
+using SemiStep.Core.Configuration.Mapping;
+using SemiStep.Tests.Config.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Core.Configuration;
+
+[Trait("Category", "Unit")]
+[Trait("Component", "Config")]
+[Trait("Area", "AppUiOptionsLoader")]
+public sealed class AppUiOptionsLoaderTests
+{
+	[Fact]
+	public async Task LoadAndMap_PresentEnglishLocale_ResolvesEn()
+	{
+		using var tempDir = TestDataCopier.CreateEmptyTempDirectory();
+		TestDataCopier.WriteYaml(tempDir, Path.Combine("ui", "app.yaml"), "locale: en\n");
+
+		var loadResult = await AppUiOptionsLoader.LoadAsync(tempDir.Path);
+
+		loadResult.IsSuccess.Should().BeTrue();
+		AppUiOptionsMapper.Map(loadResult.Value).Locale.Should().Be("en");
+	}
+
+	[Fact]
+	public async Task LoadAndMap_PresentRussianLocale_ResolvesRu()
+	{
+		using var tempDir = TestDataCopier.CreateEmptyTempDirectory();
+		TestDataCopier.WriteYaml(tempDir, Path.Combine("ui", "app.yaml"), "locale: ru\n");
+
+		var loadResult = await AppUiOptionsLoader.LoadAsync(tempDir.Path);
+
+		loadResult.IsSuccess.Should().BeTrue();
+		AppUiOptionsMapper.Map(loadResult.Value).Locale.Should().Be("ru");
+	}
+
+	[Fact]
+	public async Task LoadAndMap_AbsentFile_DefaultsToRu()
+	{
+		using var tempDir = TestDataCopier.CreateEmptyTempDirectory();
+
+		var loadResult = await AppUiOptionsLoader.LoadAsync(tempDir.Path);
+
+		loadResult.IsSuccess.Should().BeTrue();
+		loadResult.Value.Should().BeNull();
+		AppUiOptionsMapper.Map(loadResult.Value).Locale.Should().Be(AppUiOptions.DefaultLocale);
+	}
+
+	[Fact]
+	public async Task LoadAndMap_BlankLocale_DefaultsToRu()
+	{
+		using var tempDir = TestDataCopier.CreateEmptyTempDirectory();
+		TestDataCopier.WriteYaml(tempDir, Path.Combine("ui", "app.yaml"), "locale: \"   \"\n");
+
+		var loadResult = await AppUiOptionsLoader.LoadAsync(tempDir.Path);
+
+		loadResult.IsSuccess.Should().BeTrue();
+		AppUiOptionsMapper.Map(loadResult.Value).Locale.Should().Be(AppUiOptions.DefaultLocale);
+	}
+
+	[Fact]
+	public async Task LoadAndMap_GarbageLocale_StoredAsIs()
+	{
+		using var tempDir = TestDataCopier.CreateEmptyTempDirectory();
+		TestDataCopier.WriteYaml(tempDir, Path.Combine("ui", "app.yaml"), "locale: not-a-culture\n");
+
+		var loadResult = await AppUiOptionsLoader.LoadAsync(tempDir.Path);
+
+		loadResult.IsSuccess.Should().BeTrue();
+		AppUiOptionsMapper.Map(loadResult.Value).Locale.Should().Be("not-a-culture");
+	}
+}

--- a/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionFormulaIntegrationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionFormulaIntegrationTests.cs
@@ -188,7 +188,8 @@ public sealed class RecipeSessionFormulaIntegrationTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: actions,
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		var registry = new RecipeMetadataRegistry(configuration);
 		var analyzer = new RecipeAnalyzer(registry);

--- a/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionSelectorSeedIntegrationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionSelectorSeedIntegrationTests.cs
@@ -154,7 +154,8 @@ public sealed class RecipeSessionSelectorSeedIntegrationTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: actions,
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(configuration);
 	}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Analysis/ExecutionTimeEstimatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Analysis/ExecutionTimeEstimatorTests.cs
@@ -58,7 +58,8 @@ public sealed class ExecutionTimeEstimatorTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: actions,
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Analysis/TimingCalculatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Analysis/TimingCalculatorTests.cs
@@ -57,7 +57,8 @@ public sealed class TimingCalculatorTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: actions,
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Formulas/FormulaEvaluatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Formulas/FormulaEvaluatorTests.cs
@@ -664,7 +664,8 @@ public sealed class FormulaEvaluatorTests
 			Groups: groups,
 			Actions: actions,
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default));
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default));
 	}
 
 	private static RecipeMetadataRegistry BuildRegistryWithoutFormula()
@@ -698,7 +699,8 @@ public sealed class FormulaEvaluatorTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: actions,
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 	}
 
 	private static void EnsureStringSentinelProperty(Dictionary<string, PropertyTypeDefinition> properties)

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeMetadataRegistryTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeMetadataRegistryTests.cs
@@ -35,7 +35,8 @@ public sealed class RecipeMetadataRegistryTests
 			Groups: groups,
 			Actions: new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}
@@ -252,7 +253,8 @@ public sealed class RecipeMetadataRegistryTests
 			Groups: new Dictionary<string, GroupDefinition>(StringComparer.OrdinalIgnoreCase),
 			Actions: actions,
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/Helpers/TestRecipeMetadataRegistryFactory.cs
+++ b/SemiStep/SemiStep.Tests/Helpers/TestRecipeMetadataRegistryFactory.cs
@@ -46,7 +46,8 @@ internal static class TestRecipeMetadataRegistryFactory
 			Groups: groups ?? new Dictionary<string, GroupDefinition>(),
 			Actions: actions ?? new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/S7/PlcExecutionMonitorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcExecutionMonitorTests.cs
@@ -44,7 +44,8 @@ public sealed class PlcExecutionMonitorTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcSyncCoordinatorTests.cs
@@ -68,7 +68,8 @@ public sealed class PlcSyncCoordinatorTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/S7/PlcTransactionExecutorTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/PlcTransactionExecutorTests.cs
@@ -53,7 +53,8 @@ public sealed class PlcTransactionExecutorTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/S7/S7DiArrayCodecRegistrationTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/S7DiArrayCodecRegistrationTests.cs
@@ -69,6 +69,7 @@ public sealed class S7DiArrayCodecRegistrationTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 	}
 }

--- a/SemiStep/SemiStep.Tests/S7/S7DiTransportSingletonTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/S7DiTransportSingletonTests.cs
@@ -50,6 +50,7 @@ public sealed class S7DiTransportSingletonTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 	}
 }

--- a/SemiStep/SemiStep.Tests/S7/S7ServiceTests.cs
+++ b/SemiStep/SemiStep.Tests/S7/S7ServiceTests.cs
@@ -45,7 +45,8 @@ public sealed class S7ServiceTests
 			Groups: new Dictionary<string, GroupDefinition>(),
 			Actions: new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/UI/GroupComboBoxRecyclingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/GroupComboBoxRecyclingTests.cs
@@ -214,7 +214,8 @@ public sealed class GroupComboBoxRecyclingTests : IAsyncLifetime
 			Groups: groups,
 			Actions: new Dictionary<int, ActionDefinition>(),
 			GridStyle: GridStyleOptions.Default,
-			PlcConfiguration: PlcConfiguration.Default);
+			PlcConfiguration: PlcConfiguration.Default,
+			Ui: AppUiOptions.Default);
 
 		return new RecipeMetadataRegistry(config);
 	}

--- a/SemiStep/SemiStep.Tests/UI/Localization/ChromeLocalizationTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ChromeLocalizationTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+
+using FluentAssertions;
+
+using SemiStep.UI.Localization;
+using SemiStep.UI.MainWindow;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.Localization;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Localization")]
+[Trait("Category", "Unit")]
+public sealed class ChromeLocalizationTests
+{
+	[AvaloniaFact]
+	public void RecipeMenuBar_UnderRussianCulture_RendersRussianHeaders()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			var menuBar = new RecipeMenuBar();
+			var headers = menuBar.GetLogicalDescendants()
+				.OfType<MenuItem>()
+				.Select(item => item.Header as string)
+				.ToList();
+
+			headers.Should().Contain("_Файл");
+			headers.Should().Contain("_Правка");
+		}
+	}
+
+	[Fact]
+	public void DialogKeys_UnderRussianCulture_ResolveToRussianValues()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			Resources.DialogSave.Should().Be("Сохранить");
+			Resources.DialogCancel.Should().Be("Отмена");
+			Resources.PlcConflictKeepLocal.Should().Be("Оставить локальный");
+		}
+	}
+
+	[Fact]
+	public void ChromeKeys_UnderEnglishCulture_ResolveToNeutralValues()
+	{
+		using (ResourcesCultureScope.Use("en"))
+		{
+			Resources.MenuFile.Should().Be("_File");
+			Resources.DialogSave.Should().Be("Save");
+			Resources.PlcConflictKeepLocal.Should().Be("Keep local");
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Localization/ResourceResolutionTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ResourceResolutionTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Globalization;
+
+using FluentAssertions;
+
+using SemiStep.UI.Localization;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.Localization;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Localization")]
+[Trait("Category", "Unit")]
+public sealed class ResourceResolutionTests
+{
+	[Fact]
+	public void GetString_EnglishCulture_ReturnsNeutralValue()
+	{
+		Resources.ResourceManager.GetString("MenuFile", new CultureInfo("en"))
+			.Should().Be("_File");
+	}
+
+	[Fact]
+	public void GetString_RussianCulture_ReturnsSatelliteValue()
+	{
+		Resources.ResourceManager.GetString("MenuFile", new CultureInfo("ru"))
+			.Should().Be("_Файл");
+	}
+
+	[Fact]
+	public void Culture_Russian_ResolvesTypedAccessorToSatelliteValue()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			Resources.MenuFile.Should().Be("_Файл");
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Localization/ResourceSyncTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ResourceSyncTests.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+using FluentAssertions;
+
+using SemiStep.UI.Localization;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.Localization;
+
+[Trait("Component", "UI")]
+[Trait("Category", "Unit")]
+public sealed class ResourceSyncTests
+{
+	public static IEnumerable<object[]> LocalizedKeys()
+	{
+		return typeof(Resources)
+			.GetProperties(BindingFlags.Public | BindingFlags.Static)
+			.Where(property => property.PropertyType == typeof(string))
+			.Select(property => new object[] { property.Name });
+	}
+
+	[Theory]
+	[MemberData(nameof(LocalizedKeys))]
+	public void Key_ResolvesToNonEmptyValue_UnderEnglishAndRussian(string keyName)
+	{
+		var property = typeof(Resources).GetProperty(keyName, BindingFlags.Public | BindingFlags.Static)!;
+
+		foreach (var culture in new[] { "en", "ru" })
+		{
+			using (ResourcesCultureScope.Use(culture))
+			{
+				var value = (string)property.GetValue(null)!;
+
+				value.Should().NotBeNullOrEmpty(
+					"key '{0}' must resolve under culture '{1}' (missing resx entry?)", keyName, culture);
+			}
+		}
+	}
+
+	public static IEnumerable<object[]> FormatKeys()
+	{
+		var keyNames = new[]
+		{
+			nameof(Resources.LastSyncAgoFormat),
+			nameof(Resources.LastSyncPrefix),
+			nameof(Resources.MessagePanelErrorsFormat),
+			nameof(Resources.MessagePanelWarningsFormat),
+			nameof(Resources.PlcConflictLocalSteps),
+			nameof(Resources.PlcConflictPlcSteps)
+		};
+
+		return keyNames.Select(keyName => new object[] { keyName });
+	}
+
+	[Theory]
+	[MemberData(nameof(FormatKeys))]
+	public void FormatKey_ContainsPlaceholder_UnderEnglishAndRussian(string keyName)
+	{
+		var property = typeof(Resources).GetProperty(keyName, BindingFlags.Public | BindingFlags.Static)!;
+
+		foreach (var culture in new[] { "en", "ru" })
+		{
+			using (ResourcesCultureScope.Use(culture))
+			{
+				var value = (string)property.GetValue(null)!;
+
+				value.Should().Contain(
+					"{0}", "format key '{0}' must keep its placeholder under culture '{1}'", keyName, culture);
+			}
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Localization/ResourceSyncTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ResourceSyncTests.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 using FluentAssertions;
 
@@ -15,6 +17,11 @@ namespace SemiStep.Tests.UI.Localization;
 [Trait("Category", "Unit")]
 public sealed class ResourceSyncTests
 {
+	// tryParents: false reads only the requested culture's own entries, so a key missing
+	// from a satellite is absent here instead of silently falling back to the neutral value.
+	private static readonly Dictionary<string, string> _neutral = ReadOwnResourceSet(CultureInfo.InvariantCulture);
+	private static readonly Dictionary<string, string> _russian = ReadOwnResourceSet(new CultureInfo("ru"));
+
 	public static IEnumerable<object[]> LocalizedKeys()
 	{
 		return typeof(Resources)
@@ -41,36 +48,48 @@ public sealed class ResourceSyncTests
 		}
 	}
 
-	public static IEnumerable<object[]> FormatKeys()
+	[Fact]
+	public void RussianSatellite_ContainsEveryNeutralKey_AndNoOrphans()
 	{
-		var keyNames = new[]
-		{
-			nameof(Resources.LastSyncAgoFormat),
-			nameof(Resources.LastSyncPrefix),
-			nameof(Resources.MessagePanelErrorsFormat),
-			nameof(Resources.MessagePanelWarningsFormat),
-			nameof(Resources.PlcConflictLocalSteps),
-			nameof(Resources.PlcConflictPlcSteps)
-		};
-
-		return keyNames.Select(keyName => new object[] { keyName });
+		// ResourceManager falls back to the neutral value for a missing satellite key, so the
+		// per-key resolution test above cannot catch an untranslated key. Compare the raw key
+		// sets instead: every English key must have a Russian entry, and no orphan ru keys exist.
+		_russian.Keys.Should().BeEquivalentTo(_neutral.Keys,
+			"every neutral (English) resx key must have a matching Russian translation, and vice versa");
 	}
 
-	[Theory]
-	[MemberData(nameof(FormatKeys))]
-	public void FormatKey_ContainsPlaceholder_UnderEnglishAndRussian(string keyName)
+	[Fact]
+	public void EveryValue_IsNonEmpty_InBothSatellites()
 	{
-		var property = typeof(Resources).GetProperty(keyName, BindingFlags.Public | BindingFlags.Static)!;
+		_neutral.Values.Should().NotContain(string.Empty, "no English resx value may be blank");
+		_russian.Values.Should().NotContain(string.Empty, "no Russian resx value may be blank");
+	}
 
-		foreach (var culture in new[] { "en", "ru" })
+	[Fact]
+	public void PlaceholderSets_Match_BetweenEnglishAndRussian()
+	{
+		foreach (var (key, englishValue) in _neutral)
 		{
-			using (ResourcesCultureScope.Use(culture))
-			{
-				var value = (string)property.GetValue(null)!;
+			var englishPlaceholders = Placeholders(englishValue);
+			var russianPlaceholders = Placeholders(_russian.GetValueOrDefault(key, string.Empty));
 
-				value.Should().Contain(
-					"{0}", "format key '{0}' must keep its placeholder under culture '{1}'", keyName, culture);
-			}
+			russianPlaceholders.Should().BeEquivalentTo(englishPlaceholders,
+				"key '{0}' must use the same {{n}} format placeholders in English and Russian", key);
 		}
+	}
+
+	private static ISet<int> Placeholders(string value)
+	{
+		return Regex.Matches(value, @"\{(\d+)")
+			.Select(match => int.Parse(match.Groups[1].Value))
+			.ToHashSet();
+	}
+
+	private static Dictionary<string, string> ReadOwnResourceSet(CultureInfo culture)
+	{
+		var set = Resources.ResourceManager.GetResourceSet(culture, createIfNotExists: true, tryParents: false)!;
+
+		return set.Cast<DictionaryEntry>()
+			.ToDictionary(entry => (string)entry.Key, entry => (string)entry.Value!);
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/Localization/ResourcesCultureScope.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ResourcesCultureScope.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Globalization;
+
+using SemiStep.UI.Localization;
+
+namespace SemiStep.Tests.UI.Localization;
+
+internal sealed class ResourcesCultureScope : IDisposable
+{
+	private readonly CultureInfo? _previousCulture;
+
+	private ResourcesCultureScope(string culture)
+	{
+		_previousCulture = Resources.Culture;
+		Resources.Culture = new CultureInfo(culture);
+	}
+
+	public static IDisposable Use(string culture)
+	{
+		return new ResourcesCultureScope(culture);
+	}
+
+	public void Dispose()
+	{
+		Resources.Culture = _previousCulture;
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Localization/UiCultureSelectorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/UiCultureSelectorTests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+
+using SemiStep.UI.Localization;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.Localization;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Localization")]
+[Trait("Category", "Unit")]
+public sealed class UiCultureSelectorTests
+{
+	[Fact]
+	public void Resolve_EnglishTag_ReturnsEnglish()
+	{
+		UiCultureSelector.Resolve("en").Name.Should().Be("en");
+	}
+
+	[Fact]
+	public void Resolve_RussianTag_ReturnsRussian()
+	{
+		UiCultureSelector.Resolve("ru").Name.Should().Be("ru");
+	}
+
+	[Fact]
+	public void Resolve_Null_ReturnsRussian()
+	{
+		UiCultureSelector.Resolve(null).Name.Should().Be("ru");
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("  ")]
+	public void Resolve_Blank_ReturnsRussian(string locale)
+	{
+		UiCultureSelector.Resolve(locale).Name.Should().Be("ru");
+	}
+
+	[Fact]
+	public void Resolve_InvalidTag_ReturnsRussian()
+	{
+		UiCultureSelector.Resolve("zz-ZZ-garbage").Name.Should().Be("ru");
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Localization/ViewModelLocalizationTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ViewModelLocalizationTests.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Globalization;
+
+using FluentAssertions;
+
+using SemiStep.Core.Plc.State;
+
+using SemiStep.UI.Localization;
+using SemiStep.UI.MainWindow;
+using SemiStep.UI.MessageService;
+using SemiStep.UI.Plc;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.Localization;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Localization")]
+[Trait("Category", "Unit")]
+public sealed class ViewModelLocalizationTests
+{
+	[Theory]
+	[InlineData(PlcSyncStatus.Idle, "Ожидание")]
+	[InlineData(PlcSyncStatus.Syncing, "Синхронизация…")]
+	[InlineData(PlcSyncStatus.Synced, "Синхронизировано")]
+	[InlineData(PlcSyncStatus.Failed, "Ошибка")]
+	public void MapSyncStatus_UnderRussianCulture_ReturnsRussianText(PlcSyncStatus status, string expected)
+	{
+		WithCulture("ru", () => MainWindowViewModel.MapSyncStatus(status).Should().Be(expected));
+	}
+
+	[Theory]
+	[InlineData(PlcSyncStatus.Idle, "Idle")]
+	[InlineData(PlcSyncStatus.Syncing, "Syncing...")]
+	[InlineData(PlcSyncStatus.Synced, "Synced")]
+	[InlineData(PlcSyncStatus.Failed, "Failed")]
+	public void MapSyncStatus_UnderEnglishCulture_ReturnsNeutralText(PlcSyncStatus status, string expected)
+	{
+		WithCulture("en", () => MainWindowViewModel.MapSyncStatus(status).Should().Be(expected));
+	}
+
+	[Fact]
+	public void MapSyncStatus_OutOfSync_ReturnsEmptyRegardlessOfCulture()
+	{
+		WithCulture("ru", () => MainWindowViewModel.MapSyncStatus(PlcSyncStatus.OutOfSync).Should().BeEmpty());
+	}
+
+	[Fact]
+	public void FormatLastSyncTime_Never_UnderRussianCulture_ReturnsRussianText()
+	{
+		WithCulture("ru", () => MainWindowViewModel.FormatLastSyncTime(null).Should().Be("Синхр.: Никогда"));
+	}
+
+	[Fact]
+	public void FormatLastSyncTime_Never_UnderEnglishCulture_ReturnsNeutralText()
+	{
+		WithCulture("en", () => MainWindowViewModel.FormatLastSyncTime(null).Should().Be("Last sync: Never"));
+	}
+
+	[Fact]
+	public void FormatLastSyncTime_Elapsed_KeepsNumberInvariant()
+	{
+		WithCulture("ru", () =>
+		{
+			var text = MainWindowViewModel.FormatLastSyncTime(DateTimeOffset.UtcNow.AddSeconds(-100));
+
+			text.Should().StartWith("Синхр.: ");
+			text.Should().Contain("с назад");
+			text.Should().Contain("100.0");
+			text.Should().NotContain(",");
+		});
+	}
+
+	[Fact]
+	public void LastSyncAgoFormat_UnderRussianCulture_RendersInvariantDecimal()
+	{
+		WithCulture("ru", () =>
+			string.Format(
+					CultureInfo.InvariantCulture,
+					Resources.LastSyncAgoFormat ?? "{0}",
+					(12.5).ToString("0.0", CultureInfo.InvariantCulture))
+				.Should().Be("12.5 с назад"));
+	}
+
+	[Theory]
+	[InlineData(0, "Ошибок: 0")]
+	[InlineData(1, "Ошибок: 1")]
+	[InlineData(5, "Ошибок: 5")]
+	public void FormatErrorCount_UnderRussianCulture_ReturnsRussianText(int count, string expected)
+	{
+		WithCulture("ru", () => MessagePanelViewModel.FormatErrorCount(count).Should().Be(expected));
+	}
+
+	[Theory]
+	[InlineData(0, "Предупреждений: 0")]
+	[InlineData(1, "Предупреждений: 1")]
+	[InlineData(5, "Предупреждений: 5")]
+	public void FormatWarningCount_UnderRussianCulture_ReturnsRussianText(int count, string expected)
+	{
+		WithCulture("ru", () => MessagePanelViewModel.FormatWarningCount(count).Should().Be(expected));
+	}
+
+	[Fact]
+	public void FormatErrorCount_UnderEnglishCulture_ReturnsNeutralText()
+	{
+		WithCulture("en", () => MessagePanelViewModel.FormatErrorCount(2).Should().Be("Errors: 2"));
+	}
+
+	[Fact]
+	public void PlcConflictStepCounts_UnderRussianCulture_ReturnRussianText()
+	{
+		WithCulture("ru", () =>
+		{
+			var viewModel = new PlcConflictDialogViewModel(3, 7);
+
+			viewModel.LocalStepCountText.Should().Be("Локально шагов: 3");
+			viewModel.PlcStepCountText.Should().Be("Шагов в ПЛК: 7");
+		});
+	}
+
+	[Fact]
+	public void PlcConflictStepCounts_UnderEnglishCulture_ReturnNeutralText()
+	{
+		WithCulture("en", () =>
+		{
+			var viewModel = new PlcConflictDialogViewModel(3, 7);
+
+			viewModel.LocalStepCountText.Should().Be("Local steps: 3");
+			viewModel.PlcStepCountText.Should().Be("PLC steps: 7");
+		});
+	}
+
+	private static void WithCulture(string culture, Action assertion)
+	{
+		using (ResourcesCultureScope.Use(culture))
+		{
+			assertion();
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/AppStatusBarTimerFontTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/AppStatusBarTimerFontTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 
 using SemiStep.Core.Configuration;
 using SemiStep.Tests.UI.Helpers;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.Styles;
 
@@ -53,10 +54,11 @@ public sealed class AppStatusBarTimerFontTests : IAsyncLifetime
 
 		var labels = statusBar.GetVisualDescendants()
 			.OfType<TextBlock>()
-			.Where(textBlock => textBlock.Text is "Шаг:" or "Рецепт:")
+			.Where(textBlock => textBlock.Text == Resources.StatusStepLabel
+				|| textBlock.Text == Resources.StatusRecipeLabel)
 			.ToList();
 
-		labels.Should().HaveCount(2, "each timer row carries a Шаг:/Рецепт: label TextBlock");
+		labels.Should().HaveCount(2, "each timer row carries a step/recipe label TextBlock");
 
 		foreach (var label in labels)
 		{

--- a/SemiStep/SemiStep.Tests/UI/MainWindowViewModelSyncStateTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindowViewModelSyncStateTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using SemiStep.Core.Plc.State;
 using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
+using SemiStep.Tests.UI.Localization;
 using SemiStep.UI.MainWindow;
 
 using Xunit;
@@ -124,9 +125,21 @@ public sealed class MainWindowViewModelSyncStateTests : IAsyncLifetime
 	[InlineData(PlcSyncStatus.Failed, "Failed")]
 	public void PlcSyncStatusText_ForPipelineStatuses_ReturnsText(PlcSyncStatus status, string expected)
 	{
-		_fixture.PlcSyncService.Status = status;
+		using (ResourcesCultureScope.Use("en"))
+		{
+			_fixture.PlcSyncService.Status = status;
 
-		_viewModel.PlcSyncStatusText.Should().Be(expected);
+			_viewModel.PlcSyncStatusText.Should().Be(expected);
+		}
+	}
+
+	[AvaloniaFact]
+	public void WindowTitle_NewRecipe_UnderRussianCulture_UsesRussianLabelAndKeepsBrand()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			_viewModel.WindowTitle.Should().Be("SemiStep - Новый рецепт");
+		}
 	}
 
 	private int CountTrueStates()

--- a/SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs
@@ -6,6 +6,7 @@ using FluentResults;
 
 using SemiStep.Core.Shared;
 
+using SemiStep.Tests.UI.Localization;
 using SemiStep.UI.MessageService;
 
 using Xunit;
@@ -31,32 +32,38 @@ public sealed class MessagePanelViewModelTests
 	}
 
 	[AvaloniaTheory]
-	[InlineData(1, "1 Error")]
-	[InlineData(2, "2 Errors")]
-	public void ErrorCountText_UsesSingularOrPlural(int errorCount, string expected)
+	[InlineData(1, "Errors: 1")]
+	[InlineData(2, "Errors: 2")]
+	public void ErrorCountText_UsesLabelThenCount(int errorCount, string expected)
 	{
-		var panel = new MessagePanelViewModel();
-		var reasons = Enumerable.Range(0, errorCount).Select(IReason (i) => new Error($"msg{i}")).ToList();
+		using (ResourcesCultureScope.Use("en"))
+		{
+			var panel = new MessagePanelViewModel();
+			var reasons = Enumerable.Range(0, errorCount).Select(IReason (i) => new Error($"msg{i}")).ToList();
 
-		panel.RefreshReasons(reasons);
+			panel.RefreshReasons(reasons);
 
-		panel.ErrorCountText.Should().Be(expected);
+			panel.ErrorCountText.Should().Be(expected);
+		}
 	}
 
 	[AvaloniaTheory]
-	[InlineData(1, 1, "1 Error, 1 Warning")]
-	[InlineData(2, 0, "2 Errors")]
-	[InlineData(0, 1, "1 Warning")]
+	[InlineData(1, 1, "Errors: 1, Warnings: 1")]
+	[InlineData(2, 0, "Errors: 2")]
+	[InlineData(0, 1, "Warnings: 1")]
 	public void StatusErrorSummary_CombinesErrorsAndWarnings(int errorCount, int warningCount, string expected)
 	{
-		var panel = new MessagePanelViewModel();
-		var reasons = new List<IReason>();
-		reasons.AddRange(Enumerable.Range(0, errorCount).Select(IReason (i) => new Error($"e{i}")));
-		reasons.AddRange(Enumerable.Range(0, warningCount).Select(IReason (i) => new Warning($"w{i}")));
+		using (ResourcesCultureScope.Use("en"))
+		{
+			var panel = new MessagePanelViewModel();
+			var reasons = new List<IReason>();
+			reasons.AddRange(Enumerable.Range(0, errorCount).Select(IReason (i) => new Error($"e{i}")));
+			reasons.AddRange(Enumerable.Range(0, warningCount).Select(IReason (i) => new Warning($"w{i}")));
 
-		panel.RefreshReasons(reasons);
+			panel.RefreshReasons(reasons);
 
-		panel.StatusErrorSummary.Should().Be(expected);
+			panel.StatusErrorSummary.Should().Be(expected);
+		}
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.Tests/UI/StyleEditor/GridStyleEditorViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/StyleEditor/GridStyleEditorViewModelTests.cs
@@ -4,6 +4,7 @@ using Avalonia.Media;
 using FluentAssertions;
 
 using SemiStep.Core.Configuration;
+using SemiStep.UI.Localization;
 using SemiStep.UI.StyleEditor;
 
 using Xunit;
@@ -246,7 +247,7 @@ public sealed class GridStyleEditorViewModelTests
 		var viewModel = CreateViewModel(source);
 
 		viewModel.AvailableFontFamilies[0].Value.Should().Be("");
-		viewModel.AvailableFontFamilies[0].Name.Should().Be("(Default)");
+		viewModel.AvailableFontFamilies[0].Name.Should().Be(Resources.EditorDefaultFont);
 		viewModel.AvailableFontFamilies.Should().Contain(option => option.Value == "No Such Installed Font 12345");
 	}
 

--- a/SemiStep/SemiStep.Tests/YamlConfigs/Standard/ui/app.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/Standard/ui/app.yaml
@@ -1,0 +1,1 @@
+locale: ru

--- a/SemiStep/SemiStep.UI/Dialogs/ErrorWindow.axaml
+++ b/SemiStep/SemiStep.UI/Dialogs/ErrorWindow.axaml
@@ -1,7 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="SemiStep.UI.Dialogs.ErrorWindow"
-        Title="Ошибка загрузки конфигурации"
+        Title="Configuration Load Error"
         Width="600"
         Height="400"
         CanResize="False"
@@ -16,7 +16,7 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0"
-                   Text="Ошибки загрузки конфигурации:"
+                   Text="Configuration load errors:"
                    FontWeight="Bold"
                    Margin="0,0,0,10" />
 
@@ -33,7 +33,7 @@
         </ScrollViewer>
 
         <Button Grid.Row="2"
-                Content="Выход"
+                Content="Exit"
                 Classes="primary"
                 HorizontalAlignment="Right"
                 Margin="0,16,0,0"

--- a/SemiStep/SemiStep.UI/Dialogs/MessageDialog.axaml
+++ b/SemiStep/SemiStep.UI/Dialogs/MessageDialog.axaml
@@ -2,9 +2,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:l="clr-namespace:SemiStep.UI.Localization"
         mc:Ignorable="d"
         x:Class="SemiStep.UI.Dialogs.MessageDialog"
-        Title="Message"
+        Title="{x:Static l:Resources.DialogMessageTitle}"
         Width="400"
         SizeToContent="Height"
         WindowStartupLocation="CenterOwner"
@@ -24,7 +25,7 @@
                    MinHeight="50" />
 
         <Button Grid.Row="1"
-                Content="OK"
+                Content="{x:Static l:Resources.DialogOk}"
                 Classes="primary"
                 HorizontalAlignment="Right"
                 Margin="0,20,0,0"

--- a/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
+++ b/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
@@ -1,0 +1,294 @@
+using System.CodeDom.Compiler;
+using System.Diagnostics;
+using System.Globalization;
+using System.Resources;
+
+#nullable enable
+
+namespace SemiStep.UI.Localization;
+
+[GeneratedCode("SemiStep.Localization", "1.0.0.0")]
+[DebuggerNonUserCode]
+public class Resources
+{
+	private static ResourceManager? resourceManager;
+
+	private static CultureInfo? resourceCulture;
+
+	public static ResourceManager ResourceManager
+	{
+		get
+		{
+			if (resourceManager is null)
+			{
+				resourceManager = new ResourceManager("SemiStep.UI.Localization.Resources", typeof(Resources).Assembly);
+			}
+
+			return resourceManager;
+		}
+	}
+
+	public static CultureInfo? Culture
+	{
+		get => resourceCulture;
+		set => resourceCulture = value;
+	}
+
+	public static string MenuFile => ResourceManager.GetString("MenuFile", resourceCulture) ?? string.Empty;
+
+	public static string MenuFileNewRecipe => ResourceManager.GetString("MenuFileNewRecipe", resourceCulture) ?? string.Empty;
+
+	public static string MenuFileOpenRecipe => ResourceManager.GetString("MenuFileOpenRecipe", resourceCulture) ?? string.Empty;
+
+	public static string MenuFileSaveRecipe => ResourceManager.GetString("MenuFileSaveRecipe", resourceCulture) ?? string.Empty;
+
+	public static string MenuFileSaveRecipeAs => ResourceManager.GetString("MenuFileSaveRecipeAs", resourceCulture) ?? string.Empty;
+
+	public static string MenuFileExit => ResourceManager.GetString("MenuFileExit", resourceCulture) ?? string.Empty;
+
+	public static string MenuEdit => ResourceManager.GetString("MenuEdit", resourceCulture) ?? string.Empty;
+
+	public static string MenuEditAddStep => ResourceManager.GetString("MenuEditAddStep", resourceCulture) ?? string.Empty;
+
+	public static string MenuEditDeleteStep => ResourceManager.GetString("MenuEditDeleteStep", resourceCulture) ?? string.Empty;
+
+	public static string MenuEditCopySteps => ResourceManager.GetString("MenuEditCopySteps", resourceCulture) ?? string.Empty;
+
+	public static string MenuEditCutSteps => ResourceManager.GetString("MenuEditCutSteps", resourceCulture) ?? string.Empty;
+
+	public static string MenuEditPasteSteps => ResourceManager.GetString("MenuEditPasteSteps", resourceCulture) ?? string.Empty;
+
+	public static string MenuEditUndo => ResourceManager.GetString("MenuEditUndo", resourceCulture) ?? string.Empty;
+
+	public static string MenuEditRedo => ResourceManager.GetString("MenuEditRedo", resourceCulture) ?? string.Empty;
+
+	public static string MenuView => ResourceManager.GetString("MenuView", resourceCulture) ?? string.Empty;
+
+	public static string MenuViewToolbar => ResourceManager.GetString("MenuViewToolbar", resourceCulture) ?? string.Empty;
+
+	public static string MenuViewNotificationLog => ResourceManager.GetString("MenuViewNotificationLog", resourceCulture) ?? string.Empty;
+
+	public static string MenuViewGridStyleSettings => ResourceManager.GetString("MenuViewGridStyleSettings", resourceCulture) ?? string.Empty;
+
+	public static string MenuHelp => ResourceManager.GetString("MenuHelp", resourceCulture) ?? string.Empty;
+
+	public static string MenuHelpAbout => ResourceManager.GetString("MenuHelpAbout", resourceCulture) ?? string.Empty;
+
+	public static string ContextAddStep => ResourceManager.GetString("ContextAddStep", resourceCulture) ?? string.Empty;
+
+	public static string ContextDeleteStep => ResourceManager.GetString("ContextDeleteStep", resourceCulture) ?? string.Empty;
+
+	public static string ContextCopyStep => ResourceManager.GetString("ContextCopyStep", resourceCulture) ?? string.Empty;
+
+	public static string ContextCutStep => ResourceManager.GetString("ContextCutStep", resourceCulture) ?? string.Empty;
+
+	public static string ContextPasteStep => ResourceManager.GetString("ContextPasteStep", resourceCulture) ?? string.Empty;
+
+	public static string ToolbarAddStep => ResourceManager.GetString("ToolbarAddStep", resourceCulture) ?? string.Empty;
+
+	public static string ToolbarDeleteStep => ResourceManager.GetString("ToolbarDeleteStep", resourceCulture) ?? string.Empty;
+
+	public static string ToolbarCopyStep => ResourceManager.GetString("ToolbarCopyStep", resourceCulture) ?? string.Empty;
+
+	public static string ToolbarCutStep => ResourceManager.GetString("ToolbarCutStep", resourceCulture) ?? string.Empty;
+
+	public static string ToolbarPasteStep => ResourceManager.GetString("ToolbarPasteStep", resourceCulture) ?? string.Empty;
+
+	public static string ToolbarUndo => ResourceManager.GetString("ToolbarUndo", resourceCulture) ?? string.Empty;
+
+	public static string ToolbarRedo => ResourceManager.GetString("ToolbarRedo", resourceCulture) ?? string.Empty;
+
+	public static string StatusSyncOn => ResourceManager.GetString("StatusSyncOn", resourceCulture) ?? string.Empty;
+
+	public static string StatusSyncOff => ResourceManager.GetString("StatusSyncOff", resourceCulture) ?? string.Empty;
+
+	public static string StatusConnecting => ResourceManager.GetString("StatusConnecting", resourceCulture) ?? string.Empty;
+
+	public static string StatusStepLabel => ResourceManager.GetString("StatusStepLabel", resourceCulture) ?? string.Empty;
+
+	public static string StatusRecipeLabel => ResourceManager.GetString("StatusRecipeLabel", resourceCulture) ?? string.Empty;
+
+	public static string StatusForLabel => ResourceManager.GetString("StatusForLabel", resourceCulture) ?? string.Empty;
+
+	public static string MessagePanelClose => ResourceManager.GetString("MessagePanelClose", resourceCulture) ?? string.Empty;
+
+	public static string DialogMessageTitle => ResourceManager.GetString("DialogMessageTitle", resourceCulture) ?? string.Empty;
+
+	public static string DialogOk => ResourceManager.GetString("DialogOk", resourceCulture) ?? string.Empty;
+
+	public static string DialogExitTitle => ResourceManager.GetString("DialogExitTitle", resourceCulture) ?? string.Empty;
+
+	public static string DialogExitMessage => ResourceManager.GetString("DialogExitMessage", resourceCulture) ?? string.Empty;
+
+	public static string DialogSave => ResourceManager.GetString("DialogSave", resourceCulture) ?? string.Empty;
+
+	public static string DialogDontSave => ResourceManager.GetString("DialogDontSave", resourceCulture) ?? string.Empty;
+
+	public static string DialogCancel => ResourceManager.GetString("DialogCancel", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictTitle => ResourceManager.GetString("PlcConflictTitle", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictLine1 => ResourceManager.GetString("PlcConflictLine1", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictQuestion => ResourceManager.GetString("PlcConflictQuestion", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictKeepLocal => ResourceManager.GetString("PlcConflictKeepLocal", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictLoadFromPlc => ResourceManager.GetString("PlcConflictLoadFromPlc", resourceCulture) ?? string.Empty;
+
+	public static string StatusIdle => ResourceManager.GetString("StatusIdle", resourceCulture) ?? string.Empty;
+
+	public static string StatusSyncing => ResourceManager.GetString("StatusSyncing", resourceCulture) ?? string.Empty;
+
+	public static string StatusSynced => ResourceManager.GetString("StatusSynced", resourceCulture) ?? string.Empty;
+
+	public static string StatusFailed => ResourceManager.GetString("StatusFailed", resourceCulture) ?? string.Empty;
+
+	public static string LastSyncNever => ResourceManager.GetString("LastSyncNever", resourceCulture) ?? string.Empty;
+
+	public static string LastSyncAgoFormat => ResourceManager.GetString("LastSyncAgoFormat", resourceCulture) ?? string.Empty;
+
+	public static string LastSyncPrefix => ResourceManager.GetString("LastSyncPrefix", resourceCulture) ?? string.Empty;
+
+	public static string WindowTitleNewRecipe => ResourceManager.GetString("WindowTitleNewRecipe", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictLocalSteps => ResourceManager.GetString("PlcConflictLocalSteps", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictPlcSteps => ResourceManager.GetString("PlcConflictPlcSteps", resourceCulture) ?? string.Empty;
+
+	public static string MessagePanelErrorsFormat => ResourceManager.GetString("MessagePanelErrorsFormat", resourceCulture) ?? string.Empty;
+
+	public static string MessagePanelWarningsFormat => ResourceManager.GetString("MessagePanelWarningsFormat", resourceCulture) ?? string.Empty;
+
+	public static string EditorTitle => ResourceManager.GetString("EditorTitle", resourceCulture) ?? string.Empty;
+
+	public static string EditorRecipeGrid => ResourceManager.GetString("EditorRecipeGrid", resourceCulture) ?? string.Empty;
+
+	public static string EditorStatusBar => ResourceManager.GetString("EditorStatusBar", resourceCulture) ?? string.Empty;
+
+	public static string EditorNotificationPanel => ResourceManager.GetString("EditorNotificationPanel", resourceCulture) ?? string.Empty;
+
+	public static string EditorApplicationTheme => ResourceManager.GetString("EditorApplicationTheme", resourceCulture) ?? string.Empty;
+
+	public static string EditorDimensions => ResourceManager.GetString("EditorDimensions", resourceCulture) ?? string.Empty;
+
+	public static string EditorFonts => ResourceManager.GetString("EditorFonts", resourceCulture) ?? string.Empty;
+
+	public static string EditorColors => ResourceManager.GetString("EditorColors", resourceCulture) ?? string.Empty;
+
+	public static string EditorReadOnlyCells => ResourceManager.GetString("EditorReadOnlyCells", resourceCulture) ?? string.Empty;
+
+	public static string EditorDisabledCells => ResourceManager.GetString("EditorDisabledCells", resourceCulture) ?? string.Empty;
+
+	public static string EditorExecutionHighlight => ResourceManager.GetString("EditorExecutionHighlight", resourceCulture) ?? string.Empty;
+
+	public static string EditorTypography => ResourceManager.GetString("EditorTypography", resourceCulture) ?? string.Empty;
+
+	public static string EditorSharedColors => ResourceManager.GetString("EditorSharedColors", resourceCulture) ?? string.Empty;
+
+	public static string EditorSize => ResourceManager.GetString("EditorSize", resourceCulture) ?? string.Empty;
+
+	public static string EditorWeight => ResourceManager.GetString("EditorWeight", resourceCulture) ?? string.Empty;
+
+	public static string EditorItalic => ResourceManager.GetString("EditorItalic", resourceCulture) ?? string.Empty;
+
+	public static string EditorCurrent => ResourceManager.GetString("EditorCurrent", resourceCulture) ?? string.Empty;
+
+	public static string EditorPast => ResourceManager.GetString("EditorPast", resourceCulture) ?? string.Empty;
+
+	public static string EditorRowHeight => ResourceManager.GetString("EditorRowHeight", resourceCulture) ?? string.Empty;
+
+	public static string EditorCellPaddingLeft => ResourceManager.GetString("EditorCellPaddingLeft", resourceCulture) ?? string.Empty;
+
+	public static string EditorCellPaddingTop => ResourceManager.GetString("EditorCellPaddingTop", resourceCulture) ?? string.Empty;
+
+	public static string EditorCellPaddingRight => ResourceManager.GetString("EditorCellPaddingRight", resourceCulture) ?? string.Empty;
+
+	public static string EditorCellPaddingBottom => ResourceManager.GetString("EditorCellPaddingBottom", resourceCulture) ?? string.Empty;
+
+	public static string EditorGridHeader => ResourceManager.GetString("EditorGridHeader", resourceCulture) ?? string.Empty;
+
+	public static string EditorGridCell => ResourceManager.GetString("EditorGridCell", resourceCulture) ?? string.Empty;
+
+	public static string EditorGridBackground => ResourceManager.GetString("EditorGridBackground", resourceCulture) ?? string.Empty;
+
+	public static string EditorGridBorder => ResourceManager.GetString("EditorGridBorder", resourceCulture) ?? string.Empty;
+
+	public static string EditorGridLine => ResourceManager.GetString("EditorGridLine", resourceCulture) ?? string.Empty;
+
+	public static string EditorHeaderForeground => ResourceManager.GetString("EditorHeaderForeground", resourceCulture) ?? string.Empty;
+
+	public static string EditorSelectionBackground => ResourceManager.GetString("EditorSelectionBackground", resourceCulture) ?? string.Empty;
+
+	public static string EditorSelectionForeground => ResourceManager.GetString("EditorSelectionForeground", resourceCulture) ?? string.Empty;
+
+	public static string EditorChanged => ResourceManager.GetString("EditorChanged", resourceCulture) ?? string.Empty;
+
+	public static string EditorChangedSelected => ResourceManager.GetString("EditorChangedSelected", resourceCulture) ?? string.Empty;
+
+	public static string EditorDepth0 => ResourceManager.GetString("EditorDepth0", resourceCulture) ?? string.Empty;
+
+	public static string EditorDepth1 => ResourceManager.GetString("EditorDepth1", resourceCulture) ?? string.Empty;
+
+	public static string EditorDepth2 => ResourceManager.GetString("EditorDepth2", resourceCulture) ?? string.Empty;
+
+	public static string EditorDepth3 => ResourceManager.GetString("EditorDepth3", resourceCulture) ?? string.Empty;
+
+	public static string EditorSelected => ResourceManager.GetString("EditorSelected", resourceCulture) ?? string.Empty;
+
+	public static string EditorForeground => ResourceManager.GetString("EditorForeground", resourceCulture) ?? string.Empty;
+
+	public static string EditorCurrentStepMarker => ResourceManager.GetString("EditorCurrentStepMarker", resourceCulture) ?? string.Empty;
+
+	public static string EditorPadding => ResourceManager.GetString("EditorPadding", resourceCulture) ?? string.Empty;
+
+	public static string EditorItemSpacing => ResourceManager.GetString("EditorItemSpacing", resourceCulture) ?? string.Empty;
+
+	public static string EditorText => ResourceManager.GetString("EditorText", resourceCulture) ?? string.Empty;
+
+	public static string EditorTimerLabel => ResourceManager.GetString("EditorTimerLabel", resourceCulture) ?? string.Empty;
+
+	public static string EditorTimerValue => ResourceManager.GetString("EditorTimerValue", resourceCulture) ?? string.Empty;
+
+	public static string EditorBackground => ResourceManager.GetString("EditorBackground", resourceCulture) ?? string.Empty;
+
+	public static string EditorConnected => ResourceManager.GetString("EditorConnected", resourceCulture) ?? string.Empty;
+
+	public static string EditorDisconnected => ResourceManager.GetString("EditorDisconnected", resourceCulture) ?? string.Empty;
+
+	public static string EditorLocalMode => ResourceManager.GetString("EditorLocalMode", resourceCulture) ?? string.Empty;
+
+	public static string EditorConnecting => ResourceManager.GetString("EditorConnecting", resourceCulture) ?? string.Empty;
+
+	public static string EditorMaxHeight => ResourceManager.GetString("EditorMaxHeight", resourceCulture) ?? string.Empty;
+
+	public static string EditorInfoSeverity => ResourceManager.GetString("EditorInfoSeverity", resourceCulture) ?? string.Empty;
+
+	public static string EditorErrorSeverity => ResourceManager.GetString("EditorErrorSeverity", resourceCulture) ?? string.Empty;
+
+	public static string EditorWarningSeverity => ResourceManager.GetString("EditorWarningSeverity", resourceCulture) ?? string.Empty;
+
+	public static string EditorFontFamily => ResourceManager.GetString("EditorFontFamily", resourceCulture) ?? string.Empty;
+
+	public static string EditorPanelBackground => ResourceManager.GetString("EditorPanelBackground", resourceCulture) ?? string.Empty;
+
+	public static string EditorPanelHeaderBackground => ResourceManager.GetString("EditorPanelHeaderBackground", resourceCulture) ?? string.Empty;
+
+	public static string EditorSubtleBorder => ResourceManager.GetString("EditorSubtleBorder", resourceCulture) ?? string.Empty;
+
+	public static string EditorSeparator => ResourceManager.GetString("EditorSeparator", resourceCulture) ?? string.Empty;
+
+	public static string EditorSecondaryForeground => ResourceManager.GetString("EditorSecondaryForeground", resourceCulture) ?? string.Empty;
+
+	public static string EditorRestartTitle => ResourceManager.GetString("EditorRestartTitle", resourceCulture) ?? string.Empty;
+
+	public static string EditorRestartMessage => ResourceManager.GetString("EditorRestartMessage", resourceCulture) ?? string.Empty;
+
+	public static string EditorExitNow => ResourceManager.GetString("EditorExitNow", resourceCulture) ?? string.Empty;
+
+	public static string EditorRestartLater => ResourceManager.GetString("EditorRestartLater", resourceCulture) ?? string.Empty;
+
+	public static string EditorCannotSave => ResourceManager.GetString("EditorCannotSave", resourceCulture) ?? string.Empty;
+
+	public static string EditorDefaultFont => ResourceManager.GetString("EditorDefaultFont", resourceCulture) ?? string.Empty;
+}

--- a/SemiStep/SemiStep.UI/Localization/Resources.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.resx
@@ -1,0 +1,448 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="MenuFile" xml:space="preserve">
+    <value>_File</value>
+  </data>
+  <data name="MenuFileNewRecipe" xml:space="preserve">
+    <value>_New Recipe</value>
+  </data>
+  <data name="MenuFileOpenRecipe" xml:space="preserve">
+    <value>_Open Recipe...</value>
+  </data>
+  <data name="MenuFileSaveRecipe" xml:space="preserve">
+    <value>_Save Recipe</value>
+  </data>
+  <data name="MenuFileSaveRecipeAs" xml:space="preserve">
+    <value>Save Recipe _As...</value>
+  </data>
+  <data name="MenuFileExit" xml:space="preserve">
+    <value>E_xit</value>
+  </data>
+  <data name="MenuEdit" xml:space="preserve">
+    <value>_Edit</value>
+  </data>
+  <data name="MenuEditAddStep" xml:space="preserve">
+    <value>_Add Step</value>
+  </data>
+  <data name="MenuEditDeleteStep" xml:space="preserve">
+    <value>_Delete Step</value>
+  </data>
+  <data name="MenuEditCopySteps" xml:space="preserve">
+    <value>Cop_y Steps</value>
+  </data>
+  <data name="MenuEditCutSteps" xml:space="preserve">
+    <value>Cu_t Steps</value>
+  </data>
+  <data name="MenuEditPasteSteps" xml:space="preserve">
+    <value>_Paste Steps</value>
+  </data>
+  <data name="MenuEditUndo" xml:space="preserve">
+    <value>_Undo</value>
+  </data>
+  <data name="MenuEditRedo" xml:space="preserve">
+    <value>_Redo</value>
+  </data>
+  <data name="MenuView" xml:space="preserve">
+    <value>_View</value>
+  </data>
+  <data name="MenuViewToolbar" xml:space="preserve">
+    <value>_Toolbar</value>
+  </data>
+  <data name="MenuViewNotificationLog" xml:space="preserve">
+    <value>_Notification Log</value>
+  </data>
+  <data name="MenuViewGridStyleSettings" xml:space="preserve">
+    <value>Grid _Style Settings...</value>
+  </data>
+  <data name="MenuHelp" xml:space="preserve">
+    <value>_Help</value>
+  </data>
+  <data name="MenuHelpAbout" xml:space="preserve">
+    <value>_About</value>
+  </data>
+  <data name="ContextAddStep" xml:space="preserve">
+    <value>Add Step</value>
+  </data>
+  <data name="ContextDeleteStep" xml:space="preserve">
+    <value>Delete Step</value>
+  </data>
+  <data name="ContextCopyStep" xml:space="preserve">
+    <value>Copy Steps</value>
+  </data>
+  <data name="ContextCutStep" xml:space="preserve">
+    <value>Cut Steps</value>
+  </data>
+  <data name="ContextPasteStep" xml:space="preserve">
+    <value>Paste Steps</value>
+  </data>
+  <data name="ToolbarAddStep" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ToolbarDeleteStep" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="ToolbarCopyStep" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="ToolbarCutStep" xml:space="preserve">
+    <value>Cut</value>
+  </data>
+  <data name="ToolbarPasteStep" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="ToolbarUndo" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="ToolbarRedo" xml:space="preserve">
+    <value>Redo</value>
+  </data>
+  <data name="StatusSyncOn" xml:space="preserve">
+    <value>Sync ON</value>
+  </data>
+  <data name="StatusSyncOff" xml:space="preserve">
+    <value>Sync OFF</value>
+  </data>
+  <data name="StatusConnecting" xml:space="preserve">
+    <value>Connecting</value>
+  </data>
+  <data name="StatusStepLabel" xml:space="preserve">
+    <value>Step:</value>
+  </data>
+  <data name="StatusRecipeLabel" xml:space="preserve">
+    <value>Recipe:</value>
+  </data>
+  <data name="StatusForLabel" xml:space="preserve">
+    <value>FOR:</value>
+  </data>
+  <data name="MessagePanelClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="DialogMessageTitle" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="DialogOk" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="DialogExitTitle" xml:space="preserve">
+    <value>Unsaved Changes</value>
+  </data>
+  <data name="DialogExitMessage" xml:space="preserve">
+    <value>You have unsaved changes. Do you want to save before exiting?</value>
+  </data>
+  <data name="DialogSave" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="DialogDontSave" xml:space="preserve">
+    <value>Don't Save</value>
+  </data>
+  <data name="DialogCancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="PlcConflictTitle" xml:space="preserve">
+    <value>Recipe Conflict</value>
+  </data>
+  <data name="PlcConflictLine1" xml:space="preserve">
+    <value>The PLC contains a different recipe.</value>
+  </data>
+  <data name="PlcConflictQuestion" xml:space="preserve">
+    <value>Which version do you want to keep?</value>
+  </data>
+  <data name="PlcConflictKeepLocal" xml:space="preserve">
+    <value>Keep local</value>
+  </data>
+  <data name="PlcConflictLoadFromPlc" xml:space="preserve">
+    <value>Load from PLC</value>
+  </data>
+  <data name="StatusIdle" xml:space="preserve">
+    <value>Idle</value>
+  </data>
+  <data name="StatusSyncing" xml:space="preserve">
+    <value>Syncing...</value>
+  </data>
+  <data name="StatusSynced" xml:space="preserve">
+    <value>Synced</value>
+  </data>
+  <data name="StatusFailed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="LastSyncNever" xml:space="preserve">
+    <value>Never</value>
+  </data>
+  <data name="LastSyncAgoFormat" xml:space="preserve">
+    <value>{0} s ago</value>
+  </data>
+  <data name="LastSyncPrefix" xml:space="preserve">
+    <value>Last sync: {0}</value>
+  </data>
+  <data name="WindowTitleNewRecipe" xml:space="preserve">
+    <value>New Recipe</value>
+  </data>
+  <data name="PlcConflictLocalSteps" xml:space="preserve">
+    <value>Local steps: {0}</value>
+  </data>
+  <data name="PlcConflictPlcSteps" xml:space="preserve">
+    <value>PLC steps: {0}</value>
+  </data>
+  <data name="MessagePanelErrorsFormat" xml:space="preserve">
+    <value>Errors: {0}</value>
+  </data>
+  <data name="MessagePanelWarningsFormat" xml:space="preserve">
+    <value>Warnings: {0}</value>
+  </data>
+  <data name="EditorTitle" xml:space="preserve">
+    <value>Grid Style Settings</value>
+  </data>
+  <data name="EditorRecipeGrid" xml:space="preserve">
+    <value>Recipe Grid</value>
+  </data>
+  <data name="EditorStatusBar" xml:space="preserve">
+    <value>Status Bar</value>
+  </data>
+  <data name="EditorNotificationPanel" xml:space="preserve">
+    <value>Notification Panel</value>
+  </data>
+  <data name="EditorApplicationTheme" xml:space="preserve">
+    <value>Application Theme</value>
+  </data>
+  <data name="EditorDimensions" xml:space="preserve">
+    <value>Dimensions</value>
+  </data>
+  <data name="EditorFonts" xml:space="preserve">
+    <value>Fonts</value>
+  </data>
+  <data name="EditorColors" xml:space="preserve">
+    <value>Colors</value>
+  </data>
+  <data name="EditorReadOnlyCells" xml:space="preserve">
+    <value>Read-only cells</value>
+  </data>
+  <data name="EditorDisabledCells" xml:space="preserve">
+    <value>Disabled cells</value>
+  </data>
+  <data name="EditorExecutionHighlight" xml:space="preserve">
+    <value>Execution highlight</value>
+  </data>
+  <data name="EditorTypography" xml:space="preserve">
+    <value>Typography</value>
+  </data>
+  <data name="EditorSharedColors" xml:space="preserve">
+    <value>Shared colors</value>
+  </data>
+  <data name="EditorSize" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="EditorWeight" xml:space="preserve">
+    <value>Weight</value>
+  </data>
+  <data name="EditorItalic" xml:space="preserve">
+    <value>Italic</value>
+  </data>
+  <data name="EditorCurrent" xml:space="preserve">
+    <value>Current</value>
+  </data>
+  <data name="EditorPast" xml:space="preserve">
+    <value>Past</value>
+  </data>
+  <data name="EditorRowHeight" xml:space="preserve">
+    <value>Row height</value>
+  </data>
+  <data name="EditorCellPaddingLeft" xml:space="preserve">
+    <value>Cell padding left</value>
+  </data>
+  <data name="EditorCellPaddingTop" xml:space="preserve">
+    <value>Cell padding top</value>
+  </data>
+  <data name="EditorCellPaddingRight" xml:space="preserve">
+    <value>Cell padding right</value>
+  </data>
+  <data name="EditorCellPaddingBottom" xml:space="preserve">
+    <value>Cell padding bottom</value>
+  </data>
+  <data name="EditorGridHeader" xml:space="preserve">
+    <value>Grid header</value>
+  </data>
+  <data name="EditorGridCell" xml:space="preserve">
+    <value>Grid cell</value>
+  </data>
+  <data name="EditorGridBackground" xml:space="preserve">
+    <value>Grid background</value>
+  </data>
+  <data name="EditorGridBorder" xml:space="preserve">
+    <value>Grid border</value>
+  </data>
+  <data name="EditorGridLine" xml:space="preserve">
+    <value>Grid line</value>
+  </data>
+  <data name="EditorHeaderForeground" xml:space="preserve">
+    <value>Header foreground</value>
+  </data>
+  <data name="EditorSelectionBackground" xml:space="preserve">
+    <value>Selection background</value>
+  </data>
+  <data name="EditorSelectionForeground" xml:space="preserve">
+    <value>Selection foreground</value>
+  </data>
+  <data name="EditorChanged" xml:space="preserve">
+    <value>Changed</value>
+  </data>
+  <data name="EditorChangedSelected" xml:space="preserve">
+    <value>Changed (selected)</value>
+  </data>
+  <data name="EditorDepth0" xml:space="preserve">
+    <value>Depth 0</value>
+  </data>
+  <data name="EditorDepth1" xml:space="preserve">
+    <value>Depth 1</value>
+  </data>
+  <data name="EditorDepth2" xml:space="preserve">
+    <value>Depth 2</value>
+  </data>
+  <data name="EditorDepth3" xml:space="preserve">
+    <value>Depth 3</value>
+  </data>
+  <data name="EditorSelected" xml:space="preserve">
+    <value>Selected</value>
+  </data>
+  <data name="EditorForeground" xml:space="preserve">
+    <value>Foreground</value>
+  </data>
+  <data name="EditorCurrentStepMarker" xml:space="preserve">
+    <value>Current step marker</value>
+  </data>
+  <data name="EditorPadding" xml:space="preserve">
+    <value>Padding</value>
+  </data>
+  <data name="EditorItemSpacing" xml:space="preserve">
+    <value>Item spacing</value>
+  </data>
+  <data name="EditorText" xml:space="preserve">
+    <value>Text</value>
+  </data>
+  <data name="EditorTimerLabel" xml:space="preserve">
+    <value>Timer label</value>
+  </data>
+  <data name="EditorTimerValue" xml:space="preserve">
+    <value>Timer value</value>
+  </data>
+  <data name="EditorBackground" xml:space="preserve">
+    <value>Background</value>
+  </data>
+  <data name="EditorConnected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="EditorDisconnected" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="EditorLocalMode" xml:space="preserve">
+    <value>Local mode</value>
+  </data>
+  <data name="EditorConnecting" xml:space="preserve">
+    <value>Connecting</value>
+  </data>
+  <data name="EditorMaxHeight" xml:space="preserve">
+    <value>Max height</value>
+  </data>
+  <data name="EditorInfoSeverity" xml:space="preserve">
+    <value>Info severity</value>
+  </data>
+  <data name="EditorErrorSeverity" xml:space="preserve">
+    <value>Error severity</value>
+  </data>
+  <data name="EditorWarningSeverity" xml:space="preserve">
+    <value>Warning severity</value>
+  </data>
+  <data name="EditorFontFamily" xml:space="preserve">
+    <value>Font family</value>
+  </data>
+  <data name="EditorPanelBackground" xml:space="preserve">
+    <value>Panel background</value>
+  </data>
+  <data name="EditorPanelHeaderBackground" xml:space="preserve">
+    <value>Panel header background</value>
+  </data>
+  <data name="EditorSubtleBorder" xml:space="preserve">
+    <value>Subtle border</value>
+  </data>
+  <data name="EditorSeparator" xml:space="preserve">
+    <value>Separator</value>
+  </data>
+  <data name="EditorSecondaryForeground" xml:space="preserve">
+    <value>Secondary foreground</value>
+  </data>
+  <data name="EditorRestartTitle" xml:space="preserve">
+    <value>Settings Saved</value>
+  </data>
+  <data name="EditorRestartMessage" xml:space="preserve">
+    <value>Settings saved. Restart the application to apply the changes.</value>
+  </data>
+  <data name="EditorExitNow" xml:space="preserve">
+    <value>Exit Now</value>
+  </data>
+  <data name="EditorRestartLater" xml:space="preserve">
+    <value>Restart Later</value>
+  </data>
+  <data name="EditorCannotSave" xml:space="preserve">
+    <value>Cannot save: the current style draft has invalid or out-of-range values.</value>
+  </data>
+  <data name="EditorDefaultFont" xml:space="preserve">
+    <value>(Default)</value>
+  </data>
+</root>

--- a/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
@@ -1,0 +1,448 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="MenuFile" xml:space="preserve">
+    <value>_Файл</value>
+  </data>
+  <data name="MenuFileNewRecipe" xml:space="preserve">
+    <value>Со_здать рецепт</value>
+  </data>
+  <data name="MenuFileOpenRecipe" xml:space="preserve">
+    <value>_Открыть рецепт…</value>
+  </data>
+  <data name="MenuFileSaveRecipe" xml:space="preserve">
+    <value>_Сохранить рецепт</value>
+  </data>
+  <data name="MenuFileSaveRecipeAs" xml:space="preserve">
+    <value>Сохранить рецепт _как…</value>
+  </data>
+  <data name="MenuFileExit" xml:space="preserve">
+    <value>В_ыход</value>
+  </data>
+  <data name="MenuEdit" xml:space="preserve">
+    <value>_Правка</value>
+  </data>
+  <data name="MenuEditAddStep" xml:space="preserve">
+    <value>_Добавить шаг</value>
+  </data>
+  <data name="MenuEditDeleteStep" xml:space="preserve">
+    <value>_Удалить шаг</value>
+  </data>
+  <data name="MenuEditCopySteps" xml:space="preserve">
+    <value>_Копировать шаги</value>
+  </data>
+  <data name="MenuEditCutSteps" xml:space="preserve">
+    <value>В_ырезать шаги</value>
+  </data>
+  <data name="MenuEditPasteSteps" xml:space="preserve">
+    <value>Вст_авить шаги</value>
+  </data>
+  <data name="MenuEditUndo" xml:space="preserve">
+    <value>_Отменить</value>
+  </data>
+  <data name="MenuEditRedo" xml:space="preserve">
+    <value>_Повторить</value>
+  </data>
+  <data name="MenuView" xml:space="preserve">
+    <value>_Вид</value>
+  </data>
+  <data name="MenuViewToolbar" xml:space="preserve">
+    <value>_Панель инструментов</value>
+  </data>
+  <data name="MenuViewNotificationLog" xml:space="preserve">
+    <value>_Журнал уведомлений</value>
+  </data>
+  <data name="MenuViewGridStyleSettings" xml:space="preserve">
+    <value>Настройки _стиля таблицы…</value>
+  </data>
+  <data name="MenuHelp" xml:space="preserve">
+    <value>_Справка</value>
+  </data>
+  <data name="MenuHelpAbout" xml:space="preserve">
+    <value>_О программе</value>
+  </data>
+  <data name="ContextAddStep" xml:space="preserve">
+    <value>Добавить шаг</value>
+  </data>
+  <data name="ContextDeleteStep" xml:space="preserve">
+    <value>Удалить шаг</value>
+  </data>
+  <data name="ContextCopyStep" xml:space="preserve">
+    <value>Копировать шаги</value>
+  </data>
+  <data name="ContextCutStep" xml:space="preserve">
+    <value>Вырезать шаги</value>
+  </data>
+  <data name="ContextPasteStep" xml:space="preserve">
+    <value>Вставить шаги</value>
+  </data>
+  <data name="ToolbarAddStep" xml:space="preserve">
+    <value>Добавить</value>
+  </data>
+  <data name="ToolbarDeleteStep" xml:space="preserve">
+    <value>Удалить</value>
+  </data>
+  <data name="ToolbarCopyStep" xml:space="preserve">
+    <value>Копировать</value>
+  </data>
+  <data name="ToolbarCutStep" xml:space="preserve">
+    <value>Вырезать</value>
+  </data>
+  <data name="ToolbarPasteStep" xml:space="preserve">
+    <value>Вставить</value>
+  </data>
+  <data name="ToolbarUndo" xml:space="preserve">
+    <value>Отменить</value>
+  </data>
+  <data name="ToolbarRedo" xml:space="preserve">
+    <value>Повторить</value>
+  </data>
+  <data name="StatusSyncOn" xml:space="preserve">
+    <value>Синхр. ВКЛ</value>
+  </data>
+  <data name="StatusSyncOff" xml:space="preserve">
+    <value>Синхр. ВЫКЛ</value>
+  </data>
+  <data name="StatusConnecting" xml:space="preserve">
+    <value>Подключение</value>
+  </data>
+  <data name="StatusStepLabel" xml:space="preserve">
+    <value>Шаг:</value>
+  </data>
+  <data name="StatusRecipeLabel" xml:space="preserve">
+    <value>Рецепт:</value>
+  </data>
+  <data name="StatusForLabel" xml:space="preserve">
+    <value>FOR:</value>
+  </data>
+  <data name="MessagePanelClose" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="DialogMessageTitle" xml:space="preserve">
+    <value>Сообщение</value>
+  </data>
+  <data name="DialogOk" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="DialogExitTitle" xml:space="preserve">
+    <value>Несохранённые изменения</value>
+  </data>
+  <data name="DialogExitMessage" xml:space="preserve">
+    <value>Имеются несохранённые изменения. Сохранить перед выходом?</value>
+  </data>
+  <data name="DialogSave" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="DialogDontSave" xml:space="preserve">
+    <value>Не сохранять</value>
+  </data>
+  <data name="DialogCancel" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="PlcConflictTitle" xml:space="preserve">
+    <value>Конфликт рецептов</value>
+  </data>
+  <data name="PlcConflictLine1" xml:space="preserve">
+    <value>В ПЛК находится другой рецепт.</value>
+  </data>
+  <data name="PlcConflictQuestion" xml:space="preserve">
+    <value>Какую версию оставить?</value>
+  </data>
+  <data name="PlcConflictKeepLocal" xml:space="preserve">
+    <value>Оставить локальный</value>
+  </data>
+  <data name="PlcConflictLoadFromPlc" xml:space="preserve">
+    <value>Загрузить из ПЛК</value>
+  </data>
+  <data name="StatusIdle" xml:space="preserve">
+    <value>Ожидание</value>
+  </data>
+  <data name="StatusSyncing" xml:space="preserve">
+    <value>Синхронизация…</value>
+  </data>
+  <data name="StatusSynced" xml:space="preserve">
+    <value>Синхронизировано</value>
+  </data>
+  <data name="StatusFailed" xml:space="preserve">
+    <value>Ошибка</value>
+  </data>
+  <data name="LastSyncNever" xml:space="preserve">
+    <value>Никогда</value>
+  </data>
+  <data name="LastSyncAgoFormat" xml:space="preserve">
+    <value>{0} с назад</value>
+  </data>
+  <data name="LastSyncPrefix" xml:space="preserve">
+    <value>Синхр.: {0}</value>
+  </data>
+  <data name="WindowTitleNewRecipe" xml:space="preserve">
+    <value>Новый рецепт</value>
+  </data>
+  <data name="PlcConflictLocalSteps" xml:space="preserve">
+    <value>Локально шагов: {0}</value>
+  </data>
+  <data name="PlcConflictPlcSteps" xml:space="preserve">
+    <value>Шагов в ПЛК: {0}</value>
+  </data>
+  <data name="MessagePanelErrorsFormat" xml:space="preserve">
+    <value>Ошибок: {0}</value>
+  </data>
+  <data name="MessagePanelWarningsFormat" xml:space="preserve">
+    <value>Предупреждений: {0}</value>
+  </data>
+  <data name="EditorTitle" xml:space="preserve">
+    <value>Настройки стиля таблицы</value>
+  </data>
+  <data name="EditorRecipeGrid" xml:space="preserve">
+    <value>Таблица рецепта</value>
+  </data>
+  <data name="EditorStatusBar" xml:space="preserve">
+    <value>Строка состояния</value>
+  </data>
+  <data name="EditorNotificationPanel" xml:space="preserve">
+    <value>Панель уведомлений</value>
+  </data>
+  <data name="EditorApplicationTheme" xml:space="preserve">
+    <value>Тема приложения</value>
+  </data>
+  <data name="EditorDimensions" xml:space="preserve">
+    <value>Размеры</value>
+  </data>
+  <data name="EditorFonts" xml:space="preserve">
+    <value>Шрифты</value>
+  </data>
+  <data name="EditorColors" xml:space="preserve">
+    <value>Цвета</value>
+  </data>
+  <data name="EditorReadOnlyCells" xml:space="preserve">
+    <value>Ячейки только для чтения</value>
+  </data>
+  <data name="EditorDisabledCells" xml:space="preserve">
+    <value>Отключённые ячейки</value>
+  </data>
+  <data name="EditorExecutionHighlight" xml:space="preserve">
+    <value>Подсветка выполнения</value>
+  </data>
+  <data name="EditorTypography" xml:space="preserve">
+    <value>Типографика</value>
+  </data>
+  <data name="EditorSharedColors" xml:space="preserve">
+    <value>Общие цвета</value>
+  </data>
+  <data name="EditorSize" xml:space="preserve">
+    <value>Размер</value>
+  </data>
+  <data name="EditorWeight" xml:space="preserve">
+    <value>Насыщенность</value>
+  </data>
+  <data name="EditorItalic" xml:space="preserve">
+    <value>Курсив</value>
+  </data>
+  <data name="EditorCurrent" xml:space="preserve">
+    <value>Текущий</value>
+  </data>
+  <data name="EditorPast" xml:space="preserve">
+    <value>Прошедший</value>
+  </data>
+  <data name="EditorRowHeight" xml:space="preserve">
+    <value>Высота строки</value>
+  </data>
+  <data name="EditorCellPaddingLeft" xml:space="preserve">
+    <value>Отступ ячейки слева</value>
+  </data>
+  <data name="EditorCellPaddingTop" xml:space="preserve">
+    <value>Отступ ячейки сверху</value>
+  </data>
+  <data name="EditorCellPaddingRight" xml:space="preserve">
+    <value>Отступ ячейки справа</value>
+  </data>
+  <data name="EditorCellPaddingBottom" xml:space="preserve">
+    <value>Отступ ячейки снизу</value>
+  </data>
+  <data name="EditorGridHeader" xml:space="preserve">
+    <value>Заголовок таблицы</value>
+  </data>
+  <data name="EditorGridCell" xml:space="preserve">
+    <value>Ячейка таблицы</value>
+  </data>
+  <data name="EditorGridBackground" xml:space="preserve">
+    <value>Фон таблицы</value>
+  </data>
+  <data name="EditorGridBorder" xml:space="preserve">
+    <value>Граница таблицы</value>
+  </data>
+  <data name="EditorGridLine" xml:space="preserve">
+    <value>Линия сетки</value>
+  </data>
+  <data name="EditorHeaderForeground" xml:space="preserve">
+    <value>Текст заголовка</value>
+  </data>
+  <data name="EditorSelectionBackground" xml:space="preserve">
+    <value>Фон выделения</value>
+  </data>
+  <data name="EditorSelectionForeground" xml:space="preserve">
+    <value>Текст выделения</value>
+  </data>
+  <data name="EditorChanged" xml:space="preserve">
+    <value>Изменённая</value>
+  </data>
+  <data name="EditorChangedSelected" xml:space="preserve">
+    <value>Изменённая (выбранная)</value>
+  </data>
+  <data name="EditorDepth0" xml:space="preserve">
+    <value>Глубина 0</value>
+  </data>
+  <data name="EditorDepth1" xml:space="preserve">
+    <value>Глубина 1</value>
+  </data>
+  <data name="EditorDepth2" xml:space="preserve">
+    <value>Глубина 2</value>
+  </data>
+  <data name="EditorDepth3" xml:space="preserve">
+    <value>Глубина 3</value>
+  </data>
+  <data name="EditorSelected" xml:space="preserve">
+    <value>Выбранная</value>
+  </data>
+  <data name="EditorForeground" xml:space="preserve">
+    <value>Текст</value>
+  </data>
+  <data name="EditorCurrentStepMarker" xml:space="preserve">
+    <value>Маркер текущего шага</value>
+  </data>
+  <data name="EditorPadding" xml:space="preserve">
+    <value>Отступ</value>
+  </data>
+  <data name="EditorItemSpacing" xml:space="preserve">
+    <value>Интервал элементов</value>
+  </data>
+  <data name="EditorText" xml:space="preserve">
+    <value>Текст</value>
+  </data>
+  <data name="EditorTimerLabel" xml:space="preserve">
+    <value>Подпись таймера</value>
+  </data>
+  <data name="EditorTimerValue" xml:space="preserve">
+    <value>Значение таймера</value>
+  </data>
+  <data name="EditorBackground" xml:space="preserve">
+    <value>Фон</value>
+  </data>
+  <data name="EditorConnected" xml:space="preserve">
+    <value>Подключено</value>
+  </data>
+  <data name="EditorDisconnected" xml:space="preserve">
+    <value>Отключено</value>
+  </data>
+  <data name="EditorLocalMode" xml:space="preserve">
+    <value>Локальный режим</value>
+  </data>
+  <data name="EditorConnecting" xml:space="preserve">
+    <value>Подключение</value>
+  </data>
+  <data name="EditorMaxHeight" xml:space="preserve">
+    <value>Макс. высота</value>
+  </data>
+  <data name="EditorInfoSeverity" xml:space="preserve">
+    <value>Уровень: информация</value>
+  </data>
+  <data name="EditorErrorSeverity" xml:space="preserve">
+    <value>Уровень: ошибка</value>
+  </data>
+  <data name="EditorWarningSeverity" xml:space="preserve">
+    <value>Уровень: предупреждение</value>
+  </data>
+  <data name="EditorFontFamily" xml:space="preserve">
+    <value>Гарнитура шрифта</value>
+  </data>
+  <data name="EditorPanelBackground" xml:space="preserve">
+    <value>Фон панели</value>
+  </data>
+  <data name="EditorPanelHeaderBackground" xml:space="preserve">
+    <value>Фон заголовка панели</value>
+  </data>
+  <data name="EditorSubtleBorder" xml:space="preserve">
+    <value>Тонкая граница</value>
+  </data>
+  <data name="EditorSeparator" xml:space="preserve">
+    <value>Разделитель</value>
+  </data>
+  <data name="EditorSecondaryForeground" xml:space="preserve">
+    <value>Вторичный текст</value>
+  </data>
+  <data name="EditorRestartTitle" xml:space="preserve">
+    <value>Настройки сохранены</value>
+  </data>
+  <data name="EditorRestartMessage" xml:space="preserve">
+    <value>Настройки сохранены. Перезапустите приложение, чтобы применить изменения.</value>
+  </data>
+  <data name="EditorExitNow" xml:space="preserve">
+    <value>Выйти сейчас</value>
+  </data>
+  <data name="EditorRestartLater" xml:space="preserve">
+    <value>Перезапустить позже</value>
+  </data>
+  <data name="EditorCannotSave" xml:space="preserve">
+    <value>Сохранение невозможно: черновик стиля содержит недопустимые значения или значения вне диапазона.</value>
+  </data>
+  <data name="EditorDefaultFont" xml:space="preserve">
+    <value>(По умолчанию)</value>
+  </data>
+</root>

--- a/SemiStep/SemiStep.UI/Localization/UiCultureSelector.cs
+++ b/SemiStep/SemiStep.UI/Localization/UiCultureSelector.cs
@@ -1,0 +1,41 @@
+﻿using System.Globalization;
+
+using SemiStep.Core.Configuration;
+
+namespace SemiStep.UI.Localization;
+
+public static class UiCultureSelector
+{
+	// ICU synthesises an unnamed custom culture (this LCID) instead of throwing for
+	// structurally-valid but unknown tags. Treat those as invalid and fall back.
+	private const int UnknownCustomCultureLcid = 0x1000;
+
+	public static CultureInfo Resolve(string? locale)
+	{
+		if (string.IsNullOrWhiteSpace(locale))
+		{
+			return Fallback();
+		}
+
+		try
+		{
+			var culture = CultureInfo.GetCultureInfo(locale);
+
+			if (culture.LCID == UnknownCustomCultureLcid)
+			{
+				return Fallback();
+			}
+
+			return culture;
+		}
+		catch (CultureNotFoundException)
+		{
+			return Fallback();
+		}
+	}
+
+	private static CultureInfo Fallback()
+	{
+		return new CultureInfo(AppUiOptions.DefaultLocale);
+	}
+}

--- a/SemiStep/SemiStep.UI/MainWindow/AppStatusBar.axaml
+++ b/SemiStep/SemiStep.UI/MainWindow/AppStatusBar.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:local="clr-namespace:SemiStep.UI.MainWindow"
+             xmlns:l="clr-namespace:SemiStep.UI.Localization"
              mc:Ignorable="d"
              x:Class="SemiStep.UI.MainWindow.AppStatusBar"
              x:DataType="local:MainWindowViewModel">
@@ -15,7 +16,7 @@
             <Setter Property="BorderBrush" Value="#33000000" />
             <Setter Property="Padding" Value="10,3" />
             <Setter Property="MinHeight" Value="24" />
-            <Setter Property="Width" Value="108" />
+            <Setter Property="Width" Value="128" />
             <Setter Property="FontSize" Value="13" />
             <Setter Property="FontWeight" Value="SemiBold" />
             <Setter Property="Foreground" Value="#FFFFFF" />
@@ -179,13 +180,13 @@
                         Classes.sync-linked="{Binding IsSyncLinked}"
                         Classes.sync-connecting="{Binding IsSyncConnecting}">
                     <Panel>
-                        <TextBlock Text="Sync ON"
+                        <TextBlock Text="{x:Static l:Resources.StatusSyncOn}"
                                    IsVisible="{Binding IsSyncOnIdle}" />
-                        <TextBlock Text="Sync OFF"
+                        <TextBlock Text="{x:Static l:Resources.StatusSyncOff}"
                                    IsVisible="{Binding IsSyncLocalMode}" />
                         <StackPanel Orientation="Horizontal"
                                     IsVisible="{Binding IsSyncConnecting}">
-                            <TextBlock Text="Connecting" />
+                            <TextBlock Text="{x:Static l:Resources.StatusConnecting}" />
                             <TextBlock Classes="sync-dot d1" Text="." />
                             <TextBlock Classes="sync-dot d2" Text="." />
                             <TextBlock Classes="sync-dot d3" Text="." />
@@ -201,7 +202,7 @@
                 <!-- Last sync time -->
                 <TextBlock VerticalAlignment="Center"
                            Foreground="{DynamicResource SecondaryForegroundBrush}"
-                           Text="{Binding LastSyncTimeText, StringFormat='Last sync: {0}'}" />
+                           Text="{Binding LastSyncTimeText}" />
 
             </StackPanel>
 
@@ -219,7 +220,7 @@
 
                 <!-- Time left in current step -->
                 <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock Text="Шаг:"
+                    <TextBlock Text="{x:Static l:Resources.StatusStepLabel}"
                                Foreground="{DynamicResource SecondaryForegroundBrush}"
                                FontSize="{DynamicResource StatusBarTimerLabelFontSize}"
                                FontWeight="{DynamicResource StatusBarTimerLabelFontWeight}"
@@ -234,7 +235,7 @@
 
                 <!-- Time left in recipe -->
                 <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock Text="Рецепт:"
+                    <TextBlock Text="{x:Static l:Resources.StatusRecipeLabel}"
                                Foreground="{DynamicResource SecondaryForegroundBrush}"
                                FontSize="{DynamicResource StatusBarTimerLabelFontSize}"
                                FontWeight="{DynamicResource StatusBarTimerLabelFontWeight}"
@@ -263,7 +264,7 @@
                         VerticalAlignment="Center"
                         IsVisible="{Binding PlcMonitor.IsRecipeActive}">
 
-                <TextBlock Text="FOR:"
+                <TextBlock Text="{x:Static l:Resources.StatusForLabel}"
                            Foreground="{DynamicResource SecondaryForegroundBrush}"
                            VerticalAlignment="Center" />
 

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml
@@ -5,6 +5,7 @@
         xmlns:messageService="clr-namespace:SemiStep.UI.MessageService"
         xmlns:recipeGrid="clr-namespace:SemiStep.UI.RecipeGrid"
         xmlns:local="clr-namespace:SemiStep.UI.MainWindow"
+        xmlns:l="clr-namespace:SemiStep.UI.Localization"
         mc:Ignorable="d"
         d:DesignWidth="1600"
         d:DesignHeight="800"
@@ -48,16 +49,16 @@
                   LoadingRow="OnDataGridLoadingRow">
             <DataGrid.ContextMenu>
                 <ContextMenu>
-                    <MenuItem Header="Add Step"
+                    <MenuItem Header="{x:Static l:Resources.ContextAddStep}"
                               Command="{Binding RecipeCommands.AddStepCommand}" />
-                    <MenuItem Header="Delete Step"
+                    <MenuItem Header="{x:Static l:Resources.ContextDeleteStep}"
                               Command="{Binding RecipeCommands.DeleteStepCommand}" />
                     <Separator />
-                    <MenuItem Header="Copy Steps"
+                    <MenuItem Header="{x:Static l:Resources.ContextCopyStep}"
                               Command="{Binding Clipboard.CopyStepCommand}" />
-                    <MenuItem Header="Cut Steps"
+                    <MenuItem Header="{x:Static l:Resources.ContextCutStep}"
                               Command="{Binding Clipboard.CutStepCommand}" />
-                    <MenuItem Header="Paste Steps"
+                    <MenuItem Header="{x:Static l:Resources.ContextPasteStep}"
                               Command="{Binding Clipboard.PasteStepCommand}" />
                 </ContextMenu>
             </DataGrid.ContextMenu>

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive;
+﻿using System.Globalization;
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
@@ -14,6 +15,7 @@ using SemiStep.Core.Recipes;
 
 using SemiStep.UI.Clipboard;
 using SemiStep.UI.Coordinator;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.Plc;
 using SemiStep.UI.RecipeFile;
@@ -260,36 +262,36 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		this.RaisePropertyChanged(nameof(LastSyncTimeText));
 	}
 
-	private static string MapSyncStatus(PlcSyncStatus status)
+	internal static string MapSyncStatus(PlcSyncStatus status)
 	{
 		return status switch
 		{
-			PlcSyncStatus.Idle => "Idle",
-			PlcSyncStatus.Syncing => "Syncing...",
-			PlcSyncStatus.Synced => "Synced",
+			PlcSyncStatus.Idle => Resources.StatusIdle,
+			PlcSyncStatus.Syncing => Resources.StatusSyncing,
+			PlcSyncStatus.Synced => Resources.StatusSynced,
 			PlcSyncStatus.OutOfSync => string.Empty,
-			PlcSyncStatus.Failed => "Failed",
+			PlcSyncStatus.Failed => Resources.StatusFailed,
 			_ => status.ToString()
 		};
 	}
 
-	private static string FormatLastSyncTime(DateTimeOffset? lastSyncTime)
+	internal static string FormatLastSyncTime(DateTimeOffset? lastSyncTime)
 	{
-		if (lastSyncTime is null)
-		{
-			return "Never";
-		}
+		var value = lastSyncTime is null
+			? Resources.LastSyncNever
+			: string.Format(
+				CultureInfo.InvariantCulture,
+				Resources.LastSyncAgoFormat,
+				(DateTimeOffset.UtcNow - lastSyncTime.Value).TotalSeconds.ToString("0.0", CultureInfo.InvariantCulture));
 
-		var elapsed = (DateTimeOffset.UtcNow - lastSyncTime.Value).TotalSeconds;
-
-		return $"{elapsed:0.0} s ago";
+		return string.Format(CultureInfo.InvariantCulture, Resources.LastSyncPrefix, value);
 	}
 
 	private string BuildWindowTitle()
 	{
 		var fileName = RecipeFile.CurrentFilePath is not null
 			? Path.GetFileNameWithoutExtension(RecipeFile.CurrentFilePath)
-			: "New Recipe";
+			: Resources.WindowTitleNewRecipe;
 		var dirtyIndicator = IsDirty ? " *" : "";
 
 		return $"SemiStep - {fileName}{dirtyIndicator}";

--- a/SemiStep/SemiStep.UI/MainWindow/RecipeMenuBar.axaml
+++ b/SemiStep/SemiStep.UI/MainWindow/RecipeMenuBar.axaml
@@ -3,70 +3,71 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:local="clr-namespace:SemiStep.UI.MainWindow"
+             xmlns:l="clr-namespace:SemiStep.UI.Localization"
              mc:Ignorable="d"
              x:Class="SemiStep.UI.MainWindow.RecipeMenuBar"
              x:DataType="local:MainWindowViewModel">
 
     <Menu>
-        <MenuItem Header="_File">
-            <MenuItem Header="_New Recipe"
+        <MenuItem Header="{x:Static l:Resources.MenuFile}">
+            <MenuItem Header="{x:Static l:Resources.MenuFileNewRecipe}"
                       Command="{Binding RecipeFile.NewRecipeCommand}" />
-            <MenuItem Header="_Open Recipe..."
+            <MenuItem Header="{x:Static l:Resources.MenuFileOpenRecipe}"
                       Command="{Binding RecipeFile.LoadRecipeCommand}"
                       InputGesture="Ctrl+O" />
-            <MenuItem Header="_Save Recipe"
+            <MenuItem Header="{x:Static l:Resources.MenuFileSaveRecipe}"
                       Command="{Binding RecipeFile.SaveRecipeCommand}"
                       InputGesture="Ctrl+S" />
-            <MenuItem Header="Save Recipe _As..."
+            <MenuItem Header="{x:Static l:Resources.MenuFileSaveRecipeAs}"
                       Command="{Binding RecipeFile.SaveAsRecipeCommand}"
                       InputGesture="Ctrl+Shift+S" />
             <Separator />
-            <MenuItem Header="E_xit"
+            <MenuItem Header="{x:Static l:Resources.MenuFileExit}"
                       Command="{Binding ExitCommand}"
                       InputGesture="Alt+F4" />
         </MenuItem>
 
-        <MenuItem Header="_Edit">
-            <MenuItem Header="_Add Step"
+        <MenuItem Header="{x:Static l:Resources.MenuEdit}">
+            <MenuItem Header="{x:Static l:Resources.MenuEditAddStep}"
                       Command="{Binding RecipeCommands.AddStepCommand}"
                       InputGesture="Ctrl+N" />
-            <MenuItem Header="_Delete Step"
+            <MenuItem Header="{x:Static l:Resources.MenuEditDeleteStep}"
                       Command="{Binding RecipeCommands.DeleteStepCommand}"
                       InputGesture="Delete" />
             <Separator />
-            <MenuItem Header="Cop_y Steps"
+            <MenuItem Header="{x:Static l:Resources.MenuEditCopySteps}"
                       Command="{Binding Clipboard.CopyStepCommand}"
                       InputGesture="Ctrl+C" />
-            <MenuItem Header="Cu_t Steps"
+            <MenuItem Header="{x:Static l:Resources.MenuEditCutSteps}"
                       Command="{Binding Clipboard.CutStepCommand}"
                       InputGesture="Ctrl+X" />
-            <MenuItem Header="_Paste Steps"
+            <MenuItem Header="{x:Static l:Resources.MenuEditPasteSteps}"
                       Command="{Binding Clipboard.PasteStepCommand}"
                       InputGesture="Ctrl+V" />
             <Separator />
-            <MenuItem Header="_Undo"
+            <MenuItem Header="{x:Static l:Resources.MenuEditUndo}"
                       Command="{Binding RecipeCommands.UndoCommand}"
                       InputGesture="Ctrl+Z" />
-            <MenuItem Header="_Redo"
+            <MenuItem Header="{x:Static l:Resources.MenuEditRedo}"
                       Command="{Binding RecipeCommands.RedoCommand}"
                       InputGesture="Ctrl+Shift+Z" />
         </MenuItem>
-        <MenuItem Header="_View">
-            <MenuItem Header="_Toolbar"
+        <MenuItem Header="{x:Static l:Resources.MenuView}">
+            <MenuItem Header="{x:Static l:Resources.MenuViewToolbar}"
                       Command="{Binding ToggleToolBarCommand}"
                       ToggleType="CheckBox"
                       IsChecked="{Binding IsToolBarVisible, Mode=OneWay}" />
-            <MenuItem Header="_Notification Log"
+            <MenuItem Header="{x:Static l:Resources.MenuViewNotificationLog}"
                       Command="{Binding MessagePanel.ToggleCommand}"
                       ToggleType="CheckBox"
                       IsChecked="{Binding MessagePanel.ShowPanel, Mode=OneWay}" />
             <Separator />
-            <MenuItem Header="Grid _Style Settings..."
+            <MenuItem Header="{x:Static l:Resources.MenuViewGridStyleSettings}"
                       Command="{Binding OpenStyleEditorCommand}" />
         </MenuItem>
 
-        <MenuItem Header="_Help">
-            <MenuItem Header="_About"
+        <MenuItem Header="{x:Static l:Resources.MenuHelp}">
+            <MenuItem Header="{x:Static l:Resources.MenuHelpAbout}"
                       IsEnabled="False" />
         </MenuItem>
     </Menu>

--- a/SemiStep/SemiStep.UI/MainWindow/RecipeToolBar.axaml
+++ b/SemiStep/SemiStep.UI/MainWindow/RecipeToolBar.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:local="clr-namespace:SemiStep.UI.MainWindow"
+             xmlns:l="clr-namespace:SemiStep.UI.Localization"
              mc:Ignorable="d"
              x:Class="SemiStep.UI.MainWindow.RecipeToolBar"
              x:DataType="local:MainWindowViewModel">
@@ -34,20 +35,20 @@
             <Button x:Name="AddButton"
                     Classes="toolbar"
                     Command="{Binding RecipeCommands.AddStepCommand}"
-                    ToolTip.Tip="Add Step">
+                    ToolTip.Tip="{x:Static l:Resources.ContextAddStep}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Image Source="avares://Semistep/Assets/Icons/add.png" />
-                    <TextBlock Text="Add" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Static l:Resources.ToolbarAddStep}" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
 
             <Button x:Name="DeleteButton"
                     Classes="toolbar"
                     Command="{Binding RecipeCommands.DeleteStepCommand}"
-                    ToolTip.Tip="Delete Step">
+                    ToolTip.Tip="{x:Static l:Resources.ContextDeleteStep}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Image Source="avares://Semistep/Assets/Icons/delete.png" />
-                    <TextBlock Text="Delete" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Static l:Resources.ToolbarDeleteStep}" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
 
@@ -56,30 +57,30 @@
             <Button x:Name="CopyButton"
                     Classes="toolbar"
                     Command="{Binding Clipboard.CopyStepCommand}"
-                    ToolTip.Tip="Copy Steps">
+                    ToolTip.Tip="{x:Static l:Resources.ContextCopyStep}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Image Source="avares://Semistep/Assets/Icons/copy.png" />
-                    <TextBlock Text="Copy" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Static l:Resources.ToolbarCopyStep}" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
 
             <Button x:Name="CutButton"
                     Classes="toolbar"
                     Command="{Binding Clipboard.CutStepCommand}"
-                    ToolTip.Tip="Cut Steps">
+                    ToolTip.Tip="{x:Static l:Resources.ContextCutStep}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Image Source="avares://Semistep/Assets/Icons/cut.png" />
-                    <TextBlock Text="Cut" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Static l:Resources.ToolbarCutStep}" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
 
             <Button x:Name="PasteButton"
                     Classes="toolbar"
                     Command="{Binding Clipboard.PasteStepCommand}"
-                    ToolTip.Tip="Paste Steps">
+                    ToolTip.Tip="{x:Static l:Resources.ContextPasteStep}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Image Source="avares://Semistep/Assets/Icons/paste.png" />
-                    <TextBlock Text="Paste" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Static l:Resources.ToolbarPasteStep}" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
 
@@ -88,20 +89,20 @@
             <Button x:Name="UndoButton"
                     Classes="toolbar"
                     Command="{Binding RecipeCommands.UndoCommand}"
-                    ToolTip.Tip="Undo">
+                    ToolTip.Tip="{x:Static l:Resources.ToolbarUndo}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Image Source="avares://Semistep/Assets/Icons/undo.png" />
-                    <TextBlock Text="Undo" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Static l:Resources.ToolbarUndo}" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
 
             <Button x:Name="RedoButton"
                     Classes="toolbar"
                     Command="{Binding RecipeCommands.RedoCommand}"
-                    ToolTip.Tip="Redo">
+                    ToolTip.Tip="{x:Static l:Resources.ToolbarRedo}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Image Source="avares://Semistep/Assets/Icons/redo.png" />
-                    <TextBlock Text="Redo" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Static l:Resources.ToolbarRedo}" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
 

--- a/SemiStep/SemiStep.UI/MessageService/MessagePanel.axaml
+++ b/SemiStep/SemiStep.UI/MessageService/MessagePanel.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:messageService="clr-namespace:SemiStep.UI.MessageService"
+             xmlns:l="clr-namespace:SemiStep.UI.Localization"
              mc:Ignorable="d"
              x:Class="SemiStep.UI.MessageService.MessagePanel"
              x:DataType="messageService:MessagePanelViewModel">
@@ -69,7 +70,7 @@
                     <Button x:Name="CloseButton"
                             Grid.Column="1"
                             Command="{Binding ToggleCommand}"
-                            ToolTip.Tip="Close"
+                            ToolTip.Tip="{x:Static l:Resources.MessagePanelClose}"
                             Background="Transparent"
                             BorderThickness="0"
                             Cursor="Hand"

--- a/SemiStep/SemiStep.UI/MessageService/MessagePanelViewModel.cs
+++ b/SemiStep/SemiStep.UI/MessageService/MessagePanelViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
@@ -11,6 +12,8 @@ using FluentResults;
 using ReactiveUI;
 
 using SemiStep.Core.Shared;
+
+using SemiStep.UI.Localization;
 
 namespace SemiStep.UI.MessageService;
 
@@ -54,13 +57,13 @@ public class MessagePanelViewModel : ReactiveObject, IDisposable
 			.DisposeWith(_disposables);
 
 		_errorCountText = this.WhenAnyValue(x => x.ErrorCount)
-			.Select(c => $"{c} {(c == 1 ? "Error" : "Errors")}")
-			.ToProperty(this, x => x.ErrorCountText, initialValue: "0 Errors")
+			.Select(FormatErrorCount)
+			.ToProperty(this, x => x.ErrorCountText, initialValue: FormatErrorCount(0))
 			.DisposeWith(_disposables);
 
 		_warningCountText = this.WhenAnyValue(x => x.WarningCount)
-			.Select(c => $"{c} {(c == 1 ? "Warning" : "Warnings")}")
-			.ToProperty(this, x => x.WarningCountText, initialValue: "0 Warnings")
+			.Select(FormatWarningCount)
+			.ToProperty(this, x => x.WarningCountText, initialValue: FormatWarningCount(0))
 			.DisposeWith(_disposables);
 
 		_statusErrorSummary = this.WhenAnyValue(
@@ -223,5 +226,15 @@ public class MessagePanelViewModel : ReactiveObject, IDisposable
 		WarningCount = _validationEntries.Count(e => e.IsWarning);
 		HasEntries = _validationEntries.Count > 0
 			|| _operationEntry is { Severity: MessageSeverity.Error or MessageSeverity.Warning };
+	}
+
+	internal static string FormatErrorCount(int count)
+	{
+		return string.Format(CultureInfo.InvariantCulture, Resources.MessagePanelErrorsFormat, count);
+	}
+
+	internal static string FormatWarningCount(int count)
+	{
+		return string.Format(CultureInfo.InvariantCulture, Resources.MessagePanelWarningsFormat, count);
 	}
 }

--- a/SemiStep/SemiStep.UI/Plc/PlcConflictDialog.axaml
+++ b/SemiStep/SemiStep.UI/Plc/PlcConflictDialog.axaml
@@ -3,10 +3,11 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:plc="clr-namespace:SemiStep.UI.Plc"
+        xmlns:l="clr-namespace:SemiStep.UI.Localization"
         mc:Ignorable="d"
         x:Class="SemiStep.UI.Plc.PlcConflictDialog"
         x:DataType="plc:PlcConflictDialogViewModel"
-        Title="Recipe Conflict"
+        Title="{x:Static l:Resources.PlcConflictTitle}"
         Width="440"
         Height="200"
         WindowStartupLocation="CenterOwner"
@@ -23,11 +24,11 @@
                     Orientation="Vertical"
                     Spacing="6"
                     VerticalAlignment="Center">
-            <TextBlock Text="The PLC contains a different recipe."
+            <TextBlock Text="{x:Static l:Resources.PlcConflictLine1}"
                        TextWrapping="Wrap" />
-            <TextBlock Text="{Binding LocalStepCount, StringFormat='Local: {0} steps'}" />
-            <TextBlock Text="{Binding PlcStepCount, StringFormat='PLC: {0} steps'}" />
-            <TextBlock Text="Which version do you want to keep?"
+            <TextBlock Text="{Binding LocalStepCountText}" />
+            <TextBlock Text="{Binding PlcStepCountText}" />
+            <TextBlock Text="{x:Static l:Resources.PlcConflictQuestion}"
                        TextWrapping="Wrap"
                        Margin="0,4,0,0" />
         </StackPanel>
@@ -37,10 +38,10 @@
                     HorizontalAlignment="Right"
                     Spacing="10"
                     Margin="0,20,0,0">
-            <Button Content="Keep local"
+            <Button Content="{x:Static l:Resources.PlcConflictKeepLocal}"
                     Classes="primary"
                     Click="OnKeepLocalClick" />
-            <Button Content="Load from PLC"
+            <Button Content="{x:Static l:Resources.PlcConflictLoadFromPlc}"
                     Classes="secondary"
                     Click="OnLoadFromPlcClick" />
         </StackPanel>

--- a/SemiStep/SemiStep.UI/Plc/PlcConflictDialogViewModel.cs
+++ b/SemiStep/SemiStep.UI/Plc/PlcConflictDialogViewModel.cs
@@ -1,4 +1,8 @@
-﻿namespace SemiStep.UI.Plc;
+﻿using System.Globalization;
+
+using SemiStep.UI.Localization;
+
+namespace SemiStep.UI.Plc;
 
 internal sealed class PlcConflictDialogViewModel
 {
@@ -11,4 +15,18 @@ internal sealed class PlcConflictDialogViewModel
 	public int LocalStepCount { get; }
 
 	public int PlcStepCount { get; }
+
+	public string LocalStepCountText => FormatLocalStepCount(LocalStepCount);
+
+	public string PlcStepCountText => FormatPlcStepCount(PlcStepCount);
+
+	internal static string FormatLocalStepCount(int stepCount)
+	{
+		return string.Format(CultureInfo.InvariantCulture, Resources.PlcConflictLocalSteps, stepCount);
+	}
+
+	internal static string FormatPlcStepCount(int stepCount)
+	{
+		return string.Format(CultureInfo.InvariantCulture, Resources.PlcConflictPlcSteps, stepCount);
+	}
 }

--- a/SemiStep/SemiStep.UI/Program.cs
+++ b/SemiStep/SemiStep.UI/Program.cs
@@ -8,6 +8,8 @@ using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Import;
 
+using SemiStep.UI.Localization;
+
 using Serilog;
 using Serilog.Events;
 
@@ -19,6 +21,10 @@ public static class Program
 	[STAThread]
 	public static void Main(string[] args)
 	{
+		// Baseline UI culture before config load. Harmless: the only pre-config UI is
+		// ErrorWindow, which is hardcoded English and does not depend on culture/resx.
+		CultureInfo.DefaultThreadCurrentUICulture = UiCultureSelector.Resolve(null);
+
 		var options = StartupOptions.Parse(args);
 
 		CreateLogger(
@@ -77,6 +83,12 @@ public static class Program
 
 			return StartupOutcome.Failed(errors);
 		}
+
+		// Override the UI culture from the loaded locale. Only UICulture changes; CurrentCulture
+		// stays invariant so number/date formatting and logs remain English.
+		var uiCulture = UiCultureSelector.Resolve(result.Value.Ui.Locale);
+		CultureInfo.DefaultThreadCurrentUICulture = uiCulture;
+		Resources.Culture = uiCulture;
 
 		var services =
 			new ServiceCollection()

--- a/SemiStep/SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml
+++ b/SemiStep/SemiStep.UI/ShutdownService/ExitConfirmationDialog.axaml
@@ -2,9 +2,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:l="clr-namespace:SemiStep.UI.Localization"
         mc:Ignorable="d"
         x:Class="SemiStep.UI.ShutdownService.ExitConfirmationDialog"
-        Title="Unsaved Changes"
+        Title="{x:Static l:Resources.DialogExitTitle}"
         Width="400"
         Height="150"
         WindowStartupLocation="CenterOwner"
@@ -18,7 +19,7 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0"
-                   Text="You have unsaved changes. Do you want to save before exiting?"
+                   Text="{x:Static l:Resources.DialogExitMessage}"
                    TextWrapping="Wrap"
                    VerticalAlignment="Center" />
 
@@ -27,13 +28,13 @@
                     HorizontalAlignment="Right"
                     Spacing="10"
                     Margin="0,20,0,0">
-            <Button Content="Save"
+            <Button Content="{x:Static l:Resources.DialogSave}"
                     Classes="primary"
                     Click="OnSaveClick" />
-            <Button Content="Don't Save"
+            <Button Content="{x:Static l:Resources.DialogDontSave}"
                     Classes="secondary"
                     Click="OnDontSaveClick" />
-            <Button Content="Cancel"
+            <Button Content="{x:Static l:Resources.DialogCancel}"
                     Classes="secondary"
                     Click="OnCancelClick"
                     IsCancel="True" />

--- a/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorViewModel.cs
+++ b/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorViewModel.cs
@@ -8,6 +8,7 @@ using FluentResults;
 using ReactiveUI;
 
 using SemiStep.Core.Configuration;
+using SemiStep.UI.Localization;
 
 namespace SemiStep.UI.StyleEditor;
 
@@ -272,7 +273,7 @@ public sealed class GridStyleEditorViewModel : ReactiveObject
 	{
 		if (!CanSave)
 		{
-			ErrorMessage = "Cannot save: the current style draft has invalid or out-of-range values.";
+			ErrorMessage = Resources.EditorCannotSave;
 			return false;
 		}
 
@@ -405,7 +406,7 @@ public sealed class GridStyleEditorViewModel : ReactiveObject
 			.OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
 			.ToList();
 
-		var families = new List<FontFamilyOption> { new("", "(Default)") };
+		var families = new List<FontFamilyOption> { new("", Resources.EditorDefaultFont) };
 		if (!string.IsNullOrWhiteSpace(seededFamily) && !systemFamilies.Contains(seededFamily))
 		{
 			families.Add(new FontFamilyOption(seededFamily, seededFamily));

--- a/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml
+++ b/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml
@@ -3,12 +3,13 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:styleEditor="clr-namespace:SemiStep.UI.StyleEditor"
+        xmlns:l="clr-namespace:SemiStep.UI.Localization"
         mc:Ignorable="d"
         d:DesignWidth="720"
         d:DesignHeight="780"
         x:Class="SemiStep.UI.StyleEditor.GridStyleEditorWindow"
         x:DataType="styleEditor:GridStyleEditorViewModel"
-        Title="Grid Style Settings"
+        Title="{x:Static l:Resources.EditorTitle}"
         MinWidth="680"
         MinHeight="520"
         Width="720"
@@ -97,9 +98,9 @@
                         HorizontalAlignment="Stretch">
 
                 <StackPanel Spacing="8">
-                    <TextBlock Classes="section-header" Text="Recipe Grid" />
+                    <TextBlock Classes="section-header" Text="{x:Static l:Resources.EditorRecipeGrid}" />
 
-                    <TextBlock Classes="sub-header" Text="Dimensions" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorDimensions}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -109,24 +110,24 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Row height" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorRowHeight}" />
                         <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="12" Maximum="400" Increment="1"
                                        Value="{Binding RowHeight}" />
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Cell padding left" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorCellPaddingLeft}" />
                         <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
                                        Value="{Binding CellPaddingLeft}" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Cell padding top" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorCellPaddingTop}" />
                         <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
                                        Value="{Binding CellPaddingTop}" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Cell padding right" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorCellPaddingRight}" />
                         <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
                                        Value="{Binding CellPaddingRight}" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Cell padding bottom" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorCellPaddingBottom}" />
                         <NumericUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
                                        Value="{Binding CellPaddingBottom}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Fonts" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorFonts}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -136,11 +137,11 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
-                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Weight" />
-                        <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="Italic" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="{x:Static l:Resources.EditorSize}" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="{x:Static l:Resources.EditorWeight}" />
+                        <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="{x:Static l:Resources.EditorItalic}" />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid header" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorGridHeader}" />
                         <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
                                        Value="{Binding HeaderFontSize}" />
                         <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
@@ -151,7 +152,7 @@
                         <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
                                   IsChecked="{Binding HeaderItalic}" />
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid cell" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorGridCell}" />
                         <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
                                        Value="{Binding CellFontSize}" />
                         <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
@@ -163,7 +164,7 @@
                                   IsChecked="{Binding CellItalic}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Colors" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorColors}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -173,33 +174,33 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Grid background" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorGridBackground}" />
                         <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding GridBackground}" />
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Grid border" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorGridBorder}" />
                         <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding GridBorder}" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Grid line" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorGridLine}" />
                         <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding GridLine}" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Header foreground" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorHeaderForeground}" />
                         <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding HeaderForeground}" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Selection background" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorSelectionBackground}" />
                         <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding SelectionBackground}" />
-                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selection foreground" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorSelectionForeground}" />
                         <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding SelectionForeground}" />
-                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Changed" />
+                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorChanged}" />
                         <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding CellChanged}" />
-                        <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="Changed (selected)" />
+                        <TextBlock Grid.Row="7" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorChangedSelected}" />
                         <ColorPicker Grid.Row="7" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding CellChangedSelected}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Read-only cells" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorReadOnlyCells}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -208,38 +209,38 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
-                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="{x:Static l:Resources.EditorCurrent}" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="{x:Static l:Resources.EditorPast}" />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth0}" />
                         <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellDepth0}" />
                         <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellDepth0Past}" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth1}" />
                         <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellDepth1}" />
                         <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellDepth1Past}" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth2}" />
                         <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellDepth2}" />
                         <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellDepth2Past}" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth3}" />
                         <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellDepth3}" />
                         <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellDepth3Past}" />
-                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selected" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorSelected}" />
                         <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellSelected}" />
-                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorForeground}" />
                         <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ReadOnlyCellForeground}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Disabled cells" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorDisabledCells}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -248,38 +249,38 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
-                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="{x:Static l:Resources.EditorCurrent}" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="{x:Static l:Resources.EditorPast}" />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth0}" />
                         <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellDepth0}" />
                         <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellDepth0Past}" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth1}" />
                         <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellDepth1}" />
                         <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellDepth1Past}" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth2}" />
                         <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellDepth2}" />
                         <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellDepth2Past}" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth3}" />
                         <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellDepth3}" />
                         <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellDepth3Past}" />
-                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Selected" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorSelected}" />
                         <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellSelected}" />
-                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                        <TextBlock Grid.Row="6" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorForeground}" />
                         <ColorPicker Grid.Row="6" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding DisabledCellForeground}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Execution highlight" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorExecutionHighlight}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -288,39 +289,39 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ColorPast" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Current" />
-                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Past" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="{x:Static l:Resources.EditorCurrent}" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="{x:Static l:Resources.EditorPast}" />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Depth 0" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth0}" />
                         <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ExecutionDepth0}" />
                         <ColorPicker Grid.Row="1" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding ExecutionDepth0Past}" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Depth 1" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth1}" />
                         <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ExecutionDepth1}" />
                         <ColorPicker Grid.Row="2" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding ExecutionDepth1Past}" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Depth 2" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth2}" />
                         <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ExecutionDepth2}" />
                         <ColorPicker Grid.Row="3" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding ExecutionDepth2Past}" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Depth 3" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDepth3}" />
                         <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ExecutionDepth3}" />
                         <ColorPicker Grid.Row="4" Grid.Column="2" IsHexInputVisible="True"
                                      Color="{Binding ExecutionDepth3Past}" />
-                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Current step marker" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorCurrentStepMarker}" />
                         <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ExecutionCurrentStepMarker}" />
                     </Grid>
                 </StackPanel>
 
                 <StackPanel Spacing="8">
-                    <TextBlock Classes="section-header" Text="Status Bar" />
+                    <TextBlock Classes="section-header" Text="{x:Static l:Resources.EditorStatusBar}" />
 
-                    <TextBlock Classes="sub-header" Text="Dimensions" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorDimensions}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -330,15 +331,15 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Padding" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorPadding}" />
                         <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
                                        Value="{Binding StatusBarPadding}" />
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Item spacing" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorItemSpacing}" />
                         <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Increment="1"
                                        Value="{Binding StatusBarItemSpacing}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Fonts" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorFonts}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -348,11 +349,11 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="Size" />
-                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="Weight" />
-                        <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="Italic" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Classes="col-head" Text="{x:Static l:Resources.EditorSize}" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Classes="col-head" Text="{x:Static l:Resources.EditorWeight}" />
+                        <TextBlock Grid.Row="0" Grid.Column="3" Classes="col-head" Text="{x:Static l:Resources.EditorItalic}" />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Text" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorText}" />
                         <NumericUpDown Grid.Row="1" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
                                        Value="{Binding StatusBarFontSize}" />
                         <ComboBox Grid.Row="1" Grid.Column="2" Classes="weight-picker"
@@ -363,7 +364,7 @@
                         <CheckBox Grid.Row="1" Grid.Column="3" Classes="italic-check"
                                   IsChecked="{Binding StatusBarItalic}" />
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Timer label" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorTimerLabel}" />
                         <NumericUpDown Grid.Row="2" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
                                        Value="{Binding StatusBarTimerLabelFontSize}" />
                         <ComboBox Grid.Row="2" Grid.Column="2" Classes="weight-picker"
@@ -374,7 +375,7 @@
                         <CheckBox Grid.Row="2" Grid.Column="3" Classes="italic-check"
                                   IsChecked="{Binding StatusBarTimerLabelItalic}" />
 
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Timer value" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorTimerValue}" />
                         <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="6" Maximum="72" Increment="1"
                                        Value="{Binding StatusBarTimerValueFontSize}" />
                         <ComboBox Grid.Row="3" Grid.Column="2" Classes="weight-picker"
@@ -386,7 +387,7 @@
                                   IsChecked="{Binding StatusBarTimerValueItalic}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Colors" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorColors}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -396,31 +397,31 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorBackground}" />
                         <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding StatusBarBackground}" />
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorForeground}" />
                         <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding StatusBarForeground}" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Connected" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorConnected}" />
                         <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding Connected}" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Disconnected" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorDisconnected}" />
                         <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding Disconnected}" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Local mode" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorLocalMode}" />
                         <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding LocalMode}" />
-                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="Connecting" />
+                        <TextBlock Grid.Row="5" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorConnecting}" />
                         <ColorPicker Grid.Row="5" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding Connecting}" />
                     </Grid>
                 </StackPanel>
 
                 <StackPanel Spacing="8">
-                    <TextBlock Classes="section-header" Text="Notification Panel" />
+                    <TextBlock Classes="section-header" Text="{x:Static l:Resources.EditorNotificationPanel}" />
 
-                    <TextBlock Classes="sub-header" Text="Dimensions" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorDimensions}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto">
                         <Grid.ColumnDefinitions>
@@ -430,12 +431,12 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Max height" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorMaxHeight}" />
                         <NumericUpDown Grid.Row="0" Grid.Column="1" Minimum="20" Maximum="2000" Increment="10"
                                        Value="{Binding ValidationPanelMaxHeight}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Colors" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorColors}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -445,28 +446,28 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Background" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorBackground}" />
                         <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ValidationPanelBackground}" />
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Foreground" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorForeground}" />
                         <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ValidationPanelForeground}" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Info severity" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorInfoSeverity}" />
                         <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding Info}" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Error severity" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorErrorSeverity}" />
                         <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ValidationPanelError}" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Warning severity" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorWarningSeverity}" />
                         <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding ValidationPanelWarning}" />
                     </Grid>
                 </StackPanel>
 
                 <StackPanel Spacing="8">
-                    <TextBlock Classes="section-header" Text="Application Theme" />
+                    <TextBlock Classes="section-header" Text="{x:Static l:Resources.EditorApplicationTheme}" />
 
-                    <TextBlock Classes="sub-header" Text="Typography" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorTypography}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto">
                         <Grid.ColumnDefinitions>
@@ -476,7 +477,7 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Font family" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorFontFamily}" />
                         <ComboBox Grid.Row="0" Grid.Column="1"
                                   Width="{StaticResource FontFamilyWidth}"
                                   HorizontalAlignment="Left"
@@ -487,7 +488,7 @@
                                   SelectedValue="{Binding FontFamily}" />
                     </Grid>
 
-                    <TextBlock Classes="sub-header" Text="Shared colors" />
+                    <TextBlock Classes="sub-header" Text="{x:Static l:Resources.EditorSharedColors}" />
                     <Grid ColumnSpacing="{StaticResource LabelGap}" RowSpacing="{StaticResource RowGap}"
                           RowDefinitions="Auto,Auto,Auto,Auto,Auto">
                         <Grid.ColumnDefinitions>
@@ -497,19 +498,19 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="ItalicCol" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="Panel background" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorPanelBackground}" />
                         <ColorPicker Grid.Row="0" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding PanelBackground}" />
-                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="Panel header background" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorPanelHeaderBackground}" />
                         <ColorPicker Grid.Row="1" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding PanelHeaderBackground}" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="Subtle border" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorSubtleBorder}" />
                         <ColorPicker Grid.Row="2" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding SubtleBorder}" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="Separator" />
+                        <TextBlock Grid.Row="3" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorSeparator}" />
                         <ColorPicker Grid.Row="3" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding Separator}" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="Secondary foreground" />
+                        <TextBlock Grid.Row="4" Grid.Column="0" Classes="field-label" Text="{x:Static l:Resources.EditorSecondaryForeground}" />
                         <ColorPicker Grid.Row="4" Grid.Column="1" IsHexInputVisible="True"
                                      Color="{Binding SecondaryForeground}" />
                     </Grid>
@@ -534,11 +535,11 @@
                             Orientation="Horizontal"
                             HorizontalAlignment="Right"
                             Spacing="10">
-                    <Button Content="Save"
+                    <Button Content="{x:Static l:Resources.DialogSave}"
                             Classes="primary"
                             IsDefault="True"
                             Command="{Binding SaveCommand}" />
-                    <Button Content="Cancel"
+                    <Button Content="{x:Static l:Resources.DialogCancel}"
                             Classes="secondary"
                             IsCancel="True"
                             Click="OnCancelClick" />

--- a/SemiStep/SemiStep.UI/StyleEditor/RestartPromptDialog.axaml
+++ b/SemiStep/SemiStep.UI/StyleEditor/RestartPromptDialog.axaml
@@ -2,9 +2,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:l="clr-namespace:SemiStep.UI.Localization"
         mc:Ignorable="d"
         x:Class="SemiStep.UI.StyleEditor.RestartPromptDialog"
-        Title="Settings Saved"
+        Title="{x:Static l:Resources.EditorRestartTitle}"
         Width="420"
         Height="160"
         WindowStartupLocation="CenterOwner"
@@ -18,7 +19,7 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0"
-                   Text="Settings saved. Restart the application to apply the changes."
+                   Text="{x:Static l:Resources.EditorRestartMessage}"
                    TextWrapping="Wrap"
                    VerticalAlignment="Center" />
 
@@ -27,10 +28,10 @@
                     HorizontalAlignment="Right"
                     Spacing="10"
                     Margin="0,20,0,0">
-            <Button Content="Exit Now"
+            <Button Content="{x:Static l:Resources.EditorExitNow}"
                     Classes="secondary"
                     Click="OnExitNowClick" />
-            <Button Content="Restart Later"
+            <Button Content="{x:Static l:Resources.EditorRestartLater}"
                     Classes="primary"
                     Click="OnRestartLaterClick"
                     IsDefault="True"


### PR DESCRIPTION
Closes #69.

Russifies the application chrome with resx-based multi-language support, default Russian.

## What
- `locale` setting in `ui/app.yaml` (equipment config), default `ru`; English is the neutral fallback.
- Localized: menus, toolbar, status bar (incl. error/warning counts), DataGrid context menu, dialogs, view-model literals, and the **full grid-style settings editor + restart prompt**.
- Sync toggle button widened for the longer Russian labels.

## Design notes
- Only `UICulture` / `Resources.Culture` are set (at startup, from config). `CurrentCulture` is never touched, so number/date formatting and Serilog stay invariant/English. Logs and notification-panel diagnostics stay hardcoded English.
- The strongly-typed `Resources` accessor is a **committed source file**, not build-time-generated: build-time generation makes it invisible to Avalonia's XamlIl on a cold build (`AVLN2000` -> `App.axaml` fails to precompile -> headless `[AvaloniaFact]` deadlock). Consequence: a new key means editing three files in sync (neutral resx, ru resx, Designer). A reflection guard test enforces this. See `Docs/architecture/ui-localization.md`.
- `ErrorWindow` is deliberately hardcoded English — it renders only on config-load failure, when the locale is unknown by construction.

## Tests
Full suite: **1174 passed, 0 failed**. Adds locale loader/mapper, culture-selector, resx-resolution, resx-sync + format-placeholder guards, and chrome/view-model localization tests.

## Follow-ups (not in this PR)
- Font-weight picker names (Light/Bold/…) left English — pending decision.
- Native proofread of Russian wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)