### PR TITLE
refactor: extract IRecipeGridSurface abstraction behind the recipe grid

### DIFF
--- a/Docs/architecture/cell-change-highlight.md
+++ b/Docs/architecture/cell-change-highlight.md
@@ -43,7 +43,7 @@ view-model:
 
 ## When cells are marked
 
-Marking happens in `SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs`:
+Marking happens in `SemiStep.UI/RecipeGrid/CanonicalRecipeGridSurface.cs`:
 
 - **Action change** — `RebuildRow` marks the replacement row's `ChangedColumns` to the new
   step's property keys projected to strings (`step.Properties.Keys.Select(id => id.Value)`).
@@ -58,10 +58,12 @@ Marking happens in `SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs`:
 - **Edit** — a new value entered into the cell. `OnCellValueChanged` calls
   `ClearChanged(columnKey)` on the row after a successful update.
 - **Click-away** — the cell is clicked, then any other cell is clicked.
-  `SemiStep.UI/MainWindow/MainWindow.axaml.cs` tracks a pending `(RecipeRowViewModel, columnKey)`.
-  On `CellPointerPressed`, if a pending cell is set and the pressed cell differs, it clears the
-  pending cell's orange, then re-arms pending to the pressed cell iff that cell `IsChanged`.
-  There is no `IsReadOnly` guard, so click-away still clears while PLC sync is active.
+  `SemiStep.UI/RecipeGrid/CanonicalRecipeGridView.axaml.cs` tracks a pending
+  `(RecipeRowViewModel, columnKey)`; the pending-vs-pressed decision itself lives in
+  `ChangedCellClickResolver`. On `CellPointerPressed`, if a pending cell is set and the pressed
+  cell differs, it clears the pending cell's orange, then re-arms pending to the pressed cell iff
+  that cell `IsChanged`. There is no `IsReadOnly` guard, so click-away still clears while PLC
+  sync is active.
 - **Execution start** — `SemiStep.UI/RecipeGrid/ExecutionHighlightTracker.cs` clears every row's
   set (`ClearAllChanged`) on the inactive→active edge only; an already-active line change does
   not re-clear.

