### PR TITLE
fix: drop hover/press highlight on non-sortable grid headers

### DIFF
--- a/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
+++ b/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
@@ -66,6 +66,13 @@
         <Setter Property="IsVisible" Value="False" />
     </Style>
 
+    <Style Selector="DataGridColumnHeader:pointerover /template/ Border#HeaderBackground">
+        <Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackground}" />
+    </Style>
+    <Style Selector="DataGridColumnHeader:pressed /template/ Border#HeaderBackground">
+        <Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackground}" />
+    </Style>
+
     <!-- ============================================== -->
     <!-- Read-only and inapplicable cell appearance.    -->
     <!-- Two DISJOINT signals, each with its own        -->


### PR DESCRIPTION
Recipe-grid columns are non-sortable, so the column-header hover/press highlight signals an interaction that does nothing. Semi paints it on the inner `Border#HeaderBackground`; this pins that back to the resting header background for both states (app style loads after Semi's DataGrid theme, so it wins). Verified against Semi's DataGrid theme source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)