### PR TITLE
style: strengthen section-header hierarchy in grid style editor

### DIFF
--- a/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml
+++ b/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml
@@ -37,12 +37,15 @@
     <Window.Styles>
         <Style Selector="TextBlock.section-header">
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="FontSize" Value="13" />
-            <Setter Property="Foreground" Value="{DynamicResource SemiColorText2}" />
+            <Setter Property="FontSize" Value="15" />
+            <Setter Property="Foreground" Value="{DynamicResource SemiColorText0}" />
+            <Setter Property="Margin" Value="0,18,0,2" />
         </Style>
         <Style Selector="TextBlock.sub-header">
-            <Setter Property="FontWeight" Value="Medium" />
-            <Setter Property="Margin" Value="0,4,0,0" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Foreground" Value="{DynamicResource SemiColorText2}" />
+            <Setter Property="Margin" Value="0,10,0,2" />
         </Style>
         <Style Selector="TextBlock.field-label">
             <Setter Property="VerticalAlignment" Value="Center" />


### PR DESCRIPTION
Section titles and group sub-headers read almost the same as the field labels. Three clear tiers now: section title (primary, semibold, 15) > group sub-header (secondary grey, semibold, 12) > field label (primary, regular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)