--- a/Docs/architecture/recipe-grid-surface.md
+++ b/Docs/architecture/recipe-grid-surface.md
@@ -1,0 +1,92 @@
+# Recipe Grid Surface
+
+## Overview
+
+The recipe grid is consumed through the abstraction `IRecipeGridSurface`
+(`SemiStep.UI/RecipeGrid/IRecipeGridSurface.cs`). The canonical view (rows = steps,
+columns = parameters) is one concrete implementation; a transposed implementation can be added
+as a sibling surface + view pair without touching `MainWindow`, the command view-models, or the
+clipboard view-model.
+
+The pieces:
+
+- `IRecipeGridSurface` — the view-facing API. Selection is expressed in step indices only.
+- `CanonicalRecipeGridSurface` — the concrete surface for the canonical orientation. Owns row
+  projection (`RecipeRows`), mutation handling, execution highlighting, and the canonical-only
+  members (`ColumnBuilder`, internal `RecipeMetadataRegistry`). `ColumnBuilder` is
+  constructor-injected into the surface solely so the view can reach it through `DataContext` —
+  a recorded trade-off chosen over a service locator, to revisit when the transposed view lands.
+- `CanonicalRecipeGridView` (`ReactiveUserControl<CanonicalRecipeGridSurface>`) — wraps the
+  `DataGrid`, owns its event handlers (`BeginningEdit`, `CellEditEnded`, `SelectionChanged`,
+  `CellPointerPressed`, `LoadingRow`), column building, and the changed-cell click-away state.
+- `RecipeGridHost` — the swap point hosted by `MainWindow.axaml`. Today it is a thin
+  pass-through around `CanonicalRecipeGridView`; the transposed plan wires the actual switching.
+  Its `Surface` property (`DataContext as IRecipeGridSurface`) has no production consumer —
+  `MainWindow` reads only `IsEditing`; `Surface` is kept as the transposed-plan seam and is
+  pinned by tests.
+
+## Interface member inventory
+
+Members exist only because an existing consumer needs them (the plan's minimality rule):
+
+| Member | Consumers |
+| --- | --- |
+| `Initialize()` | `MainWindowViewModel.Initialize()` |
+| `StepCount` | `ClipboardViewModel` (paste insert index) |
+| `IsReadOnly` | view one-shot reads (edit gating) |
+| `SelectedStepIndices` / `SelectedStepIndex` | command + clipboard view-models |
+| `UpdateSelection(indices)` | the view (native selection mapped to step indices) |
+| `RequestSelection(int?)` | command + clipboard view-models, surface-internal action change |
+| `SelectionRequests` | the view (positions native selection) |
+| `CanDeleteStep` (`IObservable<bool>`, emits current value on subscription) | canExecute gates in command + clipboard view-models |
+| `EditorMustClose` (no replay) | `DataGridEditorCloseBehavior.Trigger` binding in the view |
+| `CollectSelectedSteps()` | `ClipboardViewModel` |
+
+`HasSelection` and `SelectedStepIndicesChanged` were removed: no production consumer existed,
+and every dead member would have to be implemented and contract-tested by each future surface.
+
+## Two selection directions
+
+- **View to surface:** the view translates its native selection into step indices and calls
+  `UpdateSelection`. Canonical walks `DataGrid.SelectedItems`, maps rows through
+  `RecipeRows.IndexOf`, and sorts ascending.
+- **Consumer to surface to view:** consumers push a post-mutation reposition through
+  `RequestSelection(int?)`; the surface forwards it into `SelectionRequests`; the view
+  subscribes and sets its native selection (`null` clears). `RequestSelection` is a safe no-op
+  after `Dispose()`.
+
+## Dependency injection
+
+`UiDi` registers `CanonicalRecipeGridSurface` as a singleton and forwards
+`IRecipeGridSurface` to that same instance. All three consumers (`MainWindowViewModel`,
+`RecipeCommandsViewModel`, `ClipboardViewModel`) take the interface only; the concrete type is
+referenced solely by the surface itself, `CanonicalRecipeGridView`, and the DI registration.
+The forwarding factory registration means the container tracks the instance twice for disposal;
+`Dispose` is idempotent, so the double call at teardown is harmless.
+
+## Mutation subscription ownership
+
+The surface subscribes itself to `RecipeCoordinator.Mutated` in its constructor and
+unsubscribes in `Dispose` — there is no external wiring and no "refresh me" method on the
+interface. This moved subscription order relative to the other three `Mutated` handlers
+(`PlcMonitorViewModel`, `MainWindowViewModel`, `RecipeCommandsViewModel`); order is immaterial
+because each handler reads only coordinator state committed before the event fires plus its own
+private state — no handler consumes another handler's output within a dispatch.
+
+## IsEditing forwarding chain
+
+Editing state is a view concern and is not on the interface. The chain:
+
+1. `CanonicalRecipeGridView.IsEditing` — set true in `BeginningEdit` (unless cancelled for an
+   inapplicable column), false in `CellEditEnded`, reset to false on view deactivation.
+2. `RecipeGridHost.IsEditing` — forwards to the hosted view.
+3. `MainWindow.OnKeyDown` — suppresses the Delete/Ctrl+C/X/V global shortcuts while
+   `RecipeGridHost.IsEditing` is true, so typing inside a cell editor never deletes or
+   cut/pastes steps.
+
+## Context menu placement
+
+The grid's context menu lives on the `Panel` wrapping `RecipeGridHost` in `MainWindow.axaml`
+because its commands bind to `MainWindowViewModel`. Right-clicks over grid rows bubble
+`ContextRequested` out of the DataGrid unhandled; a headless test in `RecipeGridHostTests`
+pins this.

--- a/Docs/plans/completed/20260520-recipe-grid-presentation-abstraction.md
+++ b/Docs/plans/completed/20260520-recipe-grid-presentation-abstraction.md
@@ -1,0 +1,268 @@
+# Recipe Grid Surface Abstraction
+
+## Overview
+
+Refactor the existing recipe-grid stack so it consumes an abstraction `IRecipeGridSurface` rather than the concrete `RecipeGridViewModel` + an inline Avalonia `DataGrid`. Outcome:
+
+- The current canonical view (rows = steps, columns = parameters) becomes one concrete implementation, `CanonicalRecipeGridSurface`.
+- A swap point exists for a future `TransposedRecipeGridSurface` to plug in without touching `MainWindow`, `MessagePanel`, status bar, clipboard, or command view-models.
+- Mutation routing, execution-state highlighting, and selection semantics live behind the abstraction.
+
+> **Naming note.** The interface was originally drafted as `IRecipeGridPresentation`. Renamed to `IRecipeGridSurface` to avoid collision with Avalonia's `*Presenter` infrastructure (`ContentPresenter`, `DataGridCellsPresenter`) and to make the «view-facing API of the grid» reading more honest.
+
+**Explicitly out of scope:**
+
+- The transposed implementation itself (separate plan after this lands).
+- Any `Orientation` toggle, hotkey, config-driven default, soft-limit, or new visual feature.
+- Any behaviour change. **Success criterion: zero observable change** for the operator.
+
+## Context (from discovery)
+
+**Files currently coupled to `DataGrid` / `RecipeGridViewModel`:**
+
+- `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml` — embeds `<DataGrid x:Name="RecipeGrid" .../>` directly.
+- `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs` — subscribes to `RecipeGrid.BeginningEdit`, `RecipeGrid.CellEditEnded`, `RecipeGrid.SelectionChanged`. Reads `RecipeGrid.SelectedItems`, `RecipeGrid.SelectedIndex`. Calls `_columnBuilder.BuildColumns(RecipeGrid)`. Subscribes to `ViewModel.RecipeGrid.SelectionRequested`.
+- `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs` — exposes `RecipeRows`, `CanDeleteStep`, `IsReadOnly`, `SelectedRowIndex`, `SelectedRowIndices`, `EditorMustClose`, `SelectionRequested` event, internal `RecipeMetadataRegistry`. Owns `ExecutionHighlightTracker` subscribed to coordinator's `ExecutionState`.
+- `SemiStep/SemiStep.UI/RecipeGrid/ColumnBuilder.cs` — orientation-specific column construction over a passed-in `DataGrid` instance.
+- `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowExecutionClassBinder.cs` — stamps row pseudo-classes on `DataGridRow` containers. Called from `MainWindow.axaml.cs:OnDataGridLoadingRow`.
+- Consumers reading public surface of `RecipeGridViewModel` (complete member inventory — this drives interface completeness):
+  - `MainWindowViewModel` — constructor injection; calls `Initialize()`; carries the `ColumnBuilder` pass-through property the view uses today.
+  - `RecipeCommandsViewModel` — observes `CanDeleteStep`, reads `SelectedRowIndex`, calls `RequestSelection(...)` after add/delete.
+  - `ClipboardViewModel` — observes `CanDeleteStep`, reads `RecipeRows.Count` (→ `StepCount`), calls `CollectSelectedSteps()` and `RequestSelection(...)` after cut/paste.
+
+**What is already orientation-agnostic and must stay so:**
+
+- `RecipeRowViewModel` (`SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs`) — `IsCurrentStep`, `IsPastStep`, `ForDepth`, `IsApplicable(columnKey)`, indexer `this[string columnKey]`, `PropertyValueChanged`/`ActionChanged` events. Row VM is per-step; the transposed view will need a separate row VM type (per-parameter), but the abstraction does not assume either shape.
+- `ExecutionHighlightTracker` — operates on `RecipeRowViewModel` collection; transposed view will likely need a different highlight router. The abstraction does **not** standardise highlighting — each implementation owns its own.
+- `RecipeCoordinator.Mutated`, `RecipeCoordinator.ExecutionState`, `RecipeCoordinator.CanEditRecipe` — Core/Coordinator signals; both implementations subscribe identically.
+
+## Development Approach
+
+- **Testing approach: Regular** — implement, then write tests in the same task.
+- This is a refactor. Every task ends with the full test suite passing and a manual smoke (open recipe, edit a cell, select, copy/paste, save) showing **no observable change**.
+- `dotnet format SemiStep/SemiStep.slnx` before each commit.
+- The abstraction is intentionally small. Add members only when an existing consumer needs them; do not predict future needs for the transposed view (that plan adds members as needed).
+
+## Testing Strategy
+
+- **Headless UI tests (Component=UI):** retarget existing `RecipeGridViewModel` tests onto the canonical implementation; their assertions remain valid.
+- **New abstraction contract tests** (Component=UI): operations against `IRecipeGridSurface` (selection update in both directions, edit-close, can-delete, collect-selected, dispose) produce the same observable outcome regardless of implementation. Cases defined in Task 1 (extended during review). In this plan only the canonical implementation runs them; the transposed plan reuses them.
+- **Manual parity smoke:** end of Task 6.
+
+## Backing-widget decision — made in the transposed plan
+
+The transposed view's backing widget is decided and recorded in `20260520-transposed-grid-view.md` («Backing-widget decision»): a **`ListBox` of step-columns** with a horizontal `VirtualizingStackPanel`. DataGrid was rejected for the transposed scenario (no column virtualization — element count scales as steps × parameters; hostile dynamic columns; row-only selection; columns not styleable), and the «ItemsControl with parameter rows» alternative was rejected for inheriting the same missing column virtualization.
+
+**This plan's interface is deliberately widget-agnostic.** Nothing below assumes either implementation uses a `DataGrid`. Canonical keeps its existing `DataGrid` unchanged.
+
+## Solution Overview
+
+### `IRecipeGridSurface` — minimal surface
+
+Driven strictly by what current consumers use. Two-way selection direction is explicit; everything else stays minimal.
+
+```csharp
+public interface IRecipeGridSurface : IDisposable
+{
+    // Lifecycle: initial projection from the coordinator's current recipe.
+    // Called once by MainWindowViewModel.Initialize(), exactly as today.
+    void Initialize();
+
+    // Coordinator-derived state.
+    int StepCount { get; }
+    bool IsReadOnly { get; }
+
+    // Selection — model coordinates only.
+    IReadOnlyList<int> SelectedStepIndices { get; }
+    int SelectedStepIndex { get; }            // -1 when empty
+
+    // View → Surface: actual selection produced by the control (replaces public setter on
+    // SelectedRowIndices). The view calls this after mapping its native selection into step indices.
+    void UpdateSelection(IReadOnlyList<int> stepIndices);
+
+    // Consumer → Surface: programmatic selection push (replaces the RequestSelection method +
+    // SelectionRequested event pair). null = clear. Callers: RecipeCommandsViewModel (add/delete
+    // repositioning), ClipboardViewModel (cut/paste repositioning), internal action-change handler.
+    void RequestSelection(int? stepIndex);
+
+    // Surface → View: the stream RequestSelection pushes into. View subscribes and positions
+    // its native selection.
+    IObservable<int?> SelectionRequests { get; }
+
+    // View-bound observation streams. CanDeleteStep emits its current value on subscription
+    // (WhenAnyValue semantics) — consumers build CombineLatest canExecute gates from it and
+    // must not stay disabled until the first change.
+    IObservable<bool> CanDeleteStep { get; }
+    IObservable<Unit> EditorMustClose { get; }   // derived from IsReadOnly: false → true transition
+
+    // Clipboard support — pulled onto the interface so ClipboardViewModel never sees a concrete impl.
+    IReadOnlyList<Step> CollectSelectedSteps();
+}
+```
+
+Changes from the original draft:
+
+- `UpdateSelection(...)` replaces the implicit `SelectedRowIndices` setter — direction view → surface is now explicit and the contract is closed.
+- `RequestSelection(int?)` + `SelectionRequests` split the old method/event pair by direction: consumers push through the public method (four external call sites today: `RecipeCommandsViewModel.AddStep`/`DeleteStep`, `ClipboardViewModel.CutStepsAsync`/`PasteStepsAsync`), the view subscribes to the observable. The surface's internal `Subject<int?>` is the implementation detail.
+- `Initialize()` is on the interface — `MainWindowViewModel.Initialize()` calls it today on the concrete class and keeps doing so through the interface.
+- `CollectSelectedSteps()` and `StepCount` are on the interface so `ClipboardViewModel` (which uses both today via the concrete class) does not need a concrete-class fallback.
+- `IsReadOnlyChanged` removed as redundant — `EditorMustClose` already conveys the actionable transition; `IsReadOnly` can be observed by consumers via standard ReactiveUI `WhenAnyValue` if needed.
+- `HasSelection` and `SelectedStepIndicesChanged` removed during review — no production consumer existed (call sites derive the predicate from `SelectedStepIndices.Count`), and the minimality rule above outranks the original sketch: every dead member would have to be implemented and contract-tested by each future surface.
+
+Not on the interface (stays on concrete `CanonicalRecipeGridSurface`):
+
+- `ObservableCollection<RecipeRowViewModel> RecipeRows` — canonical-specific shape, consumed only by `CanonicalRecipeGridView`.
+- Internal `RecipeMetadataRegistry` — accessed only by canonical column builder.
+
+### `RecipeGridHost` UserControl
+
+A new control at `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridHost.axaml`. Holds a child view (today: canonical only). Exposes a single `IRecipeGridSurface Surface { get; }` property — the swap point the transposed plan consumes, exercised by tests. `MainWindow.axaml` replaces its inline `DataGrid` with `<rg:RecipeGridHost x:Name="RecipeGridHost" .../>`; `MainWindow` code-behind reads only `RecipeGridHost.IsEditing`.
+
+In this plan, `RecipeGridHost` does NOT switch implementations — there is only one. The swap mechanism is wired by the transposed plan.
+
+### `CanonicalRecipeGridSurface`
+
+The existing `RecipeGridViewModel` is renamed to `CanonicalRecipeGridSurface` (file rename + class rename), implements `IRecipeGridSurface`, and continues to own the canonical-only members (`RecipeRows`, etc.).
+
+Code-behind that today lives in `MainWindow.axaml.cs` (`OnBeginningEdit`, `OnCellEditEnded`, `OnSelectionChanged`, `OnSelectionRequested`, `OnDataGridLoadingRow`, `BuildGrid`) moves into a new `CanonicalRecipeGridView.axaml.cs` — a UserControl that wraps the `DataGrid` and owns its event subscriptions.
+
+### Dependency injection
+
+Today: `RecipeGridViewModel` is registered as a concrete service. After: register `CanonicalRecipeGridSurface` as both itself and as `IRecipeGridSurface`. Consumers (`MainWindowViewModel`, `RecipeCommandsViewModel`, `ClipboardViewModel`) take `IRecipeGridSurface` by interface **only** — no fallback to the concrete class is permitted (see Task 6).
+
+## Technical Details
+
+### Selection translation (view → surface)
+
+Today `OnSelectionChanged` in `MainWindow.axaml.cs` walks `RecipeGrid.SelectedItems`, maps each to a row VM, derives the index via `RecipeRows.IndexOf(row)`. That logic moves into `CanonicalRecipeGridView.axaml.cs`. The result — a `IReadOnlyList<int>` of step indices — is fed via `surface.UpdateSelection(indices)`.
+
+The transposed implementation will have its own selection-translation; the surface sees only step indices.
+
+### Programmatic selection (surface → view)
+
+`RequestSelection(int?)` is the single public push point; internally the concrete surface owns a `Subject<int?>` exposed as `SelectionRequests`. Callers: the two command view-models and the clipboard view-model (post-mutation repositioning), plus the surface's own `OnActionChanged` after a step-action change. The view subscribes in its activation block: canonical sets `DataGrid.SelectedIndex`, transposed sets the selected column. One method, one stream, both directions closed.
+
+### Edit-must-close signal
+
+`EditorMustClose` derives from `IsReadOnly` (`false → true`) on the concrete surface. Canonical already consumes it declaratively through the `DataGridEditorCloseBehavior.Trigger` attached-property binding in AXAML (introduced by `20260520-per-window-edit-connect-mode.md`); Task 4 relocates that binding into the extracted view. Transposed will consume the same observable its own way. The signal is kept distinct from raw `IsReadOnly` because it is **actionable** (close any open editor) rather than a state to observe.
+
+### Read-only routing
+
+`IsReadOnly` is computed inside each concrete surface from `coordinator.CanEditRecipe.Select(canEdit => !canEdit)`. Exposed on the interface as a plain `bool` for one-shot reads (e.g. cancelling `BeginningEdit`). Consumers needing reactive notification observe `EditorMustClose` or `WhenAnyValue(x => x.IsReadOnly)` on the concrete instance — there is no separate `IsReadOnlyChanged` member because it would duplicate `EditorMustClose` for every existing use site.
+
+### Mutations and subscription-ownership change
+
+Both implementations subscribe to `RecipeCoordinator.Mutated` independently. The abstraction does **not** expose a "refresh me" method — implementations own that responsibility.
+
+**This is a change of subscription ownership.** Today `App.axaml.cs:114` wires `coordinator.Mutated += gridViewModel.OnMutation` externally. After this refactor, the surface subscribes itself in its constructor. Other `Mutated` subscribers (`PlcMonitorViewModel`, `MainWindowViewModel`, `RecipeCommandsViewModel`) continue to subscribe themselves as today, but **the order of invocation across handlers changes** because the surface now subscribes at construction time rather than at app startup.
+
+Expected conclusion (verify statically in Task 3 by reading the handlers): the four `Mutated` subscribers (grid row re-projection, `PlcMonitorViewModel`, `MainWindowViewModel` state-property raise, `RecipeCommandsViewModel` undo/redo refresh) have no cross-handler side-effect dependency within a single dispatch, so order is immaterial. If reading them contradicts this, fix the dependency explicitly (e.g. by routing through an ordered dispatcher) — do not paper over with subscription timing.
+
+## Implementation Steps
+
+### Task 1: Define `IRecipeGridSurface`
+
+**Files:**
+- Create: `SemiStep/SemiStep.UI/RecipeGrid/IRecipeGridSurface.cs`
+- Create: `SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridSurfaceContractTests.cs` (abstract base; concrete fixture follows in Task 3)
+
+- [x] Define the interface as in Solution Overview.
+- [x] Write the contract test base class with the cases below (the last four were added during review) — given an `IRecipeGridSurface`:
+  1. `UpdateSelection([1, 3])` → `SelectedStepIndices == [1, 3]`, `SelectedStepIndex == 1`.
+  2. `UpdateSelection([])` → `SelectedStepIndices.Count == 0`, `SelectedStepIndex == -1`.
+  3. `RequestSelection(2)` → `SelectionRequests` emits `2`.
+  4. `RequestSelection(null)` → `SelectionRequests` emits `null` (the view interprets it as "clear selection").
+  5. `EditorMustClose` emits when `IsReadOnly` transitions `false → true`; does **not** emit on `true → false`.
+  6. `CanDeleteStep` is `true` iff `SelectedStepIndices.Count > 0`; reacts to `UpdateSelection`.
+  7. `CollectSelectedSteps()` returns steps in ascending `stepIndex` order; the result is consistent with the current `SelectedStepIndices`.
+  8. After `Dispose()`, coordinator signals (`Mutated`, `ExecutionState`, `CanEditRecipe`) produce no further emissions on any surface observable and no state changes — deterministic no-leak check instead of a GC/WeakReference assertion.
+  9. `Initialize()` projects the seeded recipe: `StepCount` equals the seeded step count.
+  10. `IsReadOnly` tracks `coordinator.CanEditRecipe` in both directions.
+  11. `EditorMustClose` does not replay to a subscriber that subscribes while already read-only.
+  12. After `Dispose()`, the consumer-facing calls (`RequestSelection`, `UpdateSelection`) are safe no-ops — they must not throw.
+- [x] Run tests (vacuously pass — no implementation yet).
+
+### Task 2: Rename `RecipeGridViewModel` → `CanonicalRecipeGridSurface`
+
+**Files:**
+- Rename: `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridViewModel.cs` → `CanonicalRecipeGridSurface.cs`
+- Modify (text): every reference across `SemiStep.UI` and `SemiStep.Tests`.
+
+- [x] Mechanical rename. Run `dotnet build` to confirm zero compile errors.
+- [x] Run full test suite — must pass unchanged.
+
+### Task 3: `CanonicalRecipeGridSurface` implements the interface
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridSurface.cs`
+- Modify: `SemiStep/SemiStep.UI/UiDi.cs` — register as `IRecipeGridSurface`.
+- Modify: `SemiStep/SemiStep.UI/App.axaml.cs` — remove the external `coordinator.Mutated += gridViewModel.OnMutation` wiring (the surface now subscribes itself in its constructor).
+- Create: `SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridSurfaceContractTests.cs` — inherits from the Task 1 base.
+
+- [x] Add `: IRecipeGridSurface` to the class. Adapt member names: `SelectedRowIndices` → `SelectedStepIndices`, `SelectedRowIndex` → `SelectedStepIndex`. Drop the public setter on `SelectedStepIndices` in favour of `UpdateSelection(IReadOnlyList<int>)`. Replace the `SelectionRequested` event with the public `RequestSelection(int?)` pushing into an internal `Subject<int?>` exposed as `SelectionRequests`; `OnActionChanged` calls the same public method. The existing `RequestSelection` method signature is unchanged for the four consumer call sites.
+- [x] Rewrite the two tests that assert the old event shape (`RecipeGridViewModelTests.RequestSelection_RaisesSelectionRequestedEvent` and `..._WithNull`, `RecipeGridViewModelTests.cs:223,235`) against the `SelectionRequests` observable — they do not survive the rename mechanically.
+- [x] Add the `CanDeleteStep` observable (delegates to the existing `WhenAnyValue` path). (`SelectedStepIndicesChanged` was added here and later removed in review as a dead member.)
+- [x] Subscribe to `coordinator.Mutated` in the constructor; unsubscribe in `Dispose`. Keep `OnMutation` public — the stale-signal tests (`RecipeGridViewModelTests.cs:304-397`) call it directly.
+- [x] Remove the manual `Coordinator.Mutated += _grid.OnMutation` wiring from every test fixture that constructs the surface (`RecipeGridViewModelTests`, `ClipboardViewModelCanExecuteTests`, `MessagePanelReportingTests`, `RecipeGrid/*Tests` — grep for the pattern). Leaving them in place would double-subscribe and apply every mutation twice.
+- [x] Add `CollectSelectedSteps()` and `StepCount` (returns `RecipeRows.Count`).
+- [x] Wire contract tests against the canonical implementation; all cases pass.
+- [x] **Subscription-order verification:** read the four `Mutated` handlers and confirm the static no-cross-dependency argument from Technical Details holds; record the confirmation in the PR description. (Confirmed: each handler reads only coordinator state committed before the event fires plus its own private state — grid re-projects rows from `CurrentRecipe`/`Snapshot`, `PlcMonitorViewModel` recalculates texts from `Snapshot`, `MainWindowViewModel` raises property notifications, `RecipeCommandsViewModel` pushes `CanUndo`/`CanRedo` into its own subjects. No handler reads another handler's output within a dispatch; order is immaterial. Recorded in the commit message.)
+
+### Task 4: Extract `CanonicalRecipeGridView` UserControl
+
+**Files:**
+- Create: `SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridView.axaml` (+ `.axaml.cs`)
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml` — remove the inline `DataGrid` block (will be replaced in Task 5).
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs` — remove `OnBeginningEdit`, `OnCellEditEnded`, `OnSelectionChanged`, `OnSelectionRequested`, `OnDataGridLoadingRow`, `OnCellPointerPressed`, `BuildGrid`, the `_columnBuilder`, `_isEditing`, `_columnsBuilt`, `_pendingChangedCell` fields, and the column-builder / `CellPointerPressed` wiring inside `WhenActivated`.
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs` — remove the `ColumnBuilder` pass-through property (the view now reaches it via the surface, see below).
+
+- [x] The UserControl hosts the `DataGrid` and re-implements every event handler currently in `MainWindow.axaml.cs`, talking to the `CanonicalRecipeGridSurface` via `DataContext`. The view binds canonical-only members (`RecipeRows`, `IsReadOnly`), so its `x:DataType` is the concrete `CanonicalRecipeGridSurface`, not the interface.
+- [x] `OnCellPointerPressed` + `_pendingChangedCell` (orange-cell click-away clearing via `ChangedCellClickResolver`) move into the UserControl with the rest — they are fully DataGrid-bound.
+- [x] `RecipeRowExecutionClassBinder.BindAll` invocation moves into the UserControl's `OnDataGridLoadingRow`.
+- [x] Column building: `ColumnBuilder` is exposed as a property on `CanonicalRecipeGridSurface` (constructor-injected there instead of into `MainWindowViewModel`), so the view reaches it through `DataContext` — no service locator, no XAML-unfriendly constructor injection into the UserControl. `_columnsBuilt` guard moves with `BuildGrid`. Update the Task 3 contract-test fixture to pass the new constructor parameter (`UIFixture` already builds a `ColumnBuilder`).
+- [x] **Editing gate for global shortcuts:** `MainWindow.OnKeyDown` (`MainWindow.axaml.cs:84`) suppresses Delete/Ctrl+C/X/V while a cell editor is open by reading `_isEditing`. The flag moves into the view; the view exposes it as a public `IsEditing` CLR property, `RecipeGridHost` forwards it (`Host.IsEditing => activeView.IsEditing`), and `OnKeyDown` reads the host property. Editing state stays a view concern — it does not go on `IRecipeGridSurface`. (`OnKeyDown` reads the view's `IsEditing` directly until Task 5 introduces the host and re-routes it.)
+- [x] On `DataGrid.SelectionChanged`: walk `RecipeGrid.SelectedItems`, derive step indices, call `surface.UpdateSelection(indices)`.
+- [x] Subscribe to `surface.SelectionRequests`: on each value, set `RecipeGrid.SelectedIndex` (or clear when `null`).
+- [x] `EditorMustClose` handling stays declarative: move the existing `DataGridEditorCloseBehavior.Trigger` binding from `MainWindow.axaml` into `CanonicalRecipeGridView.axaml` unchanged. Do not add a code-behind subscription — the attached behavior is the single close mechanism (see completed plan `20260520-per-window-edit-connect-mode.md`).
+- [x] Test the UserControl headlessly: load with a surface containing 3 steps, assert rows render; push a value on `SelectionRequests` from the test and assert the corresponding row is selected.
+
+### Task 5: `RecipeGridHost` UserControl
+
+**Files:**
+- Create: `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridHost.axaml` (+ `.axaml.cs`)
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml` — replace removed `DataGrid` with `<rg:RecipeGridHost x:Name="RecipeGridHost" .../>`.
+
+- [x] The host's content is the `CanonicalRecipeGridView` instance, bound to the same `DataContext` as today's grid. No orientation logic yet; the host is a thin pass-through.
+- [x] Expose `Surface` (the `IRecipeGridSurface`) as a CLR property for tests and as the transposed-plan swap point; `MainWindow` reads only `IsEditing`.
+- [x] Expose `IsEditing` forwarding to the active view (see Task 4's editing gate) — `MainWindow.OnKeyDown` reads it.
+- [x] Headless test: instantiate the host, assert it renders the canonical view and forwards selection.
+
+### Task 6: Migrate consumers to `IRecipeGridSurface` (no concrete fallback)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs` — accept `IRecipeGridSurface`.
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs` — accept `IRecipeGridSurface`.
+- Modify: `SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs` — accept `IRecipeGridSurface`. Replace `_recipeGrid.CollectSelectedSteps()` and `_recipeGrid.RecipeRows.Count` with the corresponding interface members (`CollectSelectedSteps()`, `StepCount`).
+
+- [x] Replace constructor parameter types with the interface. **No concrete-class fallback is accepted in this plan.** If any consumer still requires a canonical-only member (`RecipeRows`, `RecipeMetadataRegistry`, etc.), one of two things is true: either the interface is missing a member (add it and update contract tests), or the consumer is doing something that crosses the abstraction boundary (refactor the consumer). The leak is the bug.
+- [x] Run full test suite. Manual smoke: open recipe, edit, select, copy/paste, save, exit. **No observable change.** (manual smoke covered by headless tests - not automatable here)
+
+### Task 7: Verify acceptance criteria
+
+- [x] `IRecipeGridSurface` defined and used by all three consumer view-models — **none of them references the concrete class**.
+- [x] Canonical view extracted to its own UserControl; `MainWindow.axaml.cs` no longer touches the DataGrid directly.
+- [x] `RecipeGridHost` in place as the swap point.
+- [x] All contract-test cases pass against canonical.
+- [x] Full test suite green.
+- [x] Manual parity smoke (headless-covered; real-app smoke performed by orchestrator post-run).
+
+### Task 8: Final — close-out
+
+- [x] `dotnet format SemiStep/SemiStep.slnx`.
+- [x] Move this plan to `Docs/plans/completed/`. (deferred to harness)
+
+## Post-Completion
+
+This plan adds **no user-facing change**. Its value is purely structural: the transposed implementation can now be added as a sibling UserControl + presentation pair without touching `MainWindow`, command view-models, or clipboard view-model.
+
+The next plan in this series — implementing the transposed view — depends on this one. Its scope is a single new surface + view pair (a `ListBox` of step-columns, per the decision recorded there), plus the orientation toggle and config default; no work inside the existing canonical view.

--- a/SemiStep/SemiStep.Tests/UI/Clipboard/ClipboardViewModelCanExecuteTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Clipboard/ClipboardViewModelCanExecuteTests.cs
@@ -4,8 +4,6 @@ using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
-using Microsoft.Extensions.Logging.Abstractions;
-
 using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Tests.Core.Helpers;
@@ -24,26 +22,21 @@ namespace SemiStep.Tests.UI.Clipboard;
 public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 {
 	private readonly UIFixture _fixture = new();
-	private RecipeGridViewModel _grid = null!;
+	private CanonicalRecipeGridSurface _surface = null!;
 	private ClipboardViewModel _clipboard = null!;
 
 	public async ValueTask InitializeAsync()
 	{
 		await _fixture.InitializeAsync();
-		_grid = new RecipeGridViewModel(
-			_fixture.Coordinator,
-			_fixture.RecipeMetadataRegistry,
-			_fixture.MessagePanel,
-			NullLogger<RecipeGridViewModel>.Instance);
-		_fixture.Coordinator.Mutated += _grid.OnMutation;
-		_grid.Initialize();
+		_surface = _fixture.CreateCanonicalSurface();
+		_surface.Initialize();
 
 		var clipboardSerializer = new ClipboardSerializer(_fixture.RecipeMetadataRegistry);
 		var importedRecipeValidator = new ImportedRecipeValidator(_fixture.RecipeMetadataRegistry);
 
 		_clipboard = new ClipboardViewModel(
 			_fixture.Coordinator,
-			_grid,
+			_surface,
 			clipboardSerializer,
 			importedRecipeValidator,
 			_fixture.MessagePanel);
@@ -52,7 +45,7 @@ public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 	public async ValueTask DisposeAsync()
 	{
 		_clipboard.Dispose();
-		_grid.Dispose();
+		_surface.Dispose();
 		await _fixture.DisposeAsync();
 	}
 
@@ -95,7 +88,7 @@ public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_grid.SelectedRowIndices = Array.Empty<int>();
+		_surface.UpdateSelection(Array.Empty<int>());
 
 		((ICommand)_clipboard.CutStepCommand).CanExecute(null).Should().BeFalse();
 	}
@@ -108,6 +101,21 @@ public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 		_fixture.SetRecipeActive(false);
 
 		((ICommand)_clipboard.CutStepCommand).CanExecute(null).Should().BeTrue();
+	}
+
+	[AvaloniaFact]
+	public void Cut_CanExecuteTrue_WhenSelectionExistsBeforeConstruction()
+	{
+		AppendStepAndSelect();
+
+		using var clipboard = new ClipboardViewModel(
+			_fixture.Coordinator,
+			_surface,
+			new ClipboardSerializer(_fixture.RecipeMetadataRegistry),
+			new ImportedRecipeValidator(_fixture.RecipeMetadataRegistry),
+			_fixture.MessagePanel);
+
+		((ICommand)clipboard.CutStepCommand).CanExecute(null).Should().BeTrue();
 	}
 
 	[AvaloniaFact]
@@ -147,6 +155,6 @@ public sealed class ClipboardViewModelCanExecuteTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_grid.SelectedRowIndices = new[] { 0 };
+		_surface.UpdateSelection(new[] { 0 });
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/Helpers/DataGridTestHelper.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/DataGridTestHelper.cs
@@ -1,0 +1,17 @@
+﻿using Avalonia.Controls;
+using Avalonia.Threading;
+
+namespace SemiStep.Tests.UI.Helpers;
+
+public static class DataGridTestHelper
+{
+	public static void SetCurrentCell(DataGrid dataGrid, int rowIndex, DataGridColumn column)
+	{
+		dataGrid.Focus();
+		dataGrid.SelectedIndex = rowIndex;
+		Dispatcher.UIThread.RunJobs();
+
+		dataGrid.CurrentColumn = column;
+		Dispatcher.UIThread.RunJobs();
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reactive.Concurrency;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 using SemiStep.Core.Configuration;
@@ -37,6 +38,7 @@ public sealed class UIFixture : IAsyncLifetime
 	public MessagePanelViewModel MessagePanel { get; private set; } = null!;
 	public RecipeCoordinator Coordinator { get; private set; } = null!;
 	public StubS7Service StubS7 { get; private set; } = null!;
+	public ColumnBuilder ColumnBuilder { get; private set; } = null!;
 
 	public async ValueTask InitializeAsync()
 	{
@@ -61,6 +63,7 @@ public sealed class UIFixture : IAsyncLifetime
 			MessagePanel,
 			NullLogger<RecipeCoordinator>.Instance);
 		Coordinator.Initialize();
+		ColumnBuilder = new ColumnBuilder(AppConfiguration.GridStyle, RecipeMetadataRegistry);
 	}
 
 	public ValueTask DisposeAsync()
@@ -70,14 +73,30 @@ public sealed class UIFixture : IAsyncLifetime
 		return ValueTask.CompletedTask;
 	}
 
+	public CanonicalRecipeGridSurface CreateCanonicalSurface(
+		ILogger<CanonicalRecipeGridSurface>? logger = null)
+	{
+		return new CanonicalRecipeGridSurface(
+			Coordinator,
+			RecipeMetadataRegistry,
+			ColumnBuilder,
+			MessagePanel,
+			logger ?? NullLogger<CanonicalRecipeGridSurface>.Instance);
+	}
+
+	public void SeedRecipe(int stepCount)
+	{
+		Coordinator.NewRecipe();
+		for (var i = 0; i < stepCount; i++)
+		{
+			Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		}
+	}
+
 	public MainWindowViewModel CreateMainWindowViewModel(
 		Func<GridStyleEditorViewModel>? styleEditorFactory = null)
 	{
-		var grid = new RecipeGridViewModel(
-			Coordinator,
-			RecipeMetadataRegistry,
-			MessagePanel,
-			NullLogger<RecipeGridViewModel>.Instance);
+		var grid = CreateCanonicalSurface();
 
 		var commands = new RecipeCommandsViewModel(Coordinator, grid);
 
@@ -91,8 +110,6 @@ public sealed class UIFixture : IAsyncLifetime
 			MessagePanel);
 
 		var recipeFile = new RecipeFileViewModel(Coordinator, MessagePanel);
-
-		var columnBuilder = new ColumnBuilder(AppConfiguration.GridStyle, RecipeMetadataRegistry);
 
 		var plcMonitor = new PlcMonitorViewModel(
 			Coordinator,
@@ -112,7 +129,6 @@ public sealed class UIFixture : IAsyncLifetime
 			clipboard,
 			recipeFile,
 			MessagePanel,
-			columnBuilder,
 			plcMonitor,
 			gridStyleEditorViewModelFactory,
 			NullLogger<MainWindowViewModel>.Instance);

--- a/SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs
@@ -7,8 +7,6 @@ using Avalonia.Threading;
 
 using FluentAssertions;
 
-using Microsoft.Extensions.Logging.Abstractions;
-
 using ReactiveUI;
 
 using SemiStep.Core.Recipes.Clipboard;
@@ -31,23 +29,18 @@ namespace SemiStep.Tests.UI;
 public sealed class MessagePanelReportingTests : IAsyncLifetime
 {
 	private readonly UIFixture _fixture = new();
-	private RecipeGridViewModel _grid = null!;
+	private CanonicalRecipeGridSurface _surface = null!;
 
 	public async ValueTask InitializeAsync()
 	{
 		await _fixture.InitializeAsync();
-		_grid = new RecipeGridViewModel(
-			_fixture.Coordinator,
-			_fixture.RecipeMetadataRegistry,
-			_fixture.MessagePanel,
-			NullLogger<RecipeGridViewModel>.Instance);
-		_fixture.Coordinator.Mutated += _grid.OnMutation;
-		_grid.Initialize();
+		_surface = _fixture.CreateCanonicalSurface();
+		_surface.Initialize();
 	}
 
 	public async ValueTask DisposeAsync()
 	{
-		_grid.Dispose();
+		_surface.Dispose();
 		await _fixture.DisposeAsync();
 	}
 
@@ -124,7 +117,7 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.RecipeRows[0].SetPropertyValue(RecipeTestDriver.StepDurationColumn, "not_a_valid_number");
+		_surface.RecipeRows[0].SetPropertyValue(RecipeTestDriver.StepDurationColumn, "not_a_valid_number");
 
 		var operationEntry = _fixture.MessagePanel.Entries.Should().ContainSingle(entry => entry.IsError).Subject;
 		operationEntry.Message.Should().StartWith("Step 1:");
@@ -138,7 +131,7 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.RecipeRows[0].SetPropertyValue("action", "999999");
+		_surface.RecipeRows[0].SetPropertyValue("action", "999999");
 
 		var operationEntry = _fixture.MessagePanel.Entries.Should().ContainSingle(entry => entry.IsError).Subject;
 		operationEntry.Message.Should().StartWith("Step 1: Failed to change action");
@@ -153,7 +146,7 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 		var importedRecipeValidator = new ImportedRecipeValidator(_fixture.RecipeMetadataRegistry);
 		var clipboardViewModel = new ClipboardViewModel(
 			_fixture.Coordinator,
-			_grid,
+			_surface,
 			clipboardSerializer,
 			importedRecipeValidator,
 			_fixture.MessagePanel);
@@ -191,7 +184,7 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 		var importedRecipeValidator = new ImportedRecipeValidator(_fixture.RecipeMetadataRegistry);
 		var clipboardViewModel = new ClipboardViewModel(
 			_fixture.Coordinator,
-			_grid,
+			_surface,
 			clipboardSerializer,
 			importedRecipeValidator,
 			_fixture.MessagePanel);
@@ -205,12 +198,12 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 
 		try
 		{
-			_grid.SelectedRowIndices = [0];
+			_surface.UpdateSelection([0]);
 			await clipboardViewModel.CopyStepCommand.Execute();
 
 			await clipboardViewModel.PasteStepCommand.Execute();
 
-			_grid.RecipeRows.Count.Should().Be(2,
+			_surface.RecipeRows.Count.Should().Be(2,
 				"the valid copied step is pasted, doubling the single-step recipe");
 			_fixture.MessagePanel.Entries.Should().NotContain(entry => entry.IsError,
 				"a successful paste is a successful mutation that clears the operation slot");

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridSurfaceContractTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridSurfaceContractTests.cs
@@ -1,0 +1,13 @@
+﻿using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+public sealed class CanonicalRecipeGridSurfaceContractTests : RecipeGridSurfaceContractTests
+{
+	protected override IRecipeGridSurface CreateSurface(UIFixture fixture)
+	{
+		return fixture.CreateCanonicalSurface();
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridSurfaceReadOnlyTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridSurfaceReadOnlyTests.cs
@@ -2,8 +2,6 @@
 
 using FluentAssertions;
 
-using Microsoft.Extensions.Logging.Abstractions;
-
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
@@ -16,33 +14,28 @@ namespace SemiStep.Tests.UI.RecipeGrid;
 [Trait("Component", "UI")]
 [Trait("Area", "RecipeGrid")]
 [Trait("Category", "Integration")]
-public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
+public sealed class CanonicalRecipeGridSurfaceReadOnlyTests : IAsyncLifetime
 {
 	private readonly UIFixture _fixture = new();
-	private RecipeGridViewModel _grid = null!;
+	private CanonicalRecipeGridSurface _surface = null!;
 
 	public async ValueTask InitializeAsync()
 	{
 		await _fixture.InitializeAsync();
-		_grid = new RecipeGridViewModel(
-			_fixture.Coordinator,
-			_fixture.RecipeMetadataRegistry,
-			_fixture.MessagePanel,
-			NullLogger<RecipeGridViewModel>.Instance);
-		_fixture.Coordinator.Mutated += _grid.OnMutation;
-		_grid.Initialize();
+		_surface = _fixture.CreateCanonicalSurface();
+		_surface.Initialize();
 	}
 
 	public async ValueTask DisposeAsync()
 	{
-		_grid.Dispose();
+		_surface.Dispose();
 		await _fixture.DisposeAsync();
 	}
 
 	[AvaloniaFact]
 	public void IsReadOnly_False_Initially_WhenNoExecution()
 	{
-		_grid.IsReadOnly.Should().BeFalse();
+		_surface.IsReadOnly.Should().BeFalse();
 	}
 
 	[AvaloniaFact]
@@ -51,7 +44,7 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 		// §2.7: execution being active locks editing.
 		_fixture.SetRecipeActive(true);
 
-		_grid.IsReadOnly.Should().BeTrue();
+		_surface.IsReadOnly.Should().BeTrue();
 	}
 
 	[AvaloniaFact]
@@ -60,7 +53,7 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 		_fixture.SetRecipeActive(true);
 		_fixture.SetRecipeActive(false);
 
-		_grid.IsReadOnly.Should().BeFalse();
+		_surface.IsReadOnly.Should().BeFalse();
 	}
 
 	[AvaloniaFact]
@@ -69,7 +62,7 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 		// Connected-but-idle is editable: sync enabled without execution does not lock editing.
 		_fixture.SetSyncEnabled(true);
 
-		_grid.IsReadOnly.Should().BeFalse();
+		_surface.IsReadOnly.Should().BeFalse();
 	}
 
 	[AvaloniaFact]
@@ -81,9 +74,9 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_fixture.SetRecipeActive(true);
-		_grid.IsReadOnly.Should().BeTrue();
+		_surface.IsReadOnly.Should().BeTrue();
 
-		var row = _grid.RecipeRows[0];
+		var row = _surface.RecipeRows[0];
 		var originalRecipe = _fixture.Coordinator.CurrentRecipe;
 		var wasDirtyBefore = _fixture.Coordinator.IsDirty;
 
@@ -97,7 +90,7 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 	public void EditorMustClose_Emits_WhenRecipeBecomesActive()
 	{
 		var emissionCount = 0;
-		using var subscription = _grid.EditorMustClose.Subscribe(_ => emissionCount++);
+		using var subscription = _surface.EditorMustClose.Subscribe(_ => emissionCount++);
 
 		_fixture.SetRecipeActive(true);
 
@@ -108,7 +101,7 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 	public void EditorMustClose_DoesNotEmit_WhenNoExecution()
 	{
 		var emissionCount = 0;
-		using var subscription = _grid.EditorMustClose.Subscribe(_ => emissionCount++);
+		using var subscription = _surface.EditorMustClose.Subscribe(_ => emissionCount++);
 
 		_fixture.SetRecipeActive(false);
 
@@ -121,7 +114,7 @@ public sealed class RecipeGridViewModelReadOnlyTests : IAsyncLifetime
 		_fixture.SetRecipeActive(true);
 
 		var emissionCount = 0;
-		using var subscription = _grid.EditorMustClose.Subscribe(_ => emissionCount++);
+		using var subscription = _surface.EditorMustClose.Subscribe(_ => emissionCount++);
 
 		emissionCount.Should().Be(0);
 	}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridSurfaceTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridSurfaceTests.cs
@@ -15,32 +15,27 @@ using SemiStep.UI.RecipeGrid;
 
 using Xunit;
 
-namespace SemiStep.Tests.UI;
+namespace SemiStep.Tests.UI.RecipeGrid;
 
 [Trait("Component", "UI")]
 [Trait("Area", "RecipeGrid")]
 [Trait("Category", "Integration")]
-public sealed class RecipeGridViewModelTests : IAsyncLifetime
+public sealed class CanonicalRecipeGridSurfaceTests : IAsyncLifetime
 {
 	private readonly UIFixture _fixture = new();
-	private readonly RecordingLogger<RecipeGridViewModel> _logger = new();
-	private RecipeGridViewModel _grid = null!;
+	private readonly RecordingLogger<CanonicalRecipeGridSurface> _logger = new();
+	private CanonicalRecipeGridSurface _surface = null!;
 
 	public async ValueTask InitializeAsync()
 	{
 		await _fixture.InitializeAsync();
-		_grid = new RecipeGridViewModel(
-			_fixture.Coordinator,
-			_fixture.RecipeMetadataRegistry,
-			_fixture.MessagePanel,
-			_logger);
-		_fixture.Coordinator.Mutated += _grid.OnMutation;
-		_grid.Initialize();
+		_surface = _fixture.CreateCanonicalSurface(_logger);
+		_surface.Initialize();
 	}
 
 	public async ValueTask DisposeAsync()
 	{
-		_grid.Dispose();
+		_surface.Dispose();
 		await _fixture.DisposeAsync();
 	}
 
@@ -49,7 +44,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 
-		_grid.RecipeRows.Should().BeEmpty();
+		_surface.RecipeRows.Should().BeEmpty();
 	}
 
 	[AvaloniaFact]
@@ -59,7 +54,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.RecipeRows.Should().HaveCount(1);
+		_surface.RecipeRows.Should().HaveCount(1);
 	}
 
 	[AvaloniaFact]
@@ -69,7 +64,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.RecipeRows[0].ActionId.Should().Be(RecipeTestDriver.WaitActionId);
+		_surface.RecipeRows[0].ActionId.Should().Be(RecipeTestDriver.WaitActionId);
 	}
 
 	[AvaloniaFact]
@@ -79,7 +74,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.RecipeRows[0].StepNumber.Should().Be(1);
+		_surface.RecipeRows[0].StepNumber.Should().Be(1);
 	}
 
 	[AvaloniaFact]
@@ -91,7 +86,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.InsertStep(1, RecipeTestDriver.ForLoopActionId);
 
-		_grid.RecipeRows[1].ActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
+		_surface.RecipeRows[1].ActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
 	}
 
 	[AvaloniaFact]
@@ -103,8 +98,8 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.InsertStep(0, RecipeTestDriver.ForLoopActionId);
 
-		_grid.RecipeRows[1].StepNumber.Should().Be(2);
-		_grid.RecipeRows[2].StepNumber.Should().Be(3);
+		_surface.RecipeRows[1].StepNumber.Should().Be(2);
+		_surface.RecipeRows[2].StepNumber.Should().Be(3);
 	}
 
 	[AvaloniaFact]
@@ -116,7 +111,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.RemoveStep(0);
 
-		_grid.RecipeRows.Should().HaveCount(1);
+		_surface.RecipeRows.Should().HaveCount(1);
 	}
 
 	[AvaloniaFact]
@@ -129,8 +124,8 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.RemoveStep(0);
 
-		_grid.RecipeRows[0].StepNumber.Should().Be(1);
-		_grid.RecipeRows[1].StepNumber.Should().Be(2);
+		_surface.RecipeRows[0].StepNumber.Should().Be(1);
+		_surface.RecipeRows[1].StepNumber.Should().Be(2);
 	}
 
 	[AvaloniaFact]
@@ -143,7 +138,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.RemoveSteps(new[] { 0, 2 });
 
-		_grid.RecipeRows.Should().HaveCount(1);
+		_surface.RecipeRows.Should().HaveCount(1);
 	}
 
 	[AvaloniaFact]
@@ -156,7 +151,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.RemoveSteps(new[] { 0, 1 });
 
-		_grid.RecipeRows[0].StepNumber.Should().Be(1);
+		_surface.RecipeRows[0].StepNumber.Should().Be(1);
 	}
 
 	[AvaloniaFact]
@@ -167,7 +162,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.ChangeStepAction(0, RecipeTestDriver.ForLoopActionId);
 
-		_grid.RecipeRows[0].ActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
+		_surface.RecipeRows[0].ActionId.Should().Be(RecipeTestDriver.ForLoopActionId);
 	}
 
 	[AvaloniaFact]
@@ -179,7 +174,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.NewRecipe();
 
-		_grid.RecipeRows.Should().BeEmpty();
+		_surface.RecipeRows.Should().BeEmpty();
 	}
 
 	[AvaloniaFact]
@@ -193,52 +188,52 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.Undo();
 		_fixture.Coordinator.Undo();
 
-		_grid.RecipeRows.Should().HaveCount(1);
+		_surface.RecipeRows.Should().HaveCount(1);
 	}
 
 	[AvaloniaFact]
-	public void SelectedRowIndex_DerivedFromSelectedRowIndices_FirstElement()
+	public void SelectedStepIndex_DerivedFromSelectedStepIndices_FirstElement()
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.SelectedRowIndices = new[] { 1 };
+		_surface.UpdateSelection(new[] { 1 });
 
-		_grid.SelectedRowIndex.Should().Be(1);
+		_surface.SelectedStepIndex.Should().Be(1);
 	}
 
 	[AvaloniaFact]
-	public void SelectedRowIndex_NegativeOne_WhenNoSelection()
+	public void SelectedStepIndex_NegativeOne_WhenNoSelection()
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.SelectedRowIndices = Array.Empty<int>();
+		_surface.UpdateSelection(Array.Empty<int>());
 
-		_grid.SelectedRowIndex.Should().Be(-1);
+		_surface.SelectedStepIndex.Should().Be(-1);
 	}
 
 	[AvaloniaFact]
-	public void RequestSelection_RaisesSelectionRequestedEvent()
+	public void RequestSelection_EmitsOnSelectionRequests()
 	{
 		_fixture.Coordinator.NewRecipe();
 		int? captured = -100;
-		_grid.SelectionRequested += idx => captured = idx;
+		using var subscription = _surface.SelectionRequests.Subscribe(index => captured = index);
 
-		_grid.RequestSelection(5);
+		_surface.RequestSelection(5);
 
 		captured.Should().Be(5);
 	}
 
 	[AvaloniaFact]
-	public void RequestSelection_WithNull_RaisesSelectionRequestedEventWithNull()
+	public void RequestSelection_WithNull_EmitsNullOnSelectionRequests()
 	{
 		_fixture.Coordinator.NewRecipe();
 		int? captured = -100;
-		_grid.SelectionRequested += idx => captured = idx;
+		using var subscription = _surface.SelectionRequests.Subscribe(index => captured = index);
 
-		_grid.RequestSelection(null);
+		_surface.RequestSelection(null);
 
 		captured.Should().BeNull();
 	}
@@ -248,7 +243,10 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 
-		_grid.CanDeleteStep.Should().BeFalse();
+		bool? latest = null;
+		using var subscription = _surface.CanDeleteStep.Subscribe(value => latest = value);
+
+		latest.Should().BeFalse();
 	}
 
 	[AvaloniaFact]
@@ -257,9 +255,12 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.SelectedRowIndices = new[] { 0 };
+		bool? latest = null;
+		using var subscription = _surface.CanDeleteStep.Subscribe(value => latest = value);
 
-		_grid.CanDeleteStep.Should().BeTrue();
+		_surface.UpdateSelection(new[] { 0 });
+
+		latest.Should().BeTrue();
 	}
 
 	[AvaloniaFact]
@@ -269,9 +270,9 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_grid.SelectedRowIndices = new[] { 2, 0 };
+		_surface.UpdateSelection(new[] { 2, 0 });
 
-		var steps = _grid.CollectSelectedSteps();
+		var steps = _surface.CollectSelectedSteps();
 
 		steps.Should().HaveCount(2);
 		var recipe = _fixture.Coordinator.CurrentRecipe;
@@ -287,7 +288,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "15");
 
-		_grid.RecipeRows.Should().HaveCount(1);
+		_surface.RecipeRows.Should().HaveCount(1);
 	}
 
 	[AvaloniaFact]
@@ -297,7 +298,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.RecipeRows[0].StepStartTime.Should().NotBeNull();
+		_surface.RecipeRows[0].StepStartTime.Should().NotBeNull();
 	}
 
 	[AvaloniaFact]
@@ -306,7 +307,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var act = () => _grid.OnMutation(new MutationSignal.PropertyUpdated(99));
+		var act = () => _surface.OnMutation(new MutationSignal.PropertyUpdated(99));
 
 		act.Should().NotThrow();
 		_logger.Entries.Should().Contain(entry =>
@@ -318,7 +319,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 
-		var act = () => _grid.OnMutation(new MutationSignal.StepAppended(50));
+		var act = () => _surface.OnMutation(new MutationSignal.StepAppended(50));
 
 		act.Should().NotThrow();
 		_logger.Entries.Should().Contain(entry =>
@@ -331,7 +332,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var act = () => _grid.OnMutation(new MutationSignal.StepsInserted(10, 3));
+		var act = () => _surface.OnMutation(new MutationSignal.StepsInserted(10, 3));
 
 		act.Should().NotThrow();
 		_logger.Entries.Should().Contain(entry =>
@@ -344,7 +345,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var act = () => _grid.OnMutation(new MutationSignal.StepActionChanged(42));
+		var act = () => _surface.OnMutation(new MutationSignal.StepActionChanged(42));
 
 		act.Should().NotThrow();
 		_logger.Entries.Should().Contain(entry =>
@@ -367,7 +368,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var act = () => _grid.OnMutation(new MutationSignal.StepRemoved(42));
+		var act = () => _surface.OnMutation(new MutationSignal.StepRemoved(42));
 
 		act.Should().NotThrow();
 		_logger.Entries.Should().Contain(entry =>
@@ -380,7 +381,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var act = () => _grid.OnMutation(new MutationSignal.StepRemoved(-1));
+		var act = () => _surface.OnMutation(new MutationSignal.StepRemoved(-1));
 
 		act.Should().NotThrow();
 		_logger.Entries.Should().Contain(entry =>
@@ -394,7 +395,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		var act = () => _grid.OnMutation(
+		var act = () => _surface.OnMutation(
 			new MutationSignal.StepsRemoved(ImmutableArray.Create(0, 99)));
 
 		act.Should().NotThrow();
@@ -439,7 +440,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 		var expected = _fixture.Coordinator.CurrentRecipe.Steps[0].Properties.Keys
 			.Select(id => id.Value)
 			.ToList();
-		_grid.RecipeRows[0].ChangedColumns.Should().BeEquivalentTo(expected);
+		_surface.RecipeRows[0].ChangedColumns.Should().BeEquivalentTo(expected);
 	}
 
 	[AvaloniaFact]
@@ -449,7 +450,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 
-		_grid.RecipeRows[0].ChangedColumns.Should().BeEmpty();
+		_surface.RecipeRows[0].ChangedColumns.Should().BeEmpty();
 	}
 
 	[AvaloniaFact]
@@ -457,7 +458,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		var row = _grid.RecipeRows[0];
+		var row = _surface.RecipeRows[0];
 		row.MarkChanged(new[] { RecipeTestDriver.StepDurationColumn });
 
 		row.SetPropertyValue(RecipeTestDriver.StepDurationColumn, "15");
@@ -470,7 +471,7 @@ public sealed class RecipeGridViewModelTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		var row = _grid.RecipeRows[0];
+		var row = _surface.RecipeRows[0];
 		row.MarkChanged(new[] { RecipeTestDriver.StepDurationColumn });
 
 		// "999999" exceeds the duration property maximum, so UpdateStepProperty returns IsFailed and

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridViewTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/CanonicalRecipeGridViewTests.cs
@@ -1,0 +1,199 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+using FluentAssertions;
+
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public sealed class CanonicalRecipeGridViewTests : IAsyncLifetime
+{
+	private const int SeededStepCount = 3;
+
+	private readonly UIFixture _fixture = new();
+	private CanonicalRecipeGridSurface _surface = null!;
+	private Window? _window;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_fixture.SeedRecipe(SeededStepCount);
+
+		_surface = _fixture.CreateCanonicalSurface();
+		_surface.Initialize();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		_window?.Close();
+		_surface.Dispose();
+		await _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void View_WithThreeStepSurface_RendersOneRowPerStep()
+	{
+		var dataGrid = ShowView();
+
+		var dataGridRows = dataGrid.GetVisualDescendants().OfType<DataGridRow>().ToList();
+		dataGridRows.Should().HaveCount(SeededStepCount);
+		dataGrid.Columns.Should().NotBeEmpty("the view must build columns from the surface's ColumnBuilder");
+	}
+
+	[AvaloniaFact]
+	public void SelectionRequest_OnSurface_SelectsCorrespondingRow()
+	{
+		var dataGrid = ShowView();
+
+		_surface.RequestSelection(1);
+		Dispatcher.UIThread.RunJobs();
+
+		dataGrid.SelectedIndex.Should().Be(1);
+		dataGrid.SelectedItem.Should().BeSameAs(_surface.RecipeRows[1]);
+	}
+
+	[AvaloniaFact]
+	public void SelectionRequest_WithNull_ClearsGridSelection()
+	{
+		var dataGrid = ShowView();
+
+		_surface.RequestSelection(1);
+		Dispatcher.UIThread.RunJobs();
+
+		_surface.RequestSelection(null);
+		Dispatcher.UIThread.RunJobs();
+
+		dataGrid.SelectedIndex.Should().Be(-1);
+	}
+
+	[AvaloniaFact]
+	public void SelectionRequest_OutOfRange_LeavesSelectionUnchanged()
+	{
+		var dataGrid = ShowView();
+
+		_surface.RequestSelection(1);
+		Dispatcher.UIThread.RunJobs();
+
+		_surface.RequestSelection(99);
+		Dispatcher.UIThread.RunJobs();
+
+		dataGrid.SelectedIndex.Should().Be(1);
+	}
+
+	[AvaloniaFact]
+	public void GridSelection_PropagatesStepIndicesToSurface()
+	{
+		var dataGrid = ShowView();
+
+		dataGrid.SelectedIndex = 2;
+		Dispatcher.UIThread.RunJobs();
+
+		_surface.SelectedStepIndices.Should().Equal(2);
+		_surface.SelectedStepIndex.Should().Be(2);
+	}
+
+	[AvaloniaFact]
+	public void GridMultiSelection_AddedInReverseOrder_PropagatesAscendingStepIndices()
+	{
+		var dataGrid = ShowView();
+
+		dataGrid.SelectedItems.Add(_surface.RecipeRows[2]);
+		Dispatcher.UIThread.RunJobs();
+		dataGrid.SelectedItems.Add(_surface.RecipeRows[0]);
+		Dispatcher.UIThread.RunJobs();
+
+		_surface.SelectedStepIndices.Should().Equal(0, 2);
+		_surface.SelectedStepIndex.Should().Be(0);
+	}
+
+	[AvaloniaFact]
+	public void LoadingRowWiring_StampsForDepthClasses_OnRenderedRows()
+	{
+		var dataGrid = ShowView();
+
+		_surface.RecipeRows[1].ForDepth = 1;
+		Dispatcher.UIThread.RunJobs();
+
+		var dataGridRows = dataGrid.GetVisualDescendants().OfType<DataGridRow>().ToList();
+		var stampedRow = dataGridRows.Single(row => ReferenceEquals(row.DataContext, _surface.RecipeRows[1]));
+		stampedRow.Classes.Contains(RowExecutionClasses.ForDepth1Class).Should().BeTrue(
+			"the view's LoadingRow wiring must bind the ForDepth pseudo-classes on real row containers");
+	}
+
+	[AvaloniaFact]
+	public void BeginEdit_OnInapplicableColumn_IsCancelled_AndIsEditingStaysFalse()
+	{
+		var (view, dataGrid) = ShowViewWithControl();
+
+		var row = _surface.RecipeRows[0];
+		var inapplicableColumn = dataGrid.Columns.FirstOrDefault(column =>
+			!column.IsReadOnly && column.Tag is string key && !row.IsApplicable(key));
+		inapplicableColumn.Should().NotBeNull(
+			"the seeded Wait step must have at least one editable column it does not use");
+
+		DataGridTestHelper.SetCurrentCell(dataGrid, rowIndex: 0, inapplicableColumn!);
+		var began = dataGrid.BeginEdit();
+		Dispatcher.UIThread.RunJobs();
+
+		began.Should().BeFalse("the view must cancel edits on columns the step's action does not use");
+		view.IsEditing.Should().BeFalse();
+	}
+
+	[AvaloniaFact]
+	public void BeginEdit_OnApplicableColumn_SetsIsEditing_UntilEditEnds()
+	{
+		var (view, dataGrid) = ShowViewWithControl();
+
+		var durationColumn = dataGrid.Columns.Single(column =>
+			column.Tag as string == RecipeTestDriver.StepDurationColumn);
+
+		DataGridTestHelper.SetCurrentCell(dataGrid, rowIndex: 0, durationColumn);
+		dataGrid.BeginEdit();
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeTrue();
+
+		dataGrid.CancelEdit();
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeFalse();
+	}
+
+	private DataGrid ShowView()
+	{
+		var (_, dataGrid) = ShowViewWithControl();
+
+		return dataGrid;
+	}
+
+	private (CanonicalRecipeGridView View, DataGrid DataGrid) ShowViewWithControl()
+	{
+		var view = new CanonicalRecipeGridView { DataContext = _surface };
+		_window = new Window
+		{
+			Width = 1200,
+			Height = 600,
+			Content = view,
+		};
+
+		_window.Show();
+		Dispatcher.UIThread.RunJobs();
+
+		var dataGrid = view.FindControl<DataGrid>("RecipeGrid");
+		dataGrid.Should().NotBeNull();
+
+		return (view, dataGrid!);
+	}
+
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs
@@ -4,8 +4,6 @@ using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
-using Microsoft.Extensions.Logging.Abstractions;
-
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
@@ -21,26 +19,21 @@ namespace SemiStep.Tests.UI.RecipeGrid;
 public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 {
 	private readonly UIFixture _fixture = new();
-	private RecipeGridViewModel _grid = null!;
+	private CanonicalRecipeGridSurface _surface = null!;
 	private RecipeCommandsViewModel _commands = null!;
 
 	public async ValueTask InitializeAsync()
 	{
 		await _fixture.InitializeAsync();
-		_grid = new RecipeGridViewModel(
-			_fixture.Coordinator,
-			_fixture.RecipeMetadataRegistry,
-			_fixture.MessagePanel,
-			NullLogger<RecipeGridViewModel>.Instance);
-		_fixture.Coordinator.Mutated += _grid.OnMutation;
-		_grid.Initialize();
-		_commands = new RecipeCommandsViewModel(_fixture.Coordinator, _grid);
+		_surface = _fixture.CreateCanonicalSurface();
+		_surface.Initialize();
+		_commands = new RecipeCommandsViewModel(_fixture.Coordinator, _surface);
 	}
 
 	public async ValueTask DisposeAsync()
 	{
 		_commands.Dispose();
-		_grid.Dispose();
+		_surface.Dispose();
 		await _fixture.DisposeAsync();
 	}
 
@@ -80,7 +73,7 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_grid.SelectedRowIndices = new[] { 0 };
+		_surface.UpdateSelection(new[] { 0 });
 
 		((ICommand)_commands.DeleteStepCommand).CanExecute(null).Should().BeTrue();
 	}
@@ -90,7 +83,7 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_grid.SelectedRowIndices = new[] { 0 };
+		_surface.UpdateSelection(new[] { 0 });
 		_fixture.SetRecipeActive(true);
 
 		((ICommand)_commands.DeleteStepCommand).CanExecute(null).Should().BeFalse();
@@ -101,9 +94,21 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.NewRecipe();
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
-		_grid.SelectedRowIndices = Array.Empty<int>();
+		_surface.UpdateSelection(Array.Empty<int>());
 
 		((ICommand)_commands.DeleteStepCommand).CanExecute(null).Should().BeFalse();
+	}
+
+	[AvaloniaFact]
+	public void DeleteStep_CanExecuteTrue_WhenSelectionExistsBeforeConstruction()
+	{
+		_fixture.Coordinator.NewRecipe();
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		_surface.UpdateSelection(new[] { 0 });
+
+		using var commands = new RecipeCommandsViewModel(_fixture.Coordinator, _surface);
+
+		((ICommand)commands.DeleteStepCommand).CanExecute(null).Should().BeTrue();
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridHostTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridHostTests.cs
@@ -1,0 +1,149 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+using FluentAssertions;
+
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public sealed class RecipeGridHostTests : IAsyncLifetime
+{
+	private const int SeededStepCount = 3;
+
+	private readonly UIFixture _fixture = new();
+	private CanonicalRecipeGridSurface _surface = null!;
+	private Window? _window;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_fixture.SeedRecipe(SeededStepCount);
+
+		_surface = _fixture.CreateCanonicalSurface();
+		_surface.Initialize();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		_window?.Close();
+		_surface.Dispose();
+		await _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void Host_WithSurfaceDataContext_RendersCanonicalViewWithRows()
+	{
+		var host = ShowHost();
+
+		var canonicalView = host.GetVisualDescendants().OfType<CanonicalRecipeGridView>().SingleOrDefault();
+		canonicalView.Should().NotBeNull("the host must render the canonical view as its content");
+
+		var dataGrid = FindDataGrid(host);
+		var dataGridRows = dataGrid.GetVisualDescendants().OfType<DataGridRow>().ToList();
+		dataGridRows.Should().HaveCount(SeededStepCount);
+	}
+
+	[AvaloniaFact]
+	public void Surface_ReturnsHostDataContext()
+	{
+		var host = ShowHost();
+
+		host.Surface.Should().BeSameAs(_surface);
+	}
+
+	[AvaloniaFact]
+	public void SelectionRequest_OnSurface_SelectsRowInHostedView()
+	{
+		var host = ShowHost();
+
+		_surface.RequestSelection(1);
+		Dispatcher.UIThread.RunJobs();
+
+		var dataGrid = FindDataGrid(host);
+		dataGrid.SelectedIndex.Should().Be(1);
+	}
+
+	[AvaloniaFact]
+	public void IsEditing_TracksCellEditorLifecycle_ThroughHostForwarding()
+	{
+		var host = ShowHost();
+		var dataGrid = FindDataGrid(host);
+
+		host.IsEditing.Should().BeFalse();
+
+		var durationColumn = dataGrid.Columns.Single(column =>
+			column.Tag as string == RecipeTestDriver.StepDurationColumn);
+		DataGridTestHelper.SetCurrentCell(dataGrid, rowIndex: 0, durationColumn);
+		dataGrid.BeginEdit();
+		Dispatcher.UIThread.RunJobs();
+
+		host.IsEditing.Should().BeTrue();
+
+		dataGrid.CancelEdit();
+		Dispatcher.UIThread.RunJobs();
+
+		host.IsEditing.Should().BeFalse();
+	}
+
+	[AvaloniaFact]
+	public void ContextMenu_OnWrappingPanel_OpensOnRightClickOverGridRow()
+	{
+		var contextMenu = new ContextMenu { Items = { new MenuItem { Header = "Add step" } } };
+		var host = ShowHost(panel => panel.ContextMenu = contextMenu);
+		var dataGrid = FindDataGrid(host);
+
+		var window = _window!;
+		var row = dataGrid.GetVisualDescendants().OfType<DataGridRow>().First();
+		var center = row.TranslatePoint(
+			new Point(row.Bounds.Width / 2, row.Bounds.Height / 2), window);
+		center.Should().NotBeNull();
+
+		window.MouseDown(center!.Value, MouseButton.Right);
+		window.MouseUp(center.Value, MouseButton.Right);
+		Dispatcher.UIThread.RunJobs();
+
+		contextMenu.IsOpen.Should().BeTrue(
+			"a right-click over grid rows must bubble to the wrapping panel's context menu");
+	}
+
+	private RecipeGridHost ShowHost(Action<Panel>? configurePanel = null)
+	{
+		var host = new RecipeGridHost { DataContext = _surface };
+		var panel = new Panel { Children = { host } };
+		configurePanel?.Invoke(panel);
+
+		_window = new Window
+		{
+			Width = 1200,
+			Height = 600,
+			Content = panel,
+		};
+
+		_window.Show();
+		Dispatcher.UIThread.RunJobs();
+
+		return host;
+	}
+
+	private static DataGrid FindDataGrid(RecipeGridHost host)
+	{
+		var dataGrid = host.GetVisualDescendants().OfType<DataGrid>().SingleOrDefault();
+		dataGrid.Should().NotBeNull();
+
+		return dataGrid!;
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridSurfaceContractTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridSurfaceContractTests.cs
@@ -150,6 +150,20 @@ public abstract class RecipeGridSurfaceContractTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
+	public void CanDeleteStep_UnchangedValue_DoesNotReEmit()
+	{
+		var emissionCount = 0;
+		using var subscription = Surface.CanDeleteStep.Subscribe(_ => emissionCount++);
+		emissionCount.Should().Be(1);
+
+		Surface.UpdateSelection([0]);
+		emissionCount.Should().Be(2);
+
+		Surface.UpdateSelection([1]);
+		emissionCount.Should().Be(2);
+	}
+
+	[AvaloniaFact]
 	public void CollectSelectedSteps_ReturnsStepsInAscendingIndexOrder()
 	{
 		Surface.UpdateSelection([2, 0]);

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridSurfaceContractTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridSurfaceContractTests.cs
@@ -1,0 +1,202 @@
+﻿using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+/// <summary>
+/// Contract every <see cref="IRecipeGridSurface"/> implementation must satisfy.
+/// Concrete fixtures derive from this class and supply the surface under test;
+/// the fixture recipe is seeded with four steps before the surface is created.
+/// </summary>
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public abstract class RecipeGridSurfaceContractTests : IAsyncLifetime
+{
+	private const int SeededStepCount = 4;
+
+	protected UIFixture Fixture { get; } = new();
+
+	protected IRecipeGridSurface Surface { get; private set; } = null!;
+
+	protected abstract IRecipeGridSurface CreateSurface(UIFixture fixture);
+
+	public async ValueTask InitializeAsync()
+	{
+		await Fixture.InitializeAsync();
+		Fixture.SeedRecipe(SeededStepCount);
+
+		Surface = CreateSurface(Fixture);
+		Surface.Initialize();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		Surface.Dispose();
+		await Fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void Initialize_ProjectsSeededRecipe_StepCountMatches()
+	{
+		Surface.StepCount.Should().Be(SeededStepCount);
+	}
+
+	[AvaloniaFact]
+	public void IsReadOnly_TracksCoordinatorCanEditRecipe()
+	{
+		Surface.IsReadOnly.Should().BeFalse();
+
+		Fixture.SetRecipeActive(true);
+		Surface.IsReadOnly.Should().BeTrue();
+
+		Fixture.SetRecipeActive(false);
+		Surface.IsReadOnly.Should().BeFalse();
+	}
+
+	[AvaloniaFact]
+	public void UpdateSelection_WithIndices_ExposesSelection()
+	{
+		Surface.UpdateSelection([1, 3]);
+
+		Surface.SelectedStepIndices.Should().Equal(1, 3);
+		Surface.SelectedStepIndex.Should().Be(1);
+	}
+
+	[AvaloniaFact]
+	public void UpdateSelection_WithEmptyList_ClearsSelection()
+	{
+		Surface.UpdateSelection([1, 3]);
+
+		Surface.UpdateSelection([]);
+
+		Surface.SelectedStepIndices.Should().BeEmpty();
+		Surface.SelectedStepIndex.Should().Be(-1);
+	}
+
+	[AvaloniaFact]
+	public void RequestSelection_WithIndex_EmitsOnSelectionRequests()
+	{
+		int? received = -100;
+		using var subscription = Surface.SelectionRequests.Subscribe(index => received = index);
+
+		Surface.RequestSelection(2);
+
+		received.Should().Be(2);
+	}
+
+	[AvaloniaFact]
+	public void RequestSelection_WithNull_EmitsNullOnSelectionRequests()
+	{
+		int? received = -100;
+		var emitted = false;
+		using var subscription = Surface.SelectionRequests.Subscribe(index =>
+		{
+			received = index;
+			emitted = true;
+		});
+
+		Surface.RequestSelection(null);
+
+		emitted.Should().BeTrue();
+		received.Should().BeNull();
+	}
+
+	[AvaloniaFact]
+	public void EditorMustClose_EmitsOnReadOnlyTransition_NotOnRelease()
+	{
+		var emissionCount = 0;
+		using var subscription = Surface.EditorMustClose.Subscribe(_ => emissionCount++);
+
+		Fixture.SetRecipeActive(true);
+		emissionCount.Should().Be(1);
+
+		Fixture.SetRecipeActive(false);
+		emissionCount.Should().Be(1);
+	}
+
+	[AvaloniaFact]
+	public void EditorMustClose_SubscribedWhileAlreadyReadOnly_DoesNotReplay()
+	{
+		Fixture.SetRecipeActive(true);
+
+		var emissionCount = 0;
+		using var subscription = Surface.EditorMustClose.Subscribe(_ => emissionCount++);
+
+		emissionCount.Should().Be(0);
+	}
+
+	[AvaloniaFact]
+	public void CanDeleteStep_TrueIffSelectionNonEmpty_ReactsToUpdateSelection()
+	{
+		var values = new List<bool>();
+		using var subscription = Surface.CanDeleteStep.Subscribe(values.Add);
+
+		values.Should().Equal(false);
+
+		Surface.UpdateSelection([0]);
+		values[^1].Should().BeTrue();
+
+		Surface.UpdateSelection([]);
+		values[^1].Should().BeFalse();
+	}
+
+	[AvaloniaFact]
+	public void CollectSelectedSteps_ReturnsStepsInAscendingIndexOrder()
+	{
+		Surface.UpdateSelection([2, 0]);
+
+		var steps = Surface.CollectSelectedSteps();
+
+		var recipe = Fixture.Coordinator.CurrentRecipe;
+		steps.Should().HaveCount(Surface.SelectedStepIndices.Count);
+		steps[0].Should().Be(recipe.Steps[0]);
+		steps[1].Should().Be(recipe.Steps[2]);
+	}
+
+	[AvaloniaFact]
+	public void Dispose_CoordinatorSignals_ProduceNoFurtherEmissionsOrStateChanges()
+	{
+		Surface.UpdateSelection([1]);
+		var stepCountBeforeDispose = Surface.StepCount;
+
+		var canDeleteEmissions = 0;
+		var editorMustCloseEmissions = 0;
+		using var canDeleteSubscription = Surface.CanDeleteStep.Subscribe(_ => canDeleteEmissions++);
+		using var editorMustCloseSubscription = Surface.EditorMustClose.Subscribe(_ => editorMustCloseEmissions++);
+		var canDeleteBaseline = canDeleteEmissions;
+
+		Surface.Dispose();
+
+		Fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		Fixture.SetRecipeActive(true);
+
+		canDeleteEmissions.Should().Be(canDeleteBaseline);
+		editorMustCloseEmissions.Should().Be(0);
+		Surface.StepCount.Should().Be(stepCountBeforeDispose);
+		Surface.IsReadOnly.Should().BeFalse();
+		Surface.SelectedStepIndices.Should().Equal(1);
+	}
+
+	[AvaloniaFact]
+	public void Dispose_ConsumerFacingCalls_AreSafeNoOps()
+	{
+		Surface.Dispose();
+
+		var requestExisting = () => Surface.RequestSelection(0);
+		var requestClear = () => Surface.RequestSelection(null);
+		var updateSelection = () => Surface.UpdateSelection([]);
+
+		requestExisting.Should().NotThrow();
+		requestClear.Should().NotThrow();
+		updateSelection.Should().NotThrow();
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeRowForDepthPropagationTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeRowForDepthPropagationTests.cs
@@ -2,8 +2,6 @@
 
 using FluentAssertions;
 
-using Microsoft.Extensions.Logging.Abstractions;
-
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
@@ -19,23 +17,18 @@ namespace SemiStep.Tests.UI.RecipeGrid;
 public sealed class RecipeRowForDepthPropagationTests : IAsyncLifetime
 {
 	private readonly UIFixture _fixture = new();
-	private RecipeGridViewModel _grid = null!;
+	private CanonicalRecipeGridSurface _surface = null!;
 
 	public async ValueTask InitializeAsync()
 	{
 		await _fixture.InitializeAsync();
-		_grid = new RecipeGridViewModel(
-			_fixture.Coordinator,
-			_fixture.RecipeMetadataRegistry,
-			_fixture.MessagePanel,
-			NullLogger<RecipeGridViewModel>.Instance);
-		_fixture.Coordinator.Mutated += _grid.OnMutation;
-		_grid.Initialize();
+		_surface = _fixture.CreateCanonicalSurface();
+		_surface.Initialize();
 	}
 
 	public async ValueTask DisposeAsync()
 	{
-		_grid.Dispose();
+		_surface.Dispose();
 		await _fixture.DisposeAsync();
 	}
 
@@ -50,7 +43,7 @@ public sealed class RecipeRowForDepthPropagationTests : IAsyncLifetime
 		AppendEndFor();
 		AppendEndFor();
 
-		_grid.RecipeRows.Should().HaveCount(6);
+		_surface.RecipeRows.Should().HaveCount(6);
 
 		AssertForDepth(0, 1);
 		AssertForDepth(1, 1);
@@ -68,7 +61,7 @@ public sealed class RecipeRowForDepthPropagationTests : IAsyncLifetime
 		AppendWait();
 		AppendWait();
 
-		foreach (var row in _grid.RecipeRows)
+		foreach (var row in _surface.RecipeRows)
 		{
 			row.ForDepth.Should().Be(0);
 			row.IsForDepth1.Should().BeFalse();
@@ -94,7 +87,7 @@ public sealed class RecipeRowForDepthPropagationTests : IAsyncLifetime
 		AppendEndFor();
 		AppendEndFor();
 
-		var innermostWait = _grid.RecipeRows[3];
+		var innermostWait = _surface.RecipeRows[3];
 		innermostWait.ForDepth.Should().Be(3);
 		innermostWait.IsForDepth1.Should().BeFalse();
 		innermostWait.IsForDepth2.Should().BeFalse();
@@ -107,7 +100,7 @@ public sealed class RecipeRowForDepthPropagationTests : IAsyncLifetime
 		_fixture.Coordinator.NewRecipe();
 		AppendWait();
 
-		var row = _grid.RecipeRows[0];
+		var row = _surface.RecipeRows[0];
 		var changedProperties = new List<string?>();
 		row.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
 
@@ -137,7 +130,7 @@ public sealed class RecipeRowForDepthPropagationTests : IAsyncLifetime
 
 	private void AssertForDepth(int rowIndex, int expectedDepth)
 	{
-		var row = _grid.RecipeRows[rowIndex];
+		var row = _surface.RecipeRows[rowIndex];
 		row.ForDepth.Should().Be(expectedDepth);
 		row.IsForDepth1.Should().Be(expectedDepth == 1);
 		row.IsForDepth2.Should().Be(expectedDepth == 2);

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeRowSelectorEditTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeRowSelectorEditTests.cs
@@ -10,6 +10,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
+using SemiStep.Core.Configuration;
 using SemiStep.Core.Plc;
 using SemiStep.Core.Plc.State;
 using SemiStep.Core.Recipes;
@@ -50,7 +51,7 @@ public sealed class RecipeRowSelectorEditTests : IAsyncLifetime
 	private RecipeMetadataRegistry _registry = null!;
 	private MessagePanelViewModel _messagePanel = null!;
 	private RecipeCoordinator _coordinator = null!;
-	private RecipeGridViewModel _grid = null!;
+	private CanonicalRecipeGridSurface _surface = null!;
 
 	public async ValueTask InitializeAsync()
 	{
@@ -71,18 +72,18 @@ public sealed class RecipeRowSelectorEditTests : IAsyncLifetime
 			NullLogger<RecipeCoordinator>.Instance);
 		_coordinator.Initialize();
 
-		_grid = new RecipeGridViewModel(
+		_surface = new CanonicalRecipeGridSurface(
 			_coordinator,
 			_registry,
+			new ColumnBuilder(GridStyleOptions.Default, _registry),
 			_messagePanel,
-			NullLogger<RecipeGridViewModel>.Instance);
-		_coordinator.Mutated += _grid.OnMutation;
-		_grid.Initialize();
+			NullLogger<CanonicalRecipeGridSurface>.Instance);
+		_surface.Initialize();
 	}
 
 	public ValueTask DisposeAsync()
 	{
-		_grid.Dispose();
+		_surface.Dispose();
 		_coordinator.Dispose();
 		_messagePanel.Dispose();
 		return ValueTask.CompletedTask;
@@ -91,7 +92,7 @@ public sealed class RecipeRowSelectorEditTests : IAsyncLifetime
 	private RecipeRowViewModel AppendBranchingRow()
 	{
 		_coordinator.AppendStep(BranchingActionId);
-		return _grid.RecipeRows.Single();
+		return _surface.RecipeRows.Single();
 	}
 
 	[AvaloniaFact]
@@ -144,7 +145,7 @@ public sealed class RecipeRowSelectorEditTests : IAsyncLifetime
 
 		_coordinator.Undo();
 
-		var restored = _grid.RecipeRows.Single();
+		var restored = _surface.RecipeRows.Single();
 		restored.GetPropertyValue(SelectorColumn).Should().Be(1);
 		restored.GetPropertyValue(SubColumn).Should().Be(73f);
 	}
@@ -236,7 +237,7 @@ public sealed class RecipeRowSelectorEditTests : IAsyncLifetime
 		// apply the changed delta (same instance, no new membership).
 		var stubS7 = _services.GetRequiredService<StubS7Service>();
 		stubS7.PushExecutionState(PlcExecutionInfo.Empty with { RecipeActive = true });
-		_grid.IsReadOnly.Should().BeTrue();
+		_surface.IsReadOnly.Should().BeTrue();
 		var afterExecutionStart = row.ChangedColumns;
 
 		row.SetPropertyValue(SelectorColumn, AutoValue);

--- a/SemiStep/SemiStep.UI/App.axaml.cs
+++ b/SemiStep/SemiStep.UI/App.axaml.cs
@@ -12,7 +12,6 @@ using SemiStep.UI.Coordinator;
 using SemiStep.UI.Dialogs;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.MessageService;
-using SemiStep.UI.RecipeGrid;
 using SemiStep.UI.Styles;
 
 using Serilog;
@@ -105,9 +104,6 @@ public class App : Application
 
 		var coordinator = provider.GetRequiredService<RecipeCoordinator>();
 		coordinator.Initialize();
-
-		var gridViewModel = provider.GetRequiredService<RecipeGridViewModel>();
-		coordinator.Mutated += gridViewModel.OnMutation;
 	}
 
 	public static void RunErrorWindow(IReadOnlyList<string> errors)

--- a/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
+++ b/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
@@ -28,12 +28,12 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 	private readonly CompositeDisposable _disposables = new();
 	private readonly ImportedRecipeValidator _importedRecipeValidator;
 	private readonly MessagePanelViewModel _messagePanel;
-	private readonly RecipeGridViewModel _recipeGrid;
+	private readonly IRecipeGridSurface _recipeGrid;
 	private IClipboard? _clipboard;
 
 	public ClipboardViewModel(
 		RecipeCoordinator coordinator,
-		RecipeGridViewModel recipeGrid,
+		IRecipeGridSurface recipeGrid,
 		ClipboardSerializer clipboardSerializer,
 		ImportedRecipeValidator importedRecipeValidator,
 		MessagePanelViewModel messagePanel)
@@ -44,7 +44,7 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 		_importedRecipeValidator = importedRecipeValidator;
 		_messagePanel = messagePanel;
 
-		var canCopyOrCut = _recipeGrid.WhenAnyValue(x => x.CanDeleteStep);
+		var canCopyOrCut = _recipeGrid.CanDeleteStep;
 		var canEdit = _coordinator.CanEditRecipe;
 
 		CopyStepCommand = ReactiveCommand.CreateFromTask(CopyStepsAsync, canCopyOrCut);
@@ -88,7 +88,7 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 
 	private async Task CopyStepsAsync()
 	{
-		if (_clipboard is null || _recipeGrid.SelectedRowIndices.Count == 0)
+		if (_clipboard is null || _recipeGrid.SelectedStepIndices.Count == 0)
 		{
 			return;
 		}
@@ -100,7 +100,7 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 
 	private async Task CutStepsAsync()
 	{
-		if (_clipboard is null || _recipeGrid.SelectedRowIndices.Count == 0)
+		if (_clipboard is null || _recipeGrid.SelectedStepIndices.Count == 0)
 		{
 			return;
 		}
@@ -109,7 +109,7 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 		var csvText = SerializeStepsForClipboard(steps);
 		await _clipboard.SetTextAsync(csvText);
 
-		var result = _coordinator.RemoveSteps(_recipeGrid.SelectedRowIndices);
+		var result = _coordinator.RemoveSteps(_recipeGrid.SelectedStepIndices);
 		if (result.IsFailed)
 		{
 			_messagePanel.ReportFailure(result);
@@ -144,9 +144,9 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
-		var rowCount = _recipeGrid.RecipeRows.Count;
-		var insertIndex = _recipeGrid.SelectedRowIndices.Count > 0
-			? Math.Min(_recipeGrid.SelectedRowIndices.Max() + 1, rowCount)
+		var rowCount = _recipeGrid.StepCount;
+		var insertIndex = _recipeGrid.SelectedStepIndices.Count > 0
+			? Math.Min(_recipeGrid.SelectedStepIndices.Max() + 1, rowCount)
 			: rowCount;
 
 		var insertResult = _coordinator.InsertSteps(insertIndex, recipeResult.Value.Steps);

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml
@@ -30,24 +30,8 @@
         <local:RecipeToolBar Grid.Row="1"
                              IsVisible="{Binding IsToolBarVisible}" />
 
-        <DataGrid Grid.Row="2"
-                  x:Name="RecipeGrid"
-                  ItemsSource="{Binding RecipeGrid.RecipeRows}"
-                  AutoGenerateColumns="False"
-                  CanUserReorderColumns="False"
-                  CanUserResizeColumns="True"
-                  IsReadOnly="{Binding RecipeGrid.IsReadOnly}"
-                  Classes.read-only="{Binding RecipeGrid.IsReadOnly}"
-                  recipeGrid:DataGridEditorCloseBehavior.Trigger="{Binding RecipeGrid.EditorMustClose}"
-                  GridLinesVisibility="All"
-                  HeadersVisibility="Column"
-                  BorderThickness="1"
-                  BorderBrush="{DynamicResource GridBorderBrush}"
-                  Background="{DynamicResource GridBackgroundBrush}"
-                  SelectionMode="Extended"
-                  ClipboardCopyMode="None"
-                  LoadingRow="OnDataGridLoadingRow">
-            <DataGrid.ContextMenu>
+        <Panel Grid.Row="2">
+            <Panel.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="{x:Static l:Resources.ContextAddStep}"
                               Command="{Binding RecipeCommands.AddStepCommand}" />
@@ -61,8 +45,10 @@
                     <MenuItem Header="{x:Static l:Resources.ContextPasteStep}"
                               Command="{Binding Clipboard.PasteStepCommand}" />
                 </ContextMenu>
-            </DataGrid.ContextMenu>
-        </DataGrid>
+            </Panel.ContextMenu>
+            <recipeGrid:RecipeGridHost x:Name="RecipeGridHost"
+                                       DataContext="{Binding RecipeGrid}" />
+        </Panel>
 
         <messageService:MessagePanel Grid.Row="3"
                                      x:Name="LogPanel"

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reactive;
-using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
@@ -10,19 +9,14 @@ using Avalonia.Platform.Storage;
 using ReactiveUI;
 using ReactiveUI.Avalonia;
 
-using SemiStep.UI.RecipeGrid;
 using SemiStep.UI.ShutdownService;
 
 namespace SemiStep.UI.MainWindow;
 
 internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 {
-	private ColumnBuilder? _columnBuilder;
 	private bool _forceClose;
 	private bool _exitChoiceInProgress;
-	private bool _isEditing;
-	private bool _columnsBuilt;
-	private (RecipeRowViewModel Row, string ColumnKey)? _pendingChangedCell;
 
 	public MainWindow()
 	{
@@ -47,28 +41,6 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 			ViewModel.RecipeFile.SaveFileInteraction
 				.RegisterHandler(HandleSaveFileDialogAsync)
 				.DisposeWith(disposables);
-
-			_columnBuilder = ViewModel.ColumnBuilder;
-			BuildGrid();
-
-			RecipeGrid.BeginningEdit += OnBeginningEdit;
-			RecipeGrid.CellEditEnded += OnCellEditEnded;
-			RecipeGrid.SelectionChanged += OnSelectionChanged;
-			RecipeGrid.CellPointerPressed += OnCellPointerPressed;
-			ViewModel.RecipeGrid.SelectionRequested += OnSelectionRequested;
-
-			Disposable.Create(() =>
-			{
-				RecipeGrid.BeginningEdit -= OnBeginningEdit;
-				RecipeGrid.CellEditEnded -= OnCellEditEnded;
-				RecipeGrid.SelectionChanged -= OnSelectionChanged;
-				RecipeGrid.CellPointerPressed -= OnCellPointerPressed;
-				_pendingChangedCell = null;
-				if (ViewModel is not null)
-				{
-					ViewModel.RecipeGrid.SelectionRequested -= OnSelectionRequested;
-				}
-			}).DisposeWith(disposables);
 		});
 	}
 
@@ -81,7 +53,7 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 			return;
 		}
 
-		if (!_isEditing)
+		if (!RecipeGridHost.IsEditing)
 		{
 			switch (e.Key)
 			{
@@ -112,97 +84,6 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 		}
 
 		base.OnKeyDown(e);
-	}
-
-	private void OnBeginningEdit(object? sender, DataGridBeginningEditEventArgs e)
-	{
-		if (e.Row.DataContext is RecipeRowViewModel row
-			&& e.Column.Tag is string columnKey
-			&& !row.IsApplicable(columnKey))
-		{
-			e.Cancel = true;
-
-			return;
-		}
-
-		_isEditing = true;
-	}
-
-	private void OnCellEditEnded(object? sender, DataGridCellEditEndedEventArgs e)
-	{
-		_isEditing = false;
-	}
-
-	// Click-away rule: a changed (orange) cell clears the moment any OTHER cell is pressed. This is
-	// not an edit, so it must run even while the grid is read-only during PLC sync — no IsReadOnly guard.
-	private void OnCellPointerPressed(object? sender, DataGridCellPointerPressedEventArgs e)
-	{
-		var pressedRow = e.Row.DataContext as RecipeRowViewModel;
-		var pressedColumnKey = e.Column.Tag as string;
-
-		var (cellToClear, newPending) = ChangedCellClickResolver.Resolve(
-			_pendingChangedCell,
-			pressedRow,
-			pressedColumnKey);
-
-		if (cellToClear is { } toClear
-			&& (ViewModel is null || ViewModel.RecipeGrid.RecipeRows.Contains(toClear.Row)))
-		{
-			toClear.Row.ClearChanged(toClear.ColumnKey);
-		}
-
-		_pendingChangedCell = newPending;
-	}
-
-	private void OnDataGridLoadingRow(object? sender, DataGridRowEventArgs e)
-	{
-		RecipeRowExecutionClassBinder.BindAll(e.Row);
-	}
-
-	private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
-	{
-		if (ViewModel is null)
-		{
-			return;
-		}
-
-		var indices = new List<int>();
-		foreach (var item in RecipeGrid.SelectedItems)
-		{
-			if (item is RecipeRowViewModel row)
-			{
-				var index = ViewModel.RecipeGrid.RecipeRows.IndexOf(row);
-				if (index >= 0)
-				{
-					indices.Add(index);
-				}
-			}
-		}
-
-		indices.Sort();
-		ViewModel.RecipeGrid.SelectedRowIndices = indices;
-	}
-
-	private void OnSelectionRequested(int? suggestedIndex)
-	{
-		if (ViewModel is null)
-		{
-			return;
-		}
-
-		if (suggestedIndex is null)
-		{
-			RecipeGrid.SelectedIndex = -1;
-			return;
-		}
-
-		var index = suggestedIndex.Value;
-		if (index < 0 || index >= ViewModel.RecipeGrid.RecipeRows.Count)
-		{
-			return;
-		}
-
-		RecipeGrid.SelectedIndex = index;
 	}
 
 	private async void OnWindowClosing(object? sender, WindowClosingEventArgs e)
@@ -342,16 +223,5 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
 		var selectedPath = file?.Path.LocalPath;
 		context.SetOutput(selectedPath);
-	}
-
-	private void BuildGrid()
-	{
-		if (_columnsBuilt || _columnBuilder is null || ViewModel is null)
-		{
-			return;
-		}
-
-		_columnBuilder.BuildColumns(RecipeGrid);
-		_columnsBuilt = true;
 	}
 }

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
@@ -35,12 +35,11 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 
 	public MainWindowViewModel(
 		RecipeCoordinator coordinator,
-		RecipeGridViewModel recipeGrid,
+		IRecipeGridSurface recipeGrid,
 		RecipeCommandsViewModel recipeCommands,
 		ClipboardViewModel clipboard,
 		RecipeFileViewModel recipeFile,
 		MessagePanelViewModel messagePanel,
-		ColumnBuilder columnBuilder,
 		PlcMonitorViewModel plcMonitor,
 		Func<GridStyleEditorViewModel> gridStyleEditorViewModelFactory,
 		ILogger<MainWindowViewModel> logger)
@@ -53,7 +52,6 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		Clipboard = clipboard;
 		RecipeFile = recipeFile;
 		MessagePanel = messagePanel;
-		ColumnBuilder = columnBuilder;
 		PlcMonitor = plcMonitor;
 
 		ExitCommand = ReactiveCommand.Create(ExecuteExit);
@@ -90,7 +88,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 
 	public Window? MainWindow { get; set; }
 
-	public RecipeGridViewModel RecipeGrid { get; }
+	public IRecipeGridSurface RecipeGrid { get; }
 
 	public RecipeCommandsViewModel RecipeCommands { get; }
 
@@ -99,8 +97,6 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 	public RecipeFileViewModel RecipeFile { get; }
 
 	public MessagePanelViewModel MessagePanel { get; }
-
-	public ColumnBuilder ColumnBuilder { get; }
 
 	public PlcMonitorViewModel PlcMonitor { get; }
 

--- a/SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridSurface.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridSurface.cs
@@ -5,6 +5,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 
 using Avalonia.Threading;
 
@@ -19,43 +20,43 @@ using SemiStep.UI.MessageService;
 
 namespace SemiStep.UI.RecipeGrid;
 
-public class RecipeGridViewModel : ReactiveObject, IDisposable
+public class CanonicalRecipeGridSurface : ReactiveObject, IRecipeGridSurface
 {
-	private readonly ObservableAsPropertyHelper<bool> _canDeleteStep;
 	private readonly ObservableAsPropertyHelper<bool> _isReadOnly;
-	private readonly ObservableAsPropertyHelper<int> _selectedRowIndex;
+	private readonly ObservableAsPropertyHelper<int> _selectedStepIndex;
 	private readonly RecipeCoordinator _coordinator;
 	private readonly CompositeDisposable _disposables = new();
 	private readonly ExecutionHighlightTracker _executionHighlightTracker;
-	private readonly ILogger<RecipeGridViewModel> _logger;
+	private readonly ILogger<CanonicalRecipeGridSurface> _logger;
 	private readonly MessagePanelViewModel _messagePanel;
+	private readonly Subject<int?> _selectionRequests = new();
 
-	private IReadOnlyList<int> _selectedRowIndices = [];
+	private IReadOnlyList<int> _selectedStepIndices = [];
 
-	public RecipeGridViewModel(
+	public CanonicalRecipeGridSurface(
 		RecipeCoordinator coordinator,
 		RecipeMetadataRegistry recipeMetadataRegistry,
+		ColumnBuilder columnBuilder,
 		MessagePanelViewModel messagePanel,
-		ILogger<RecipeGridViewModel> logger)
+		ILogger<CanonicalRecipeGridSurface> logger)
 	{
 		_coordinator = coordinator;
 		RecipeMetadataRegistry = recipeMetadataRegistry;
+		ColumnBuilder = columnBuilder;
 		_messagePanel = messagePanel;
 		_logger = logger;
 
 		RecipeRows = new ObservableCollection<RecipeRowViewModel>();
 		_executionHighlightTracker = new ExecutionHighlightTracker(RecipeRows);
 
-		_canDeleteStep = this
-			.WhenAnyValue(x => x.SelectedRowIndices)
-			.Select(indices => indices.Count > 0)
-			.ToProperty(this, x => x.CanDeleteStep)
-			.DisposeWith(_disposables);
+		CanDeleteStep = this
+			.WhenAnyValue(x => x.SelectedStepIndices)
+			.Select(indices => indices.Count > 0);
 
-		_selectedRowIndex = this
-			.WhenAnyValue(x => x.SelectedRowIndices)
+		_selectedStepIndex = this
+			.WhenAnyValue(x => x.SelectedStepIndices)
 			.Select(indices => indices.Count > 0 ? indices[0] : -1)
-			.ToProperty(this, x => x.SelectedRowIndex)
+			.ToProperty(this, x => x.SelectedStepIndex)
 			.DisposeWith(_disposables);
 
 		_isReadOnly = coordinator.CanEditRecipe
@@ -72,27 +73,40 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 		coordinator.ExecutionState
 			.Subscribe(_executionHighlightTracker.OnExecutionStateChanged)
 			.DisposeWith(_disposables);
+
+		coordinator.Mutated += OnMutation;
+		Disposable.Create(() => coordinator.Mutated -= OnMutation)
+			.DisposeWith(_disposables);
 	}
 
 	public IObservable<Unit> EditorMustClose { get; }
 
 	internal RecipeMetadataRegistry RecipeMetadataRegistry { get; }
 
+	public ColumnBuilder ColumnBuilder { get; }
+
 	public ObservableCollection<RecipeRowViewModel> RecipeRows { get; }
 
-	public bool CanDeleteStep => _canDeleteStep.Value;
+	public IObservable<bool> CanDeleteStep { get; }
 
 	public bool IsReadOnly => _isReadOnly.Value;
 
-	public int SelectedRowIndex => _selectedRowIndex.Value;
+	public int SelectedStepIndex => _selectedStepIndex.Value;
 
-	public IReadOnlyList<int> SelectedRowIndices
+	public IReadOnlyList<int> SelectedStepIndices
 	{
-		get => _selectedRowIndices;
-		set => this.RaiseAndSetIfChanged(ref _selectedRowIndices, value);
+		get => _selectedStepIndices;
+		private set => this.RaiseAndSetIfChanged(ref _selectedStepIndices, value);
 	}
 
-	public event Action<int?>? SelectionRequested;
+	public int StepCount => RecipeRows.Count;
+
+	public IObservable<int?> SelectionRequests => _selectionRequests.AsObservable();
+
+	public void UpdateSelection(IReadOnlyList<int> stepIndices)
+	{
+		SelectedStepIndices = stepIndices;
+	}
 
 	public void Dispose()
 	{
@@ -158,7 +172,7 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 
 	private void ReconcileSelectionWithRows()
 	{
-		var currentSelection = SelectedRowIndices;
+		var currentSelection = SelectedStepIndices;
 		if (currentSelection.Count == 0)
 		{
 			return;
@@ -170,12 +184,17 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
-		SelectedRowIndices = currentSelection.Where(index => index < rowCount).ToList();
+		SelectedStepIndices = currentSelection.Where(index => index < rowCount).ToList();
 	}
 
-	public void RequestSelection(int? suggestedIndex)
+	public void RequestSelection(int? stepIndex)
 	{
-		SelectionRequested?.Invoke(suggestedIndex);
+		if (_disposables.IsDisposed)
+		{
+			return;
+		}
+
+		_selectionRequests.OnNext(stepIndex);
 	}
 
 	private void OnCellValueChanged(RecipeRowViewModel row, string columnKey, string? value)
@@ -457,11 +476,11 @@ public class RecipeGridViewModel : ReactiveObject, IDisposable
 		}
 	}
 
-	public List<Step> CollectSelectedSteps()
+	public IReadOnlyList<Step> CollectSelectedSteps()
 	{
 		var recipe = _coordinator.CurrentRecipe;
 
-		return _selectedRowIndices
+		return _selectedStepIndices
 			.OrderBy(i => i)
 			.Select(i => recipe.Steps[i])
 			.ToList();

--- a/SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridSurface.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridSurface.cs
@@ -51,7 +51,8 @@ public class CanonicalRecipeGridSurface : ReactiveObject, IRecipeGridSurface
 
 		CanDeleteStep = this
 			.WhenAnyValue(x => x.SelectedStepIndices)
-			.Select(indices => indices.Count > 0);
+			.Select(indices => indices.Count > 0)
+			.DistinctUntilChanged();
 
 		_selectedStepIndex = this
 			.WhenAnyValue(x => x.SelectedStepIndices)

--- a/SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridView.axaml
+++ b/SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridView.axaml
@@ -1,0 +1,29 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:recipeGrid="clr-namespace:SemiStep.UI.RecipeGrid"
+             mc:Ignorable="d"
+             d:DesignWidth="1600"
+             d:DesignHeight="600"
+             x:Class="SemiStep.UI.RecipeGrid.CanonicalRecipeGridView"
+             x:DataType="recipeGrid:CanonicalRecipeGridSurface">
+
+    <DataGrid x:Name="RecipeGrid"
+              ItemsSource="{Binding RecipeRows}"
+              AutoGenerateColumns="False"
+              CanUserReorderColumns="False"
+              CanUserResizeColumns="True"
+              IsReadOnly="{Binding IsReadOnly}"
+              Classes.read-only="{Binding IsReadOnly}"
+              recipeGrid:DataGridEditorCloseBehavior.Trigger="{Binding EditorMustClose}"
+              GridLinesVisibility="All"
+              HeadersVisibility="Column"
+              BorderThickness="1"
+              BorderBrush="{DynamicResource GridBorderBrush}"
+              Background="{DynamicResource GridBackgroundBrush}"
+              SelectionMode="Extended"
+              ClipboardCopyMode="None"
+              LoadingRow="OnDataGridLoadingRow" />
+
+</UserControl>

--- a/SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridView.axaml.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/CanonicalRecipeGridView.axaml.cs
@@ -1,0 +1,161 @@
+﻿using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+
+using Avalonia.Controls;
+
+using ReactiveUI;
+using ReactiveUI.Avalonia;
+
+namespace SemiStep.UI.RecipeGrid;
+
+public partial class CanonicalRecipeGridView : ReactiveUserControl<CanonicalRecipeGridSurface>
+{
+	private bool _columnsBuilt;
+	private (RecipeRowViewModel Row, string ColumnKey)? _pendingChangedCell;
+
+	public CanonicalRecipeGridView()
+	{
+		InitializeComponent();
+
+		this.WhenActivated(disposables =>
+		{
+			RecipeGrid.BeginningEdit += OnBeginningEdit;
+			RecipeGrid.CellEditEnded += OnCellEditEnded;
+			RecipeGrid.SelectionChanged += OnSelectionChanged;
+			RecipeGrid.CellPointerPressed += OnCellPointerPressed;
+
+			var selectionRequestsSubscription = new SerialDisposable()
+				.DisposeWith(disposables);
+
+			this.WhenAnyValue(x => x.ViewModel)
+				.Subscribe(surface =>
+				{
+					if (surface is null)
+					{
+						selectionRequestsSubscription.Disposable = null;
+
+						return;
+					}
+
+					BuildGrid();
+					selectionRequestsSubscription.Disposable =
+						surface.SelectionRequests.Subscribe(OnSelectionRequested);
+				})
+				.DisposeWith(disposables);
+
+			Disposable.Create(() =>
+			{
+				RecipeGrid.BeginningEdit -= OnBeginningEdit;
+				RecipeGrid.CellEditEnded -= OnCellEditEnded;
+				RecipeGrid.SelectionChanged -= OnSelectionChanged;
+				RecipeGrid.CellPointerPressed -= OnCellPointerPressed;
+				_pendingChangedCell = null;
+				IsEditing = false;
+			}).DisposeWith(disposables);
+		});
+	}
+
+	public bool IsEditing { get; private set; }
+
+	private void OnBeginningEdit(object? sender, DataGridBeginningEditEventArgs e)
+	{
+		if (e.Row.DataContext is RecipeRowViewModel row
+			&& e.Column.Tag is string columnKey
+			&& !row.IsApplicable(columnKey))
+		{
+			e.Cancel = true;
+
+			return;
+		}
+
+		IsEditing = true;
+	}
+
+	private void OnCellEditEnded(object? sender, DataGridCellEditEndedEventArgs e)
+	{
+		IsEditing = false;
+	}
+
+	// Click-away rule: a changed (orange) cell clears the moment any OTHER cell is pressed. This is
+	// not an edit, so it must run even while the grid is read-only during PLC sync — no IsReadOnly guard.
+	private void OnCellPointerPressed(object? sender, DataGridCellPointerPressedEventArgs e)
+	{
+		var pressedRow = e.Row.DataContext as RecipeRowViewModel;
+		var pressedColumnKey = e.Column.Tag as string;
+
+		var (cellToClear, newPending) = ChangedCellClickResolver.Resolve(
+			_pendingChangedCell,
+			pressedRow,
+			pressedColumnKey);
+
+		if (cellToClear is { } toClear
+			&& (ViewModel is null || ViewModel.RecipeRows.Contains(toClear.Row)))
+		{
+			toClear.Row.ClearChanged(toClear.ColumnKey);
+		}
+
+		_pendingChangedCell = newPending;
+	}
+
+	private void OnDataGridLoadingRow(object? sender, DataGridRowEventArgs e)
+	{
+		RecipeRowExecutionClassBinder.BindAll(e.Row);
+	}
+
+	private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+	{
+		if (ViewModel is null)
+		{
+			return;
+		}
+
+		var indices = new List<int>();
+		foreach (var item in RecipeGrid.SelectedItems)
+		{
+			if (item is RecipeRowViewModel row)
+			{
+				var index = ViewModel.RecipeRows.IndexOf(row);
+				if (index >= 0)
+				{
+					indices.Add(index);
+				}
+			}
+		}
+
+		indices.Sort();
+		ViewModel.UpdateSelection(indices);
+	}
+
+	private void OnSelectionRequested(int? suggestedIndex)
+	{
+		if (ViewModel is null)
+		{
+			return;
+		}
+
+		if (suggestedIndex is null)
+		{
+			RecipeGrid.SelectedIndex = -1;
+			return;
+		}
+
+		var index = suggestedIndex.Value;
+		if (index < 0 || index >= ViewModel.RecipeRows.Count)
+		{
+			return;
+		}
+
+		RecipeGrid.SelectedIndex = index;
+	}
+
+	private void BuildGrid()
+	{
+		if (_columnsBuilt || ViewModel is null)
+		{
+			return;
+		}
+
+		ViewModel.ColumnBuilder.BuildColumns(RecipeGrid);
+		_columnsBuilt = true;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/IRecipeGridSurface.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/IRecipeGridSurface.cs
@@ -1,0 +1,42 @@
+﻿using System.Reactive;
+
+using SemiStep.Core.Recipes;
+
+namespace SemiStep.UI.RecipeGrid;
+
+/// <summary>
+/// View-facing API of the recipe grid. Selection is expressed in step indices only;
+/// each implementation owns its native widget, mutation handling, and execution highlighting.
+/// </summary>
+public interface IRecipeGridSurface : IDisposable
+{
+	/// <summary>Initial projection from the coordinator's current recipe. Called once at startup.</summary>
+	void Initialize();
+
+	int StepCount { get; }
+
+	bool IsReadOnly { get; }
+
+	IReadOnlyList<int> SelectedStepIndices { get; }
+
+	/// <summary>First selected step index, or -1 when the selection is empty.</summary>
+	int SelectedStepIndex { get; }
+
+	/// <summary>View to surface: the actual selection produced by the control, mapped to step indices.</summary>
+	void UpdateSelection(IReadOnlyList<int> stepIndices);
+
+	/// <summary>Consumer to surface: programmatic selection push. Null clears the selection.</summary>
+	void RequestSelection(int? stepIndex);
+
+	/// <summary>Surface to view: the stream <see cref="RequestSelection"/> pushes into.</summary>
+	IObservable<int?> SelectionRequests { get; }
+
+	/// <summary>Emits the current value on subscription (WhenAnyValue semantics).</summary>
+	IObservable<bool> CanDeleteStep { get; }
+
+	/// <summary>Emits on each <see cref="IsReadOnly"/> false-to-true transition; no replay on subscription.</summary>
+	IObservable<Unit> EditorMustClose { get; }
+
+	/// <summary>Selected steps in ascending step-index order.</summary>
+	IReadOnlyList<Step> CollectSelectedSteps();
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs
@@ -16,11 +16,11 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 	private readonly CompositeDisposable _disposables = new();
 	private readonly BehaviorSubject<bool> _canUndo = new(false);
 	private readonly BehaviorSubject<bool> _canRedo = new(false);
-	private readonly RecipeGridViewModel _recipeGrid;
+	private readonly IRecipeGridSurface _recipeGrid;
 
 	public RecipeCommandsViewModel(
 		RecipeCoordinator coordinator,
-		RecipeGridViewModel recipeGrid)
+		IRecipeGridSurface recipeGrid)
 	{
 		_coordinator = coordinator;
 		_recipeGrid = recipeGrid;
@@ -30,8 +30,7 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 		_disposables.Add(_canUndo);
 		_disposables.Add(_canRedo);
 
-		var canDelete = _recipeGrid
-			.WhenAnyValue(x => x.CanDeleteStep);
+		var canDelete = _recipeGrid.CanDeleteStep;
 
 		var canEdit = _coordinator.CanEditRecipe;
 
@@ -71,8 +70,8 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 	{
 		var firstActionId = _coordinator.GetDefaultActionId();
 
-		var result = _recipeGrid.SelectedRowIndex >= 0
-			? _coordinator.InsertStep(_recipeGrid.SelectedRowIndex + 1, firstActionId)
+		var result = _recipeGrid.SelectedStepIndex >= 0
+			? _coordinator.InsertStep(_recipeGrid.SelectedStepIndex + 1, firstActionId)
 			: _coordinator.AppendStep(firstActionId);
 
 		if (result.IsSuccess)
@@ -83,7 +82,7 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 
 	private void DeleteStep()
 	{
-		var indices = _recipeGrid.SelectedRowIndices;
+		var indices = _recipeGrid.SelectedStepIndices;
 		if (indices.Count == 0)
 		{
 			return;

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridHost.axaml
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridHost.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:recipeGrid="clr-namespace:SemiStep.UI.RecipeGrid"
+             mc:Ignorable="d"
+             d:DesignWidth="1600"
+             d:DesignHeight="600"
+             x:Class="SemiStep.UI.RecipeGrid.RecipeGridHost">
+
+    <recipeGrid:CanonicalRecipeGridView x:Name="CanonicalView" />
+
+</UserControl>

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridHost.axaml.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridHost.axaml.cs
@@ -1,0 +1,15 @@
+﻿using Avalonia.Controls;
+
+namespace SemiStep.UI.RecipeGrid;
+
+public partial class RecipeGridHost : UserControl
+{
+	public RecipeGridHost()
+	{
+		InitializeComponent();
+	}
+
+	public IRecipeGridSurface? Surface => DataContext as IRecipeGridSurface;
+
+	public bool IsEditing => CanonicalView.IsEditing;
+}

--- a/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
+++ b/SemiStep/SemiStep.UI/Styles/DataGridStyles.axaml
@@ -100,7 +100,7 @@
     <!-- Grid-level read-only state (PLC sync active).  -->
     <!-- DataGrid.read-only class is toggled from XAML  -->
     <!-- via Classes.read-only binding to               -->
-    <!-- RecipeGridViewModel.IsReadOnly. ComboBox cells -->
+    <!-- CanonicalRecipeGridSurface.IsReadOnly. ComboBox cells -->
     <!-- live in CellTemplate (never CellEditingTemplate -->
     <!-- per Avalonia 12 DataGrid issue #236), so       -->
     <!-- DataGrid.IsReadOnly does not propagate to them -->

--- a/SemiStep/SemiStep.UI/UiDi.cs
+++ b/SemiStep/SemiStep.UI/UiDi.cs
@@ -26,7 +26,9 @@ public static class UiDi
 		services.AddSingleton<IScheduler>(_ => RxSchedulers.MainThreadScheduler);
 		services.AddSingleton<MessagePanelViewModel>();
 		services.AddSingleton<RecipeCoordinator>();
-		services.AddSingleton<RecipeGridViewModel>();
+		services.AddSingleton<CanonicalRecipeGridSurface>();
+		services.AddSingleton<IRecipeGridSurface>(
+			provider => provider.GetRequiredService<CanonicalRecipeGridSurface>());
 		services.AddSingleton<RecipeCommandsViewModel>();
 		services.AddSingleton<ClipboardViewModel>();
 		services.AddSingleton<RecipeFileViewModel>();


### PR DESCRIPTION
## Why

The upcoming transposed grid view (parameters as rows, steps as columns; plan in `Docs/plans/20260520-transposed-grid-view.md` on its branch) needs a second grid implementation next to the canonical one. Today `MainWindow.axaml.cs` owns the `DataGrid` directly and three view-models depend on the concrete `RecipeGridViewModel`, so there is no seam to plug a second view into.

## What changed

- `IRecipeGridSurface` — narrow interface over the grid: step-index selection in both directions (`UpdateSelection` from the view, `RequestSelection`/`SelectionRequests` to the view), `EditorMustClose`, `CanDeleteStep`, `CollectSelectedSteps`, `StepCount`, `Initialize`
- `RecipeGridViewModel` renamed to `CanonicalRecipeGridSurface`, implements the interface; `MainWindowViewModel`, `RecipeCommandsViewModel`, `ClipboardViewModel` take the interface only, no concrete fallback
- grid view code extracted from `MainWindow` into `CanonicalRecipeGridView` (all DataGrid handlers, column building, click-away clearing, editor-close behavior binding); `RecipeGridHost` is the future swap point
- `coordinator.Mutated` subscription moved into the surface constructor; external `App.axaml.cs` wiring and manual test-fixture wiring removed (handler order verified independent)
- editing gate for window shortcuts: view `IsEditing` → `RecipeGridHost` → `MainWindow.OnKeyDown`
- new `Docs/architecture/recipe-grid-surface.md`; stale paths in `cell-change-highlight.md` fixed; plan moved to `Docs/plans/completed/`

## Behavior

Zero observable change for the operator. Handlers moved verbatim; the one structural AXAML change (context menu moved to a wrapping `Panel`) is pinned by a headless right-click test.

## Testing

Suite grew 1092 → 1120, all green. New: 12-case `IRecipeGridSurface` contract base (reused by the transposed plan), `CanonicalRecipeGridView` and `RecipeGridHost` headless tests (edit lifecycle, inapplicable-cell cancel, multi-select ordering, execution-class stamping via production wiring, context menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)