### PR TITLE
fix: bound fractional formula result display to 3 decimals

### DIFF
--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/PropertyTimeMultiConverterTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/PropertyTimeMultiConverterTests.cs
@@ -1,0 +1,34 @@
+﻿using FluentAssertions;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+[Trait("Component", "UI")]
+[Trait("Category", "Unit")]
+public sealed class PropertyTimeMultiConverterTests
+{
+	[Theory]
+	[InlineData(1.1952192f, "1.195")]
+	[InlineData(1.2f, "1.2")]
+	[InlineData(5f, "5")]
+	[InlineData(0.12345f, "0.123")]
+	public void FormatNumeric_Float_BoundsToThreeInvariantDecimals(float value, string expected)
+	{
+		PropertyTimeMultiConverter.FormatNumeric(value).Should().Be(expected);
+	}
+
+	[Fact]
+	public void FormatNumeric_Int_IsUnchanged()
+	{
+		PropertyTimeMultiConverter.FormatNumeric(20).Should().Be("20");
+	}
+
+	[Fact]
+	public void FormatNumeric_String_PassesThrough()
+	{
+		PropertyTimeMultiConverter.FormatNumeric("n/a").Should().Be("n/a");
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeMultiConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeMultiConverter.cs
@@ -31,12 +31,22 @@ internal sealed class PropertyTimeMultiConverter : IMultiValueConverter
 			return string.Empty;
 		}
 
-		var rawString = cellValue as string ?? cellValue.ToString();
+		var rawString = cellValue as string ?? FormatNumeric(cellValue);
 		if (string.IsNullOrEmpty(rawString))
 		{
 			return string.Empty;
 		}
 
 		return TimeFormatHelper.FormatValue(rawString, formatKind, units);
+	}
+
+	internal static string FormatNumeric(object cellValue)
+	{
+		if (cellValue is float or double or decimal)
+		{
+			return ((IFormattable)cellValue).ToString("0.###", CultureInfo.InvariantCulture);
+		}
+
+		return cellValue.ToString() ?? string.Empty;
 	}
 }


### PR DESCRIPTION
The recipe-grid 'Скорость' (formula) cell rendered a full-precision float like `1.1952192 %/мин`, overflowing and clipping the cell. Bound the displayed value to 3 decimals (trailing zeros trimmed) in `PropertyTimeMultiConverter` (the text-cell display path); invariant keeps it parseable by the time_hms branch and matches CSV export. Whole values (5, 20) unchanged; editing path untouched. Unit test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)