### PR TITLE
chore(deps): bump 15 packages incl. NCalc 6.3.3

### DIFF
--- a/SemiStep/Directory.Packages.props
+++ b/SemiStep/Directory.Packages.props
@@ -5,24 +5,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.4"/>
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.4"/>
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0"/>
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.4"/>
-    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.4"/>
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.4"/>
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.4"/>
-    <PackageVersion Include="Avalonia.Win32" Version="12.0.4"/>
+    <PackageVersion Include="Avalonia" Version="12.0.5"/>
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.5"/>
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.1"/>
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.5"/>
+    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.5"/>
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.5"/>
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.5"/>
+    <PackageVersion Include="Avalonia.Win32" Version="12.0.5"/>
     <PackageVersion Include="CsvHelper" Version="33.1.0"/>
     <PackageVersion Include="FluentAssertions" Version="8.10.0"/>
     <PackageVersion Include="FluentResults" Version="4.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
-    <PackageVersion Include="NCalcSync" Version="5.12.0"/>
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.1"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0"/>
+    <PackageVersion Include="NCalcSync" Version="6.3.3"/>
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3"/>
     <PackageVersion Include="S7netplus" Version="0.20.0"/>
     <PackageVersion Include="Semi.Avalonia" Version="12.0.3"/>
     <PackageVersion Include="Semi.Avalonia.ColorPicker" Version="12.0.3"/>
@@ -31,11 +31,11 @@
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0"/>
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1"/>
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0"/>
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.8"/>
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.9"/>
     <PackageVersion Include="System.Reactive" Version="6.1.0"/>
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
     <PackageVersion Include="xunit.v3" Version="3.2.2"/>
-    <PackageVersion Include="YamlDotNet" Version="18.0.0"/>
+    <PackageVersion Include="YamlDotNet" Version="18.1.0"/>
   </ItemGroup>
 
 </Project>

--- a/SemiStep/SemiStep.Core/Configuration/Mapping/ActionMapper.cs
+++ b/SemiStep/SemiStep.Core/Configuration/Mapping/ActionMapper.cs
@@ -1,6 +1,6 @@
 ﻿using FluentResults;
 
-using NCalc.Domain;
+using NCalc;
 
 using SemiStep.Core.Configuration.Dto;
 using SemiStep.Core.Recipes;

--- a/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaDefinition.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaDefinition.cs
@@ -1,4 +1,4 @@
-﻿using NCalc.Domain;
+﻿using NCalc;
 
 namespace SemiStep.Core.Recipes.Formulas;
 

--- a/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs
@@ -5,7 +5,6 @@ using FluentResults;
 using Microsoft.Extensions.Logging;
 
 using NCalc;
-using NCalc.Domain;
 
 using SemiStep.Core.Recipes.Formulas.Errors;
 

--- a/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaIdentifierExtractor.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaIdentifierExtractor.cs
@@ -1,7 +1,6 @@
 ﻿using FluentResults;
 
 using NCalc;
-using NCalc.Domain;
 
 namespace SemiStep.Core.Recipes.Formulas;
 

--- a/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionFormulaIntegrationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionFormulaIntegrationTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 
-using NCalc.Domain;
+using NCalc;
 
 using SemiStep.Core.Configuration;
 using SemiStep.Core.Plc.Configuration;

--- a/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionSelectorSeedIntegrationTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Recipes/RecipeSessionSelectorSeedIntegrationTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 
-using NCalc.Domain;
+using NCalc;
 
 using SemiStep.Core.Configuration;
 using SemiStep.Core.Plc.Configuration;

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Formulas/FormulaEvaluatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Formulas/FormulaEvaluatorTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 
-using NCalc.Domain;
+using NCalc;
 
 using SemiStep.Core.Configuration;
 using SemiStep.Core.Plc.Configuration;


### PR DESCRIPTION
Supersedes #99. Same 15-package group bump, plus the NCalc 5→6 namespace migration that #99 was missing (which is why #99's CI failed to compile).

## Updates
Avalonia 12.0.4→12.0.5 (DataGrid →12.0.1), Microsoft.Extensions.* 10.0.8→10.0.9, Microsoft.NET.Test.Sdk 18.6→18.7, ReactiveUI.Avalonia 12.0.1→12.0.3, System.IO.Hashing →10.0.9, YamlDotNet 18.0→18.1, **NCalcSync 5.12.0→6.3.3**.

## NCalc 6 migration
NCalc 6.0 moved public domain types out of `NCalc.Domain` into `NCalc`. Swapped `using NCalc.Domain;` → `using NCalc;` in 7 files (3 core formula files + `ActionMapper` + 4 tests). `Expression.LogicalExpression` and the `Expression(LogicalExpression, …)` ctor are unchanged, the Domain assembly is transitive via NCalcSync — no other code or package-reference changes. Clears the NU1902 (GHSA-3w5p-95mh-gq75) advisory that was on NCalc 5.12.

## Verification
Build 0 errors, full suite 1171 passed / 0 failed (incl. all formula/evaluator tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)