### PR TITLE
perf: reduce transposed grid allocation on the mutation hot path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifi
 ```
 
 Test traits: `[Trait("Component", "Core|Config|UI|Domain|Csv|S7")]`, `[Trait("Area", "<AreaName>")]`,
-`[Trait("Category", "Unit|Integration")]`.
+`[Trait("Category", "Unit|Integration|Performance")]` (Performance = env-gated measurement probes, skipped by default).
 
 Invalid config test cases use an overlay pattern: copy `SemiStep.Tests/YamlConfigs/Standard/` to a temp
 directory and overlay only the differing files from `SemiStep.Tests/YamlConfigs/Invalid/{CaseName}/`.

--- a/Docs/architecture/recipe-grid-surface.md
+++ b/Docs/architecture/recipe-grid-surface.md
@@ -241,6 +241,37 @@ Editing state is a view concern and is not on the interface. The chain:
    `RecipeGridHost.IsEditing` is true, so typing inside a cell editor never deletes or
    cut/pastes steps.
 
+## Allocation characteristics
+
+The transposed surface previously retained ~3x the managed heap of the canonical surface for the
+same recipe and churned gen0 on every mutation. The reductions land in three places:
+
+- **Core analysis cost per mutation.** Every mutation re-analyzes the whole recipe
+  (`RecipeSession.Apply → RecipeAnalyzer.Analyze`), so the analyze path is O(N) per mutation and is
+  kept allocation-lean. `TimingCalculator` resolves each step's action through
+  `RecipeMetadataRegistry.TryGetAction` (a non-allocating `out`-parameter lookup) instead of the
+  `Result<>`-returning `GetAction`, and the snapshot's `StepStartTimes` is a dense `TimeSpan[]`
+  indexed by step position rather than a `Dictionary<int,TimeSpan>`. Readers bounds-check the index
+  and fall back to the old empty/missing behavior. The per-PLC-tick timing path shares
+  `ExtractStepDuration`, so it inherits the same win.
+- **Cell background via a converter, not a style matrix.** The transposed cell background is
+  resolved by a single `IMultiValueConverter`
+  (`TransposedCellBackgroundConverter`) over the full state set
+  `(ForDepth, IsPastStep, IsReadOnly, IsApplicable, IsChanged, IsSelected)` and applied as a local
+  `Border.Background` MultiBinding, reproducing the old document-order last-match-wins precedence.
+  This replaces the descendant-selector background rules in `TransposedGridStyles.axaml`, avoiding
+  the per-cell style-activator / dynamic-resource machinery those rules multiplied. The
+  `TextElement.Foreground` setters stay as style setters (background stripped out), so foreground
+  precedence is unchanged.
+- **Lighter cell VMs and recyclable templates.** Transposed cell view models are plain
+  `INotifyPropertyChanged`, not `ReactiveObject` (nothing observes a cell VM reactively);
+  `StepColumnViewModel.Cells` materialize lazily, so a column never scrolled to or keyboard-traversed
+  never builds its cell VMs; and the per-action metadata dictionaries (Units / FormatKinds /
+  GroupItems) are cached per `ActionDefinition` instead of rebuilt per row. The text and read-only
+  cell templates are `supportsRecycling: true`: the text editor displays through a OneWay converter
+  binding and commits in the focus/key handlers to a cell reference captured on `GotFocus` (a
+  stale-guard), so a still-focused recycled `TextBox` cannot write into the cell it was rebound onto.
+
 ## Context menu placement
 
 The grid's context menu lives on the `Panel` wrapping `RecipeGridHost` in `MainWindow.axaml`

--- a/Docs/plans/completed/20260714-transposed-grid-allocation-reduction.md
+++ b/Docs/plans/completed/20260714-transposed-grid-allocation-reduction.md
@@ -1,0 +1,505 @@
+# Transposed Recipe Grid Allocation Reduction
+
+## Overview
+
+The transposed recipe grid retains ~3x the managed heap of the canonical grid for the same recipe
+and generates heavy per-mutation GC ("active GC") while steps are added. Six heap dumps
+(`dotnet-gcdump`, transposed vs canonical, 8/40/200 steps) established the facts:
+
+- **No leak.** Retained heap plateaus: transposed 56 / 112 / 117 MB at 8 / 40 / 200 steps;
+  canonical 19 / 39 / 41 MB (Debug build). Column virtualization works — realized `ListBoxItem`
+  8 / 18 / 24, `CompositionVisual` plateaus 2453 / 5086 / 5086. Heap grew only +0.13 MB from
+  40 → 200 steps.
+- **The 3x is styling/theming machinery, not raw visual weight.** Per realized cell the transposed
+  grid carries roughly double the style-activator/resource machinery of the canonical grid,
+  exploded by the descendant-selector matrix in `TransposedGridStyles.axaml`.
+- **The "active GC" is per-mutation churn.** Every mutation re-analyzes the whole recipe in Core
+  (`RecipeSession.Apply → RecipeAnalyzer.Analyze`), O(N) per mutation → O(N²) per build,
+  ~165 KB/append at N=500 (transient, returns to baseline after GC). The `supportsRecycling:false`
+  cell templates rebuild each column's visual subtree on every recycle, adding scroll/append churn.
+
+This plan is fixed-cost + churn reduction, not a leak fix. It preserves behavior and the
+always-live-editor design. Work is structured as fix-and-measure: each task lands independently and
+is checked against a heap-dump / allocation-probe delta before moving on.
+
+### Baseline numbers (record; re-measure on Release for clean absolutes)
+
+Delta drivers — transposed minus canonical at 200 steps (Debug, contains `XamlSourceInfo`
+diagnostics, so Release will be lower):
+
+| Type | Δ (tr − nontr) | Source |
+| --- | --- | --- |
+| `DynamicResourceExpression` | +6.3 MB | per-cell style matrix |
+| `StyleInstance` | +4.0 MB | per-cell style matrix |
+| `StyleClassActivator` | +3.4 MB (16.8 vs 8.8 per visual) | descendant selectors |
+| `EventHandler<AvaloniaPropertyChangedEventArgs>` | +2.9 MB | style/binding machinery |
+| `AndActivator` + activator lists | +2.9 MB | compound selectors |
+| `TemplateBindingExpression` | +2.1 MB | per-cell templates |
+| cell-VM ReactiveUI scaffolding | +2.5–3 MB | `ReactiveObject` per cell VM |
+
+Core per-append allocation: ~165 KB at N=500, ~98% in `RecipeAnalyzer.Analyze`.
+
+Core per-append (measured, Debug) — recorded baseline from `CoreAllocationProbe` (config `WithGroups`,
+`RecipeSession.AppendStep`, one append at the given recipe size):
+
+| N (recipe size) | per-append bytes |
+| --- | --- |
+| 10 | 7,368 |
+| 100 | 36,480 |
+| 500 | 164,968 |
+
+The linear growth in per-append bytes with N is the O(N)-per-mutation churn the Core tasks reduce;
+compare later runs against this table.
+
+## Context (from discovery)
+
+- Files/components involved:
+  - Core: `SemiStep/SemiStep.Core/Recipes/Analysis/{TimingCalculator,RecipeAnalyzer,LoopParser}.cs`,
+    `SemiStep/SemiStep.Core/Recipes/RecipeSnapshot.cs` (note: NOT under `Analysis/`),
+    `RecipeSession.cs`, `RecipeMetadataRegistry` (find exact path).
+  - UI: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/{TransposedCellTemplateFactory.cs,StepColumnViewModel.cs,ParameterCellViewModel*.cs,TransposedRecipeGridView.axaml}`,
+    `SemiStep/SemiStep.UI/Styles/TransposedGridStyles.axaml`, `RecipeGridSurfaceBase.cs`,
+    `RecipeRowViewModel.cs`.
+  - Tests: `SemiStep/SemiStep.Tests/UI/RecipeGrid/` + Core analysis tests.
+- Related patterns:
+  - The canonical `DataGrid` binds cells via templates over the row indexer (cell VMs viewport-bound);
+    the transposed grid eagerly builds a `ParameterCellViewModel` per step × parameter and keeps it.
+  - The transposed ComboBox cell template is already `supportsRecycling:true` and binding-driven —
+    it is the model for making the text/readonly templates recyclable.
+- Dependencies / ordering:
+  - **Prerequisite (resolve before Task 2):** the `recipe-grid-mutation-tail-churn` branch
+    (incremental start-time refresh) is unmerged and rewrites `RecipeGridSurfaceBase.cs` including
+    `RefreshStepStartTimes` and `CreateItemChecked`. Task 2 (edits `CreateItemChecked`) and Task 3
+    (changes the `StepStartTimes` type consumed by `RefreshStepStartTimes`) both touch that file, so
+    land the branch first or rebase this work on it. All line numbers below are indicative — verify
+    against the working tree at implementation time.
+
+## Development Approach
+
+- **Testing approach**: Regular (code first, then tests). Behavior must stay identical; correctness
+  is pinned by the existing contract/analysis tests, and each task adds targeted tests.
+- Complete each task fully (code + tests + measurement gate) before the next.
+- Small, focused changes; each task is independently landable and could be its own PR (Core churn
+  tasks may share one PR; each UI lever its own PR given differing risk).
+- **Every task includes new/updated tests** and passes the full suite before the next starts.
+- Keep `dotnet format` clean.
+- **Maintain backward compatibility and visual parity** — the projected values, formatting, and
+  cell appearance across every state combination must be unchanged.
+
+## Testing Strategy
+
+- **Unit / contract tests**: required per task. Core changes are pinned by
+  `SemiStep/SemiStep.Tests/...` analysis/snapshot tests (start-times, loop depths, timing) and the
+  `RecipeGridSurfaceContractTests` (both surfaces). UI-style changes are pinned by headless
+  `[AvaloniaFact]` tests asserting cell background/state for the relevant `ForDepth` × `IsPastStep`
+  × `IsReadOnly` × `IsApplicable` combinations, plus a virtualization/recycling test for the
+  recyclable-template change.
+- **Measurement gate (first-class, "fix and watch")** after each task — not a unit test, a manual
+  check recorded in this plan:
+  - *Core tasks*: run the headless Core allocation probe (Task 1) at N=10/100/500 and record the
+    per-append byte delta vs the previous baseline.
+  - *UI tasks*: on a **Release** build, build the transposed grid to 200 steps,
+    `dotnet-gcdump collect`, `dotnet-gcdump report`, and diff the driver type totals
+    (`DynamicResourceExpression`, `StyleClassActivator`, `StyleInstance`, `CompositionVisual`,
+    `PropertyTextCellViewModel`) against the baseline. Record the delta before moving on.
+- **No e2e**: headless `[AvaloniaFact]` is the harness.
+
+## Progress Tracking
+
+- Mark completed items `[x]` immediately.
+- Record each task's measured delta inline (append to the task section).
+- Add newly discovered work with ➕, blockers with ⚠️.
+
+## Solution Overview
+
+Three cheap, low-risk Core changes cut the per-mutation churn (the "active GC"): stop allocating a
+`Result<>` per step, replace the start-time dictionary with a dense array, and drop redundant LINQ
+in the enclosing-loop map. Three UI changes cut the transposed grid's fixed retained cost and
+scroll/append churn: flatten the per-cell background style matrix into a single binding (kills the
+style-activator explosion), lighten the cell VM layer (plain `INotifyPropertyChanged` + lazy cell
+build + cached action dictionaries), and make the text/readonly cell templates recyclable (kills
+rebuild-on-recycle churn). Higher-risk / design-level levers are deferred and documented.
+
+## Technical Details
+
+- `RecipeMetadataRegistry.TryGetAction(int id, out ActionDefinition action)` — a non-allocating
+  lookup parallel to the existing `Result<>`-returning `GetAction(int id)` (actions are keyed by
+  `int`; `Step.ActionKey` is `int`). Also called per PLC tick via `ExecutionTimeEstimator`, so the
+  win extends beyond the analyze path.
+- `RecipeSnapshot.StepStartTimes` type changes from `IReadOnlyDictionary<int,TimeSpan>` to
+  `IReadOnlyList<TimeSpan>` / `TimeSpan[]`; every reader indexes by dense step index. Update
+  `RecipeSnapshot.Empty` too.
+- Cell background: one `IMultiValueConverter` mapping the FULL state set
+  `(ForDepth, IsPastStep, IsReadOnly, IsApplicable, IsChanged, IsSelected)` to a brush. Note the
+  precedence trap: a `MultiBinding` on `Border.Background` is a LOCAL value and outranks style
+  setters, so the existing `changed`/`selected` background rules can never win over it — they must
+  be folded INTO the converter (reproducing document/last-match-wins order), or the whole thing
+  applied as a style setter (not a local binding) with the changed/selected rules kept after it.
+  Decide which at implementation and pin it with tests. The `Foreground` setters that live inside
+  the read-only/inapplicable/selected rules must be handled explicitly (kept as separate style
+  setters or folded in) — deleting those rules for the background must not drop their foreground.
+  Source brushes from the palette resources `CellPaletteInstaller` installs, not hardcoded colors.
+- Recyclable templates: Avalonia `MultiBinding`/`IMultiValueConverter` is ONE-WAY (no `ConvertBack`).
+  So the text cell becomes a OneWay display `MultiBinding` (mirroring the readonly template's
+  `_displayConverter`), and the edit COMMIT moves entirely into `LostFocus`/`KeyDown` handlers that
+  read the cell from `DataContext` (the `OnComboBoxSelectionChanged` pattern). Stale-guard: capture
+  the cell reference on `GotFocus` (or reset pending text on `DataContextChanged`) and commit only
+  to the captured cell, so a still-focused recycled `TextBox` cannot push text into the new cell.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]`): code, tests, and the per-task measurement gate.
+- **Post-Completion** (no checkboxes): the Release-build gcdump re-measure and subjective
+  scroll/add smoothness check on the running app.
+
+## Explicit Exclusions (deferred / out of scope)
+
+- **Do not** replace the always-live per-cell `TextBox` with a `TextBlock` + swap-editor-on-focus.
+  It is the single largest visual lever but contradicts the stated always-live-editor design and
+  needs a product decision plus focus/tab-navigation rework.
+- **Do not** suspend the inactive surface's VM projection. Click-away/selection sync relies on both
+  surfaces staying live (`RecipeGridSurfaceBase.cs`).
+- **Do not** make Core analysis incremental on append yet — medium risk (loop-marker edge cases,
+  undo/redo). Revisit only if churn is still painful after the Core tasks.
+- **Do not** virtualize the inner per-column `Cells` `ItemsControl` — the parameter axis is ~21
+  fully-visible rows; virtualizing buys nothing and breaks alignment with the frozen name column.
+
+## Implementation Steps
+
+### Task 1: Measurement harness and recorded baseline
+
+**Files:**
+- Create: `SemiStep/SemiStep.Tests/Performance/CoreAllocationProbe.cs` (explicit-trait, manual-run)
+- Modify: this plan file (record baseline)
+
+- [x] Add a headless Core allocation probe: build a recipe by successive appends and measure
+      `GC.GetAllocatedBytesForCurrentThread()` for a single append at recipe size 10 / 100 / 500,
+      pure Core (no grid surface). Gate it behind an explicit trait/category so it does not run in
+      the normal suite; it is a manual measurement tool.
+- [x] Document the gcdump A/B protocol in the probe file header or a short doc note: Release build,
+      transposed to 200 steps, `dotnet-gcdump collect -p <pid> -o <name>.gcdump`,
+      `dotnet-gcdump report`, diff driver type totals.
+- [x] Run the probe once and record the baseline per-append bytes in this plan. (See the
+      "Core per-append (measured, Debug)" table under Baseline numbers: 7,368 / 36,480 / 164,968 bytes
+      at N=10 / 100 / 500.)
+- [x] manual — needs a running Release app + `dotnet-gcdump`; not automatable in a headless run. The
+      Debug per-append baseline table above is recorded; the Release UI driver-type "A" is collected
+      by hand before Task 5–7's A/B (see the gcdump A/B protocol in `CoreAllocationProbe.cs`).
+- [x] Verify the probe compiles and runs; confirm it is excluded from the default `dotnet test` run.
+      (Runs with `SEMISTEP_PROBE=1` → 1 passed; without it → 1 skipped. Solution builds clean;
+      `dotnet format` reports no changes.)
+
+### Task 2: Non-allocating action lookup (Core churn)
+
+**Files:**
+- Modify: `RecipeMetadataRegistry` (add `TryGetAction`)
+- Modify: `SemiStep/SemiStep.Core/Recipes/Analysis/TimingCalculator.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs` (`CreateItemChecked`)
+- Modify: Core/registry tests
+
+- [x] Add `bool TryGetAction(int id, out ActionDefinition action)` to the registry, without
+      allocating a `Result<>` (actions are keyed by `int`).
+- [x] Use it in `TimingCalculator.ExtractStepDuration` (was per-step `GetAction`) and in
+      `RecipeGridSurfaceBase.CreateItemChecked` (keep the fail-loud `UnknownActionKeyException` path).
+      The per-PLC-tick timing path benefits automatically — it flows through
+      `TimingCalculator.ExtractStepDuration`, no separate call site to change.
+- [x] Write tests: `TryGetAction` success + unknown-key false; timing/analyze results unchanged.
+- [x] Run the full suite + the Core probe; record per-append byte delta vs baseline. Must pass.
+
+Measured (Debug, `CoreAllocationProbe`), after vs baseline:
+
+| N | baseline | after | reduction |
+| --- | --- | --- | --- |
+| 10 | 7,368 | 4,200 | −43.0% |
+| 100 | 36,480 | 7,392 | −79.7% |
+| 500 | 164,968 | 20,680 | −87.5% |
+
+Removing the per-step `Result<ActionDefinition>` allocation from `ExtractStepDuration` eliminated the
+dominant O(N)-per-mutation churn; the remaining per-append growth is near-flat with N.
+Full suite: 1305 passed, 1 skipped (probe). `dotnet format`: no changes.
+
+### Task 3: Dense start-time array (Core churn)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/Analysis/TimingCalculator.cs`,
+  `SemiStep/SemiStep.Core/Recipes/RecipeSnapshot.cs` (including `RecipeSnapshot.Empty`)
+- Modify: consumers — `RecipeGridSurfaceBase.RefreshStepStartTimes`,
+  `ExecutionTimeEstimator.TimeLeftInRecipe` (uses `TryGetValue`, needs the same bounds check);
+  grep for any other `StepStartTimes` reader before starting
+- Modify: snapshot/timing tests + both surface test files (`CoreTimingTests`/`CoreMutationTests` and
+  `RecipeGridSurfaceContractTests`)
+
+- [x] Change `StepStartTimes` from `Dictionary<int,TimeSpan>` to a dense `TimeSpan[]` /
+      `IReadOnlyList<TimeSpan>` (indices 0..N-1) and fill it directly in `TimingCalculator`; update
+      `RecipeSnapshot.Empty`.
+- [x] Update every reader to index by step; preserve the empty/missing behavior the dictionary gave
+      (an out-of-range index must behave like the old missing-key path). Readers updated:
+      `RecipeGridSurfaceBase.RefreshStepStartTimes` and `ExecutionTimeEstimator.TimeLeftInRecipe`
+      (both switched from `TryGetValue` to an `index < Count` bounds check returning the old
+      empty-string / `TimeSpan.Zero` fallback), plus the `RecipeGridSurfaceContractTests` oracle.
+- [x] Write/adjust tests: start-times identical to before for append/insert/remove/loop recipes on
+      both surfaces; snapshot start-times correct. Added
+      `TimingCalculatorTests.Calculate_ReturnsDenseStartTimesIndexedByStepIndex` (dense-shape) and
+      `ExecutionTimeEstimatorTests.TimeLeftInRecipe_ActualLineBeyondStartTimes_ReturnsZeroLikeMissingKey`
+      (out-of-range edge). Existing indexer-based timing/mutation/contract tests stay green.
+- [x] Run full suite + Core probe; record delta. Must pass.
+
+Measured (Debug, `CoreAllocationProbe`), after vs Task-2 vs original baseline:
+
+| N | baseline | Task 2 | after | vs Task 2 | vs baseline |
+| --- | --- | --- | --- | --- | --- |
+| 10 | 7,368 | 4,200 | 3,872 | −7.8% | −47.4% |
+| 100 | 36,480 | 7,392 | 5,096 | −31.1% | −86.0% |
+| 500 | 164,968 | 20,680 | 9,992 | −51.7% | −93.9% |
+
+Replacing the two `Dictionary<int,TimeSpan>` start-time allocations (one in `TimingCalculator`, plus
+the boxed hashing entries) with a single dense `TimeSpan[]` roughly halved the remaining per-append
+churn at N=500. Full suite: 1307 passed, 1 skipped (probe). `dotnet format`: no changes.
+
+### Task 4: Trim enclosing-loop map allocations (Core churn)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/RecipeSnapshot.cs` (`BuildEnclosingMap`)
+- Modify: snapshot tests
+
+- [x] Replace the per-row `OrderBy().ToList().AsReadOnly()` with a single in-place `List.Sort`.
+      Declare the builder as `Dictionary<int, IReadOnlyList<LoopInfo>>` and mutate through the
+      concrete `List` reference (a `Dictionary<int,List<>>` is not returnable as the read-only type).
+      `List.Sort` is unstable vs the old stable `OrderBy`, but loops enclosing a given row are
+      strictly nested with distinct depths, so ordering is preserved — assert this in the test.
+      The builder now holds `List<LoopInfo>` values behind the `IReadOnlyList<LoopInfo>` slot,
+      appended via a cast, then each list is sorted in place by `Depth` ascending (outer→inner,
+      the old `OrderBy(l => l.Depth)` key/direction) and the builder is returned directly — no
+      second dictionary pass.
+- [x] Write/adjust tests: enclosing-loop map and loop depths unchanged for nested-loop recipes.
+      Added `CoreLoopEdgeCasesTests.EnclosingLoops_ThreeNested_OrderedOuterToInner` pinning the exact
+      outer→inner order (depths 1/2/3, start indices 0/1/2) for a row inside three nested loops; the
+      existing `EnclosingLoops_OrderedOuterToInner` (two nested) and `EnclosingLoopsMap_CorrectlyBuilt`
+      stay green.
+- [x] Run full suite + Core probe; record delta. Must pass.
+
+Measured (Debug, `CoreAllocationProbe`), after vs Task-3 baseline:
+
+| N | Task 3 | after | reduction |
+| --- | --- | --- | --- |
+| 10 | 3,872 | 3,816 | −1.4% |
+| 100 | 5,096 | 5,040 | −1.1% |
+| 500 | 9,992 | 9,936 | −0.6% |
+
+Caveat: the probe recipe (bare `Wait` steps) has NO loops, so `BuildEnclosingMap` is near-empty there
+and the delta is only the ~56 bytes/append saved by dropping the second dictionary+`AsReadOnly` pass on
+the empty map. This task's real win lands on loop-heavy recipes, where the per-row
+`OrderBy().ToList().AsReadOnly()` re-materialization is eliminated in favor of a single in-place sort.
+Full suite: 1308 passed, 1 skipped (probe). `dotnet format`: no changes.
+
+### Task 5: Flatten the per-cell background style matrix (UI fixed cost)
+
+**Files:**
+- Create: cell-background `IMultiValueConverter` under `SemiStep/SemiStep.UI/...`
+- Modify: `SemiStep/SemiStep.UI/Styles/TransposedGridStyles.axaml`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml` /
+  `TransposedCellTemplateFactory.cs` (bind cell `Border.Background`)
+- Modify: UI tests
+
+- [x] First read ALL background-setting rules in `TransposedGridStyles.axaml` and enumerate the full
+      state set. It is not four inputs: it includes `Border.transposed-cell.changed` (the changed
+      highlight) and the `ListBoxItem:selected Border.transposed-cell...` rules (selection tint), on
+      top of `for-depth-N` / `past-step` / `read-only-cell` / `inapplicable`. Also list the
+      `TextElement.Foreground` setters that live inside those rules.
+- [x] Add a converter over the full input set
+      `(ForDepth, IsPastStep, IsReadOnly, IsApplicable, IsChanged, IsSelected)` → brush, reproducing
+      the existing document-order (last-match-wins) precedence exactly. Five inputs are cell/row VM
+      properties; `IsSelected` has NO VM property — bind `$parent[ListBoxItem].IsSelected` in the
+      template (or add a synced VM property). Source brushes from the palette resources the
+      `CellPaletteInstaller` / `ExecutionPaletteInstaller` install (selection brushes come from the
+      theme layer).
+- [x] Resolve the local-value-vs-style precedence: EITHER fold the changed/selected rules into the
+      converter and apply it as the cell `Border.Background` (local value), OR apply the converter as
+      a style SETTER (not a local binding) and keep the changed/selected rules after it. Pick one and
+      state which in the plan. Handle the `Foreground` setters explicitly (keep as separate style
+      setters or fold in) — removing background rules must not drop their foreground.
+- [x] Remove the now-redundant descendant-selector background rules from `TransposedGridStyles.axaml`.
+- [x] Write `[AvaloniaFact]` tests asserting the resolved cell background AND foreground for the FULL
+      state matrix — every `ForDepth` × `IsPastStep` × `IsReadOnly` × `IsApplicable` × `IsChanged` ×
+      `IsSelected` combination that the old rules produced — matches the pre-change brush.
+- [x] Run full suite; must pass. Measurement gate: Release gcdump A/B — record
+      `DynamicResourceExpression` / `StyleClassActivator` / `StyleInstance` deltas.
+      **Manual** — the gcdump A/B needs a running Release app + `dotnet-gcdump` (not automatable in a
+      headless run). Follow the protocol in `CoreAllocationProbe.cs`; the 29 removed
+      background setter rules are expected to drop `DynamicResourceExpression` /
+      `StyleClassActivator` / `AndActivator` / `StyleInstance` per realized cell.
+
+**Precedence approach (local binding).** Chose option (a): the full state matrix
+`(ForDepth, IsPastStep, IsReadOnly, IsApplicable, IsChanged, IsSelected)` — including the changed and
+selection tints — is folded into `TransposedCellBackgroundConverter` and applied as a **local**
+`Border.Background` MultiBinding in `TransposedRecipeGridView.axaml`. A local value outranks every
+style setter, so all 29 background setter rules (base / read-only / inapplicable / the
+exec depth·past chains / changed / the four selection variants) were removed from
+`TransposedGridStyles.axaml`. The converter reproduces the old document-order, last-match-wins
+precedence exactly: selection wins over everything (changed > inapplicable > read-only > plain
+selection among selected cells), else changed beats the depth/read-only/inapplicable tints, else
+inapplicable > read-only, else the execution depth/past tint (depth-0 idle = plain grid background).
+Brushes resolve through the target `Border` as an `IResourceHost` (`TryFindResource`), so the same
+visual-tree + application `{DynamicResource}` lookup still applies (works for both the app-scoped
+production install and window-scoped test installs).
+
+**Foreground handling (kept as style setters).** The read-only / inapplicable / selected rules also
+set `TextElement.Foreground`; those setters were kept (background stripped out of them). The four
+selected variants set the identical `SelectionForegroundBrush`, so they collapse to one
+`ListBoxItem:selected Border.transposed-cell` foreground rule. Result: three foreground setters
+survive (`read-only-cell` → `CellReadOnlyForegroundBrush`, `inapplicable` → `CellDisabledForegroundBrush`
+with inapplicable last so it wins when both, and `:selected` → `SelectionForegroundBrush` last).
+Foreground precedence is unchanged by construction.
+
+**Tests.** `TransposedCellBackgroundConverterTests` cross-checks the converter against an independent
+oracle (a literal transcription of the 29 old rules, last-match-wins) over the full 256-combo state
+matrix, plus depth clamp (≥3 → depth-3) and negative-depth (→ depth-0) cases.
+`TransposedCellStyleRenderTests` renders the real grid and asserts the live `Border.Background` (grid /
+disabled / changed / selection families) and the kept `TextElement.Foreground` setters resolve to the
+installed palette brushes. (The `WithGroups` test config has no read-only column, so the read-only
+class is exercised at the converter level, not the render level.) Full suite: 1316 passed, 1 skipped
+(the manual Core probe). `dotnet format` (UI + Tests): no changes.
+
+### Task 6: Lighten the cell view-model layer (UI per-step growth)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/ParameterCellViewModel*.cs` (and subtypes)
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/StepColumnViewModel.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs`
+- Modify: UI tests
+
+- [x] Convert `ParameterCellViewModel` and its subtypes from `ReactiveObject` to plain
+      `INotifyPropertyChanged` (they only raise `PropertyChanged`; verify nothing `WhenAnyValue`s a
+      cell VM before changing).
+- [x] Materialize `StepColumnViewModel.Cells` lazily so never-visited columns never build the cell
+      VMs; ensure `Dispose` tolerates an unmaterialized `Cells`. Note the win is bounded: once a
+      column is scrolled to or keyboard-traversed, `TransposedGridNavigator` reads its `Cells` and
+      materialization is permanent — savings cover only columns never reached, not all off-screen.
+- [x] Cache the action-derived dictionaries (Units / FormatKinds / GroupItems) per `ActionDefinition`
+      instead of rebuilding them per row in `RecipeRowViewModel`.
+- [x] Write tests: cell values/formatting and change notifications unchanged on both surfaces; a
+      disposed column with unmaterialized cells disposes cleanly.
+- [x] Run full suite; must pass. Measurement gate: Release gcdump A/B — record
+      `PropertyTextCellViewModel` + ReactiveUI-scaffolding deltas.
+      **Manual** — the gcdump A/B needs a running Release app + `dotnet-gcdump` (not automatable in a
+      headless run). Follow the protocol in `CoreAllocationProbe.cs`; per realized cell the removed
+      `ReactiveObject` base (dropping the per-VM `PropertyChangedEventManager`/`Subject` scaffolding)
+      is expected to lower the `PropertyTextCellViewModel` + ReactiveUI-scaffolding totals, and lazy
+      `Cells` removes cell VMs entirely for columns never scrolled to.
+
+**Reactive-observer check.** Grepped the whole solution for `WhenAnyValue` / `ObservableForProperty` /
+`.Changed` / `.Changing` targeting a cell VM: none exists. Cell VMs are consumed only through Avalonia
+`{Binding}` (plain `INotifyPropertyChanged`) on `Value` / `IsApplicable` / `IsChanged` / `FormatKind` /
+`Units` / `Items` and by direct reads in `TransposedGridNavigator`. The base was flipped from
+`ReactiveObject` to `INotifyPropertyChanged` with a minimal `RaisePropertyChanged` helper; the same
+properties notify with the same guard-on-unchanged semantics (the guards live in `RecipeRowViewModel`,
+which stays `ReactiveObject`, so cell notifications are unchanged). Subtypes (`PropertyTextCellViewModel`,
+`ReadOnlyCellViewModel`, `ComboBoxCellViewModel`) carried no reactive members and needed no change.
+
+**Caching scope.** The `(Units, FormatKinds, GroupItemsByColumn)` triple is cached per
+`ActionDefinition` in a static `ConditionalWeakTable<ActionDefinition, ActionColumnMetadata>` on
+`RecipeRowViewModel`. The registry hands out a stable `ActionDefinition` instance per action id
+(`_actionsById[id]`), so the reference key gives one shared, immutable metadata set across every row
+with that action; the weak table lets an entry drop when its action (a discarded test registry) is
+collected. The dictionaries are build-once and read-only, so sharing is safe. Pinned by
+`RecipeRowViewModelTests.ActionMetadata_TwoRowsSameAction_ShareCachedDictionaries` (reference-equal).
+
+### Task 7: Recyclable text/readonly cell templates (UI churn)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs`
+- Modify: UI tests
+
+- [x] Make the text `TextBox.Text` a OneWay DISPLAY `MultiBinding` fed `FormatKind`/`MaxLength` into
+      a shared stateless converter (mirror the readonly template's `_displayConverter`), NOT a TwoWay
+      binding — Avalonia `MultiBinding` has no `ConvertBack`. Bind `TextBox.MaxLength` instead of
+      baking it. New `PropertyTextEditingMultiConverter` reproduces the old per-cell
+      `PropertyTimeEditingConverter.Convert` exactly (units-less, `value.ToString()`); `MaxLength`
+      binds through a null→0 converter (0 = Semi's "unlimited", matching the old leave-unset default).
+- [x] Move the edit COMMIT out of the binding into the `LostFocus` / `KeyDown` handlers, reading the
+      cell from `DataContext` (the `OnComboBoxSelectionChanged` pattern). Implement the stale-guard:
+      capture the cell on `GotFocus` (or reset pending text on `DataContextChanged`) and commit ONLY
+      to the captured cell, so a still-focused recycled `TextBox` cannot write into the new cell.
+- [x] Set `supportsRecycling: true` on the text and read-only templates.
+- [x] Write tests: a recycling/virtualization test covering the focused-editor-scrolled-out-of-view
+      case (assert no stale write into the recycled-into cell); container reuse without stale-cell
+      writes; edit/commit still works; formatting unchanged; rejected/unparseable commit snaps the
+      display back and Escape-cancel restores the original value (both unchanged from today).
+- [x] Run full suite; must pass. Measurement gate: this is CHURN, not retained heap — use
+      `dotnet-counters` (gen0 count, allocation rate) or a `dotnet-trace` GC-events capture while
+      scrolling/adding, and note subjective GC/jank. (gcdump measures retention, not churn.)
+      **Manual** — gen0/alloc-rate via `dotnet-counters` on a running app while scrolling/adding is
+      not automatable in a headless run; expected drop in per-scroll allocation as the cell subtree is
+      reused rather than rebuilt on recycle.
+
+**Stale-guard implementation (captured-cell, per-editor attached property).** The edit target is
+pinned on `GotFocus` into a private `AttachedProperty<PropertyTextCellViewModel?>` (`EditingCell`) on
+the `TextBox` itself, so each recycled editor carries its own captured cell. `CommitEditor` writes
+ONLY to that captured cell — never `DataContext` — so a still-focused editor rebound onto a different
+cell (recycle) commits its pending text to the cell the user was editing and can never leak it into
+the rebind-target cell. The display snap-back runs only while `DataContext` still equals the captured
+cell; after a rebind the OneWay display binding already shows the new cell, so it is left untouched.
+This keeps the existing `PendingEdit_CommitsWhenItsColumnIsRecycledOut` behavior (recycle-out commits
+to the correct cell) intact.
+
+**Reject/Escape preserved: yes.** The commit reuses the exact former parse (`ParseForCommit`, factored
+out of `PropertyTimeEditingConverter.ConvertBack`), so rejected/unparseable input returns
+`BindingOperations.DoNothing` (no write) and the snap-back restores the model's formatted value — same
+as before. Escape overwrites the pending text with the captured cell's formatted value, then the
+ensuing commit re-parses that reverted text to an unchanged (no-op) write. Read-only-dropped edits are
+unchanged: the write still flows through the coordinator's read-only guard.
+
+**Tests.** `TransposedEditingTests.RecycledEditor_CommitsToCapturedCell_NotTheRebindTarget` rebinds a
+focused editor's `DataContext` onto another column's cell and asserts the pending "777" lands on the
+captured cell, not the rebind target (would fail with a naive `DataContext`-reading commit).
+`TransposedVirtualizationTests.FocusedEditorWithPendingText_RecycledAcrossScroll_DoesNotCorruptOtherCells`
+scrolls a real narrow-viewport grid with a pending edit and asserts no other column is corrupted;
+`RecycledTextEditor_ShowsRebindTargetCellValue_AfterScroll` asserts a recycled editor renders its
+rebind-target cell's formatted value. Existing editing/selector/contract tests (commit, HMS
+formatting, invalid-stays-uncommitted, Escape-reverts, read-only-drop, MaxLength) stay green against
+the recyclable template. Full suite: 1323 passed, 1 skipped (manual Core probe). `dotnet format`
+(UI + Tests): no changes.
+
+### Task 8: Verify acceptance criteria
+- [x] Confirm behavior and visual parity are unchanged (contract + style-matrix + recycling tests
+      green on both surfaces). Contract tests both surfaces (`RecipeGridSurfaceContractTests`,
+      `TransposedRecipeGridSurfaceContractTests`, `CanonicalRecipeGridSurfaceContractTests`), the
+      Task 5 cell-background parity tests (`TransposedCellBackgroundConverterTests`,
+      `TransposedCellStyleRenderTests`), and the Task 7 recycling tests (`TransposedEditingTests`,
+      `TransposedVirtualizationTests`) are all present and green (86 in the combined filter).
+- [x] Run the full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`.
+      Result: 1323 passed, 1 skipped (the gated Core allocation probe), 0 failed.
+- [x] Confirm `dotnet format` reports no changes. (This dotnet-format version rejects a `.slnx`
+      path, so verified per project — `SemiStep.Core`, `SemiStep.UI`, `SemiStep.Tests` all clean.)
+- [x] manual — collect on running Release app; the UI retained-heap reduction
+      (DynamicResourceExpression/StyleClassActivator/StyleInstance from Task 5,
+      PropertyTextCellViewModel/ReactiveUI scaffolding from Task 6) is verified by the headless
+      parity/behavior tests but its byte reduction is measured by hand. Collect a final Release
+      gcdump at 200 steps transposed per the protocol in `CoreAllocationProbe.cs` and diff the
+      driver-type totals vs the Debug "A" baseline.
+
+**Final Core allocation probe (Debug, `CoreAllocationProbe`), cumulative vs original baseline:**
+
+| N | original baseline | final | cumulative reduction |
+| --- | --- | --- | --- |
+| 10 | 7,368 | 3,816 | −48.2% |
+| 100 | 36,480 | 5,040 | −86.2% |
+| 500 | 164,968 | 9,936 | −94.0% |
+
+The four Core churn tasks (non-allocating action lookup, dense start-time array, trimmed
+enclosing-loop map, plus the earlier `Result<>` removal) cut the per-append allocation at N=500 from
+164,968 to 9,936 bytes — a 94.0% cumulative reduction — and flattened the O(N) per-mutation growth.
+Full suite: 1323 passed, 1 skipped. Format (Core/UI/Tests): no changes.
+
+### Task 9: [Final] Update documentation
+- [x] Note the allocation characteristics in `Docs/architecture/recipe-grid-surface.md` (Core
+      analysis cost per mutation; transposed cell-background via converter; recyclable cell templates).
+- [x] (harness moves the plan after all phases finish) Move this plan to `Docs/plans/completed/`.
+
+## Post-Completion
+*Informational only — no checkboxes.*
+
+**Manual verification:**
+- Rebuild Release, build a large recipe by paste and one-by-one adds on the transposed grid, and
+  confirm the GC/jank is gone and total retained heap dropped toward the canonical grid's.
+- Re-run the full gcdump A/B on Release for clean absolute numbers (the baseline dumps were Debug).

--- a/SemiStep/SemiStep.Core/Recipes/Analysis/ExecutionTimeEstimator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Analysis/ExecutionTimeEstimator.cs
@@ -33,10 +33,12 @@ public static class ExecutionTimeEstimator
 			return TimeSpan.Zero;
 		}
 
-		if (!snapshot.StepStartTimes.TryGetValue(info.ActualLine, out var stepStart))
+		if (info.ActualLine >= snapshot.StepStartTimes.Count)
 		{
 			return TimeSpan.Zero;
 		}
+
+		var stepStart = snapshot.StepStartTimes[info.ActualLine];
 
 		var loopOffset = ComputeLoopOffset(snapshot, info);
 		var elapsed = TimeSpan.FromSeconds(info.StepCurrentTime);

--- a/SemiStep/SemiStep.Core/Recipes/Analysis/TimingCalculator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Analysis/TimingCalculator.cs
@@ -5,14 +5,14 @@ internal static class TimingCalculator
 	private static readonly PropertyId _durationProperty = new("step_duration");
 
 	public static (
-		IReadOnlyDictionary<int, TimeSpan> StepStartTimes,
+		IReadOnlyList<TimeSpan> StepStartTimes,
 		TimeSpan TotalDuration,
 		IReadOnlyDictionary<int, TimeSpan> SingleIterationDurations) Calculate(
 		Recipe recipe,
 		IReadOnlyList<LoopInfo> loops,
 		RecipeMetadataRegistry registry)
 	{
-		var startTimes = new Dictionary<int, TimeSpan>(recipe.Steps.Count);
+		var startTimes = new TimeSpan[recipe.Steps.Count];
 		var singleIterations = new Dictionary<int, TimeSpan>();
 		var accumulated = TimeSpan.Zero;
 
@@ -49,14 +49,13 @@ internal static class TimingCalculator
 
 	internal static TimeSpan ExtractStepDuration(Step step, RecipeMetadataRegistry registry)
 	{
-		var actionResult = registry.GetAction(step.ActionKey);
-		if (actionResult.IsFailed)
+		if (!registry.TryGetAction(step.ActionKey, out var action))
 		{
 			throw new InvalidOperationException(
 				$"Step references unknown action id {step.ActionKey}");
 		}
 
-		if (actionResult.Value.DeployDuration == DeployDuration.Immediate)
+		if (action.DeployDuration == DeployDuration.Immediate)
 		{
 			return TimeSpan.Zero;
 		}

--- a/SemiStep/SemiStep.Core/Recipes/RecipeMetadataRegistry.cs
+++ b/SemiStep/SemiStep.Core/Recipes/RecipeMetadataRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 using FluentResults;
 
@@ -111,6 +112,11 @@ public sealed class RecipeMetadataRegistry
 	public Result<ActionDefinition> GetAction(int id)
 	{
 		return TryGetOrFail(_actionsById, id, $"Action with id {id} not found");
+	}
+
+	public bool TryGetAction(int id, [MaybeNullWhen(false)] out ActionDefinition action)
+	{
+		return _actionsById.TryGetValue(id, out action);
 	}
 
 	public Result<ActionDefinition> GetActionByName(string name)

--- a/SemiStep/SemiStep.Core/Recipes/RecipeSnapshot.cs
+++ b/SemiStep/SemiStep.Core/Recipes/RecipeSnapshot.cs
@@ -3,7 +3,7 @@
 public record struct RecipeSnapshot(
 	Recipe Recipe,
 	TimeSpan TotalDuration,
-	IReadOnlyDictionary<int, TimeSpan> StepStartTimes,
+	IReadOnlyList<TimeSpan> StepStartTimes,
 	IReadOnlyList<LoopInfo> Loops,
 	IReadOnlyDictionary<int, LoopInfo> LoopByStart,
 	IReadOnlyDictionary<int, LoopInfo> LoopByEnd,
@@ -14,7 +14,7 @@ public record struct RecipeSnapshot(
 	public static readonly RecipeSnapshot Empty = new(
 		Recipe.Empty,
 		TimeSpan.Zero,
-		new Dictionary<int, TimeSpan>(),
+		[],
 		[],
 		new Dictionary<int, LoopInfo>(),
 		new Dictionary<int, LoopInfo>(),
@@ -25,7 +25,7 @@ public record struct RecipeSnapshot(
 	public static RecipeSnapshot Create(
 		Recipe recipe,
 		TimeSpan totalDuration,
-		IReadOnlyDictionary<int, TimeSpan> stepStartTimes,
+		IReadOnlyList<TimeSpan> stepStartTimes,
 		IReadOnlyList<LoopInfo> loops,
 		IReadOnlyDictionary<int, TimeSpan> singleIterationDurations)
 	{
@@ -67,26 +67,30 @@ public record struct RecipeSnapshot(
 
 	private static Dictionary<int, IReadOnlyList<LoopInfo>> BuildEnclosingMap(IReadOnlyList<LoopInfo> loops)
 	{
-		var builder = new Dictionary<int, List<LoopInfo>>();
+		var builder = new Dictionary<int, IReadOnlyList<LoopInfo>>();
 
 		foreach (var loop in loops)
 		{
 			for (var i = loop.StartIndex + 1; i < loop.EndIndex; i++)
 			{
-				if (!builder.TryGetValue(i, out var list))
+				if (builder.TryGetValue(i, out var existing))
 				{
-					list = [];
-					builder[i] = list;
+					((List<LoopInfo>)existing).Add(loop);
 				}
-
-				list.Add(loop);
+				else
+				{
+					builder[i] = new List<LoopInfo> { loop };
+				}
 			}
 		}
 
-		return builder.ToDictionary(
-			kvp => kvp.Key, IReadOnlyList<LoopInfo> (kvp) => kvp.Value
-				.OrderBy(l => l.Depth)
-				.ToList()
-				.AsReadOnly());
+		// In-place unstable sort is safe: loops enclosing a given row are strictly nested,
+		// so their depths are distinct and no tie can reorder equal keys.
+		foreach (var list in builder.Values)
+		{
+			((List<LoopInfo>)list).Sort(static (left, right) => left.Depth.CompareTo(right.Depth));
+		}
+
+		return builder;
 	}
 }

--- a/SemiStep/SemiStep.Tests/Core/Integration/Loops/CoreLoopEdgeCasesTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Loops/CoreLoopEdgeCasesTests.cs
@@ -58,4 +58,34 @@ public sealed class CoreLoopEdgeCasesTests(CoreFixture fixture) : IClassFixture<
 		enclosing[0].StartIndex.Should().Be(0, "outer loop starts at index 0");
 		enclosing[1].StartIndex.Should().Be(1, "inner loop starts at index 1");
 	}
+
+	[Fact]
+	public void EnclosingLoops_ThreeNested_OrderedOuterToInner()
+	{
+		fixture.Session.Reset();
+
+		var driver = new RecipeTestDriver(fixture.Session);
+		driver
+			.AddFor(4)
+			.AddFor(3)
+			.AddFor(2)
+			.AddWait(1f)
+			.AddEndFor()
+			.AddEndFor()
+			.AddEndFor();
+
+		driver.IsValid.Should().BeTrue();
+		driver.Snapshot.Loops.Should().HaveCount(3);
+
+		var enclosing = driver.Snapshot.EnclosingLoops[3];
+		enclosing.Should().HaveCount(3);
+
+		enclosing[0].Depth.Should().Be(1, "outermost loop is depth 1");
+		enclosing[1].Depth.Should().Be(2, "middle loop is depth 2");
+		enclosing[2].Depth.Should().Be(3, "innermost loop is depth 3");
+
+		enclosing[0].StartIndex.Should().Be(0, "outermost loop starts at index 0");
+		enclosing[1].StartIndex.Should().Be(1, "middle loop starts at index 1");
+		enclosing[2].StartIndex.Should().Be(2, "innermost loop starts at index 2");
+	}
 }

--- a/SemiStep/SemiStep.Tests/Core/Integration/Loops/RecipeSnapshotRowLoopDepthsTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Integration/Loops/RecipeSnapshotRowLoopDepthsTests.cs
@@ -101,7 +101,7 @@ public sealed class RecipeSnapshotRowLoopDepthsTests
 		return RecipeSnapshot.Create(
 			recipe,
 			TimeSpan.Zero,
-			new Dictionary<int, TimeSpan>(),
+			[],
 			loops,
 			new Dictionary<int, TimeSpan>());
 	}

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Analysis/ExecutionTimeEstimatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Analysis/ExecutionTimeEstimatorTests.cs
@@ -113,6 +113,35 @@ public sealed class ExecutionTimeEstimatorTests
 	}
 
 	[Fact]
+	public void TimeLeftInRecipe_ActualLineBeyondStartTimes_ReturnsZeroLikeMissingKey()
+	{
+		var registry = BuildRegistry();
+		var recipe = new Recipe(ImmutableList.Create(
+			BuildStep(LongLastingActionId, 10f)));
+		var snapshot = BuildSnapshot(recipe, Array.Empty<LoopInfo>(), registry);
+
+		var result = ExecutionTimeEstimator.TimeLeftInRecipe(snapshot, Info(5, 0f));
+
+		result.Should().Be(TimeSpan.Zero,
+			"an out-of-range step index yields the same zero the missing dictionary key gave");
+	}
+
+	[Fact]
+	public void TimeLeftInRecipe_NegativeActualLine_ReturnsZeroLikeMissingKey()
+	{
+		var registry = BuildRegistry();
+		var recipe = new Recipe(ImmutableList.Create(
+			BuildStep(LongLastingActionId, 10f)));
+		var snapshot = BuildSnapshot(recipe, Array.Empty<LoopInfo>(), registry);
+
+		var result = ExecutionTimeEstimator.TimeLeftInRecipe(snapshot, Info(-1, 0f));
+
+		result.Should().Be(TimeSpan.Zero,
+			"a negative step index must not index the start-time array; it yields the same zero the "
+			+ "missing dictionary key gave");
+	}
+
+	[Fact]
 	public void TimeLeftInRecipe_LinearRecipeAtLastStepFinished_IsZero()
 	{
 		var registry = BuildRegistry();

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Analysis/TimingCalculatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/Analysis/TimingCalculatorTests.cs
@@ -152,4 +152,25 @@ public sealed class TimingCalculatorTests
 		singleIterations[0].Should().Be(outerSingle);
 		totalDuration.Should().Be(outerSingle * OuterIterations);
 	}
+
+	[Fact]
+	public void Calculate_ReturnsDenseStartTimesIndexedByStepIndex()
+	{
+		var registry = BuildRegistry();
+		var recipe = new Recipe(ImmutableList.Create(
+			BuildStep(LongLastingActionId, 10f),
+			BuildStep(LongLastingActionId, 20f),
+			BuildStep(LongLastingActionId, 30f)));
+
+		var (startTimes, _, _) = TimingCalculator.Calculate(
+			recipe,
+			Array.Empty<LoopInfo>(),
+			registry);
+
+		startTimes.Should().HaveCount(recipe.Steps.Count,
+			"start-times are a dense list with one slot per step");
+		startTimes[0].Should().Be(TimeSpan.Zero);
+		startTimes[1].Should().Be(TimeSpan.FromSeconds(10));
+		startTimes[2].Should().Be(TimeSpan.FromSeconds(30));
+	}
 }

--- a/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeMetadataRegistryTests.cs
+++ b/SemiStep/SemiStep.Tests/Core/Unit/Recipes/RecipeMetadataRegistryTests.cs
@@ -98,6 +98,30 @@ public sealed class RecipeMetadataRegistryTests
 	}
 
 	[Fact]
+	public void TryGetAction_KnownId_ReturnsTrueAndAction()
+	{
+		var registry = BuildNestedRegistry();
+
+		var found = registry.TryGetAction(300, out var action);
+
+		found.Should().BeTrue();
+		action.Should().NotBeNull();
+		action!.Id.Should().Be(300);
+		action.Should().BeSameAs(registry.GetAction(300).Value);
+	}
+
+	[Fact]
+	public void TryGetAction_UnknownId_ReturnsFalseAndDefault_WithoutThrowing()
+	{
+		var registry = BuildNestedRegistry();
+
+		var found = registry.TryGetAction(999, out var action);
+
+		found.Should().BeFalse();
+		action.Should().BeNull();
+	}
+
+	[Fact]
 	public void Subaction_DoesNotEnterRuntimeActionCollections()
 	{
 		var registry = BuildNestedRegistry();

--- a/SemiStep/SemiStep.Tests/Performance/CoreAllocationProbe.cs
+++ b/SemiStep/SemiStep.Tests/Performance/CoreAllocationProbe.cs
@@ -1,0 +1,73 @@
+﻿using SemiStep.Core.Recipes;
+
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.Helpers;
+
+using Xunit;
+
+namespace SemiStep.Tests.Performance;
+
+// Manual measurement tool, NOT part of the normal suite (Fact.Explicit). Run it directly:
+//   dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName~CoreAllocationProbe"
+// It reports the transient bytes a single Core append allocates (RecipeSession.Apply ->
+// RecipeAnalyzer.Analyze -> TimingCalculator/RecipeSnapshot) at growing recipe sizes. The per-append
+// figure scaling with N is the O(N)-per-mutation / O(N^2)-per-build churn that the Core tasks of
+// Docs/plans/20260714-transposed-grid-allocation-reduction.md reduce. Re-run it before/after each
+// Core task and compare against the recorded baseline. Results are written to
+// %TEMP%/semistep_core_probe.txt.
+//
+// gcdump A/B protocol for the UI tasks (retained heap; needs a running RELEASE app):
+//   dotnet-gcdump collect -p <pid> -o <name>.gcdump ; dotnet-gcdump report <name>.gcdump
+// Diff type totals (DynamicResourceExpression / StyleClassActivator / StyleInstance /
+// CompositionVisual / PropertyTextCellViewModel) between the transposed and canonical grids at
+// 200 steps. For the recycling churn gate (Task 7) use dotnet-counters (gen0 count, allocation
+// rate) or a dotnet-trace GC-events capture while scrolling/adding, not gcdump.
+[Trait("Category", "Performance")]
+[Trait("Component", "Core")]
+public sealed class CoreAllocationProbe
+{
+	private const int WarmupSize = 50;
+
+	[Fact]
+	public async Task Report_PerAppend_CoreAllocation()
+	{
+		Assert.SkipUnless(
+			Environment.GetEnvironmentVariable("SEMISTEP_PROBE") == "1",
+			"Measurement probe: set SEMISTEP_PROBE=1 to run.");
+
+		var (_, session, _) = await CoreTestHelper.BuildAsync("WithGroups");
+
+		// Warm the JIT and analysis paths so the measured samples are steady-state.
+		MeasureSingleAppend(session, WarmupSize);
+
+		var sizes = new[] { 10, 100, 500 };
+		var lines = new List<string>();
+		foreach (var size in sizes)
+		{
+			var bytes = MeasureSingleAppend(session, size);
+			Assert.True(bytes > 0, $"expected a positive per-append allocation at N={size}");
+			lines.Add($"N={size,4}  per-append = {bytes,12:N0} bytes");
+		}
+
+		var report = string.Join(Environment.NewLine, lines);
+		var path = Path.Combine(Path.GetTempPath(), "semistep_core_probe.txt");
+		File.WriteAllText(path, report);
+	}
+
+	// Resets the session, grows the recipe to seedSize steps, then measures the thread-local bytes
+	// allocated by exactly one more append at recipe size == seedSize.
+	private static long MeasureSingleAppend(RecipeSession session, int seedSize)
+	{
+		session.Reset().EnsureSuccess("probe reset");
+		for (var i = 0; i < seedSize; i++)
+		{
+			session.AppendStep(RecipeTestDriver.WaitActionId).EnsureSuccess("probe seed append");
+		}
+
+		var before = GC.GetAllocatedBytesForCurrentThread();
+		session.AppendStep(RecipeTestDriver.WaitActionId).EnsureSuccess("probe measured append");
+		var after = GC.GetAllocatedBytesForCurrentThread();
+
+		return after - before;
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridSurfaceContractTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridSurfaceContractTests.cs
@@ -549,12 +549,12 @@ public abstract class RecipeGridSurfaceContractTests : IAsyncLifetime
 	private string ExpectedStartTime(int index)
 	{
 		var stepStartTimes = Fixture.Coordinator.Snapshot.StepStartTimes;
-		if (!stepStartTimes.TryGetValue(index, out var time))
+		if (index >= stepStartTimes.Count)
 		{
 			return string.Empty;
 		}
 
-		var rawSeconds = time.TotalSeconds.ToString(CultureInfo.InvariantCulture);
+		var rawSeconds = stepStartTimes[index].TotalSeconds.ToString(CultureInfo.InvariantCulture);
 		return TimeFormatHelper.FormatValue(
 			rawSeconds,
 			TimeFormatHelper.TimeHmsFormat,

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/ParameterCellViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/ParameterCellViewModelTests.cs
@@ -177,6 +177,24 @@ public sealed class ParameterCellViewModelTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
+	public void Cell_IsPlainInpc_AndRaisesForValueAndChanged()
+	{
+		var row = CreateRow(RecipeTestDriver.WaitActionId);
+		var cell = CreateFactory().Create(row, FindDescriptor(RecipeTestDriver.StepDurationColumn));
+		cell.Should().BeAssignableTo<System.ComponentModel.INotifyPropertyChanged>();
+		cell.Should().NotBeAssignableTo<ReactiveUI.IReactiveObject>();
+		var changedProperties = new List<string?>();
+		cell.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+
+		row.UpdateStep(_fixture.Coordinator.CurrentRecipe.Steps[0]);
+		row.MarkChanged([RecipeTestDriver.StepDurationColumn]);
+		row.RecomputeInapplicableColumns();
+
+		changedProperties.Should().Contain(nameof(ParameterCellViewModel.Value));
+		changedProperties.Should().Contain(nameof(ParameterCellViewModel.IsChanged));
+	}
+
+	[AvaloniaFact]
 	public void Cell_IsChanged_TracksRowChangedColumns()
 	{
 		var row = CreateRow(RecipeTestDriver.WaitActionId);

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/StepColumnViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/StepColumnViewModelTests.cs
@@ -82,6 +82,46 @@ public sealed class StepColumnViewModelTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
+	public void Dispose_WithoutAccessingCells_DoesNotMaterialize()
+	{
+		var built = 0;
+		var column = CreateColumn(
+			out _,
+			(row, descriptor) =>
+			{
+				built++;
+				return new TestParameterCellViewModel(row, descriptor);
+			});
+
+		var dispose = column.Dispose;
+
+		dispose.Should().NotThrow();
+		built.Should().Be(0, "a column never asked for its cells must not build any cell view-models");
+	}
+
+	[AvaloniaFact]
+	public void Cells_AreMaterializedLazily_AndCachedAcrossAccess()
+	{
+		var built = 0;
+		var column = CreateColumn(
+			out var descriptors,
+			(row, descriptor) =>
+			{
+				built++;
+				return new TestParameterCellViewModel(row, descriptor);
+			});
+
+		built.Should().Be(0, "constructing the column must not build cells");
+
+		var firstAccess = column.Cells;
+
+		built.Should().Be(descriptors.Count);
+		firstAccess.Select(cell => cell.Descriptor).Should().Equal(descriptors);
+		column.Cells.Should().BeSameAs(firstAccess, "repeated access must reuse the materialized cell set");
+		built.Should().Be(descriptors.Count, "a second access must not rebuild the cells");
+	}
+
+	[AvaloniaFact]
 	public void Dispose_CascadesToWrappedRowViewModel()
 	{
 		var column = CreateColumn(out _);
@@ -94,7 +134,9 @@ public sealed class StepColumnViewModelTests : IAsyncLifetime
 		propertyWrites.Should().BeEmpty();
 	}
 
-	private StepColumnViewModel CreateColumn(out IReadOnlyList<ParameterDescriptor> descriptors)
+	private StepColumnViewModel CreateColumn(
+		out IReadOnlyList<ParameterDescriptor> descriptors,
+		Func<RecipeRowViewModel, ParameterDescriptor, ParameterCellViewModel>? cellFactory = null)
 	{
 		_fixture.SeedRecipe(1);
 		var step = _fixture.Coordinator.CurrentRecipe.Steps[0];
@@ -107,7 +149,7 @@ public sealed class StepColumnViewModelTests : IAsyncLifetime
 			action,
 			_fixture.RecipeMetadataRegistry,
 			descriptors,
-			(row, descriptor) => new TestParameterCellViewModel(row, descriptor));
+			cellFactory ?? ((row, descriptor) => new TestParameterCellViewModel(row, descriptor)));
 	}
 
 	private sealed class TestParameterCellViewModel(

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedCellBackgroundConverterTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedCellBackgroundConverterTests.cs
@@ -1,0 +1,191 @@
+﻿using System.Globalization;
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+
+using SemiStep.Core.Configuration;
+using SemiStep.UI.RecipeGrid.Transposed;
+using SemiStep.UI.Styles;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid.Transposed;
+
+// Pins the flattened cell-background converter to the exact document-order, last-match-wins
+// precedence the removed TransposedGridStyles.axaml background rules produced. The oracle below is a
+// literal transcription of those 29 rules (independent of the converter's nested-if shape), so
+// agreement across the full state cross-product proves the flatten preserved every cell's brush.
+[Trait("Component", "UI")]
+[Trait("Category", "Unit")]
+[Trait("Area", "RecipeGrid")]
+public sealed class TransposedCellBackgroundConverterTests
+{
+	[AvaloniaFact]
+	public void Convert_MatchesOldRulePrecedence_AcrossFullStateMatrix()
+	{
+		var host = BuildHostWithPalette(out var resources);
+		var converter = TransposedCellBackgroundConverter.Instance;
+
+		for (var depth = 0; depth <= 3; depth++)
+		{
+			foreach (var past in _bools)
+			{
+				foreach (var readOnly in _bools)
+				{
+					foreach (var applicable in _bools)
+					{
+						foreach (var changed in _bools)
+						{
+							foreach (var selected in _bools)
+							{
+								var expectedKey = ResolveExpectedKey(
+									depth, past, readOnly, !applicable, changed, selected);
+								var expectedBrush = resources[expectedKey];
+
+								var actual = converter.Convert(
+									[host, depth, past, readOnly, applicable, changed, selected],
+									typeof(IBrush),
+									null,
+									CultureInfo.InvariantCulture);
+
+								Assert.True(
+									ReferenceEquals(expectedBrush, actual),
+									$"depth={depth} past={past} readOnly={readOnly} applicable={applicable} "
+									+ $"changed={changed} selected={selected}: expected '{expectedKey}'");
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	[AvaloniaFact]
+	public void Convert_ClampsDepthAtThree()
+	{
+		var host = BuildHostWithPalette(out var resources);
+		var converter = TransposedCellBackgroundConverter.Instance;
+
+		var depthFive = converter.Convert(
+			[host, 5, false, false, true, false, false],
+			typeof(IBrush),
+			null,
+			CultureInfo.InvariantCulture);
+
+		Assert.Same(resources[ExecutionPaletteInstaller.ExecRowDepth3BrushKey], depthFive);
+	}
+
+	[AvaloniaFact]
+	public void Convert_TreatsNegativeDepthAsZero()
+	{
+		var host = BuildHostWithPalette(out var resources);
+		var converter = TransposedCellBackgroundConverter.Instance;
+
+		// depth<=0, not past, editable, applicable, not changed, not selected -> plain grid background.
+		var negative = converter.Convert(
+			[host, -1, false, false, true, false, false],
+			typeof(IBrush),
+			null,
+			CultureInfo.InvariantCulture);
+
+		Assert.Same(resources[CellPaletteInstaller.GridBackgroundBrushKey], negative);
+	}
+
+	private static readonly bool[] _bools = [false, true];
+
+	// Literal, in-document-order transcription of the old Border.transposed-cell background rules.
+	// The winner is the LAST matching rule (Avalonia last-match-wins among equal-priority setters).
+	private static string ResolveExpectedKey(
+		int depth, bool past, bool readOnly, bool inapplicable, bool changed, bool selected)
+	{
+		var winner = CellPaletteInstaller.GridBackgroundBrushKey;
+
+		void Rule(bool condition, string key)
+		{
+			if (condition)
+			{
+				winner = key;
+			}
+		}
+
+		Rule(readOnly, CellPaletteInstaller.CellReadOnlyDepth0BrushKey);
+		Rule(inapplicable, CellPaletteInstaller.CellDisabledDepth0BrushKey);
+		Rule(past, ExecutionPaletteInstaller.ExecRowDepth0PastBrushKey);
+		Rule(depth == 1, ExecutionPaletteInstaller.ExecRowDepth1BrushKey);
+		Rule(depth == 1 && past, ExecutionPaletteInstaller.ExecRowDepth1PastBrushKey);
+		Rule(depth == 2, ExecutionPaletteInstaller.ExecRowDepth2BrushKey);
+		Rule(depth == 2 && past, ExecutionPaletteInstaller.ExecRowDepth2PastBrushKey);
+		Rule(depth == 3, ExecutionPaletteInstaller.ExecRowDepth3BrushKey);
+		Rule(depth == 3 && past, ExecutionPaletteInstaller.ExecRowDepth3PastBrushKey);
+		Rule(past && readOnly, CellPaletteInstaller.CellReadOnlyDepth0PastBrushKey);
+		Rule(depth == 1 && readOnly, CellPaletteInstaller.CellReadOnlyDepth1BrushKey);
+		Rule(depth == 1 && past && readOnly, CellPaletteInstaller.CellReadOnlyDepth1PastBrushKey);
+		Rule(depth == 2 && readOnly, CellPaletteInstaller.CellReadOnlyDepth2BrushKey);
+		Rule(depth == 2 && past && readOnly, CellPaletteInstaller.CellReadOnlyDepth2PastBrushKey);
+		Rule(depth == 3 && readOnly, CellPaletteInstaller.CellReadOnlyDepth3BrushKey);
+		Rule(depth == 3 && past && readOnly, CellPaletteInstaller.CellReadOnlyDepth3PastBrushKey);
+		Rule(past && inapplicable, CellPaletteInstaller.CellDisabledDepth0PastBrushKey);
+		Rule(depth == 1 && inapplicable, CellPaletteInstaller.CellDisabledDepth1BrushKey);
+		Rule(depth == 1 && past && inapplicable, CellPaletteInstaller.CellDisabledDepth1PastBrushKey);
+		Rule(depth == 2 && inapplicable, CellPaletteInstaller.CellDisabledDepth2BrushKey);
+		Rule(depth == 2 && past && inapplicable, CellPaletteInstaller.CellDisabledDepth2PastBrushKey);
+		Rule(depth == 3 && inapplicable, CellPaletteInstaller.CellDisabledDepth3BrushKey);
+		Rule(depth == 3 && past && inapplicable, CellPaletteInstaller.CellDisabledDepth3PastBrushKey);
+		Rule(changed, CellPaletteInstaller.CellChangedBrushKey);
+		Rule(selected, CellPaletteInstaller.SelectionBackgroundBrushKey);
+		Rule(selected && readOnly, CellPaletteInstaller.CellReadOnlySelectedBackgroundBrushKey);
+		Rule(selected && inapplicable, CellPaletteInstaller.CellDisabledSelectedBackgroundBrushKey);
+		Rule(selected && changed, CellPaletteInstaller.CellChangedSelectedBackgroundBrushKey);
+
+		return winner;
+	}
+
+	private static Control BuildHostWithPalette(out IResourceDictionary resources)
+	{
+		var gridStyle = BuildDistinctPaletteGridStyle();
+		var border = new Border();
+		CellPaletteInstaller.Install(border.Resources, gridStyle);
+		ExecutionPaletteInstaller.Install(border.Resources, gridStyle);
+		resources = border.Resources;
+		return border;
+	}
+
+	// Every key the converter can select gets a distinct color, so a wrong key resolves to a
+	// different brush instance and the reference check fails loudly.
+	private static GridStyleOptions BuildDistinctPaletteGridStyle()
+	{
+		return GridStyleOptions.Default with
+		{
+			GridBackgroundColor = "#101010",
+			SelectionBackgroundColor = "#202020",
+			CellChangedColor = "#303030",
+			CellChangedSelectedColor = "#404040",
+			ReadOnlyCellSelectedColor = "#505050",
+			DisabledCellSelectedColor = "#606060",
+			ExecutionDepth1Color = "#110000",
+			ExecutionDepth2Color = "#120000",
+			ExecutionDepth3Color = "#130000",
+			ExecutionDepth0PastColor = "#140000",
+			ExecutionDepth1PastColor = "#150000",
+			ExecutionDepth2PastColor = "#160000",
+			ExecutionDepth3PastColor = "#170000",
+			ReadOnlyCellDepth0Color = "#210000",
+			ReadOnlyCellDepth1Color = "#220000",
+			ReadOnlyCellDepth2Color = "#230000",
+			ReadOnlyCellDepth3Color = "#240000",
+			ReadOnlyCellDepth0PastColor = "#250000",
+			ReadOnlyCellDepth1PastColor = "#260000",
+			ReadOnlyCellDepth2PastColor = "#270000",
+			ReadOnlyCellDepth3PastColor = "#280000",
+			DisabledCellDepth0Color = "#310000",
+			DisabledCellDepth1Color = "#320000",
+			DisabledCellDepth2Color = "#330000",
+			DisabledCellDepth3Color = "#340000",
+			DisabledCellDepth0PastColor = "#350000",
+			DisabledCellDepth1PastColor = "#360000",
+			DisabledCellDepth2PastColor = "#370000",
+			DisabledCellDepth3PastColor = "#380000",
+		};
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedCellStyleRenderTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedCellStyleRenderTests.cs
@@ -1,0 +1,207 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+using FluentAssertions;
+
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid.Transposed;
+using SemiStep.UI.Styles;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid.Transposed;
+
+// Renders the real transposed grid to confirm the flattened background MultiBinding drives the live
+// Border.Background, and that the read-only / inapplicable / selected FOREGROUND style setters kept in
+// TransposedGridStyles.axaml still resolve after the background rules were removed.
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public sealed class TransposedCellStyleRenderTests : IAsyncLifetime
+{
+	private const int SeededStepCount = 3;
+	private const string CellClass = "transposed-cell";
+
+	private readonly UIFixture _fixture = new();
+	private TransposedRecipeGridSurface _surface = null!;
+	private Window? _window;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_fixture.SeedRecipe(SeededStepCount);
+
+		_surface = _fixture.CreateTransposedSurface();
+		_surface.Initialize();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		_window?.Close();
+		_surface.Dispose();
+		await _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void EditableCell_UsesGridBackground()
+	{
+		var (_, stepListBox) = ShowView();
+		var cells = FindCellBorders(stepListBox, 0);
+		var index = IndexOfDescriptor(descriptor =>
+			!descriptor.IsReadOnlyParameter && _surface.StepColumns[0].Row.IsApplicable(descriptor.ParameterKey));
+
+		cells[index].Background.Should().BeSameAs(Resource(CellPaletteInstaller.GridBackgroundBrushKey));
+	}
+
+	[AvaloniaFact]
+	public void InapplicableCell_UsesDisabledBackgroundAndForeground()
+	{
+		var (_, stepListBox) = ShowView();
+		var row = _surface.StepColumns[0].Row;
+		var cells = FindCellBorders(stepListBox, 0);
+		var index = IndexOfDescriptor(descriptor =>
+			!descriptor.IsReadOnlyParameter && !row.IsApplicable(descriptor.ParameterKey));
+
+		cells[index].Background.Should().BeSameAs(Resource(CellPaletteInstaller.CellDisabledDepth0BrushKey));
+		cells[index].GetValue(TextElement.ForegroundProperty)
+			.Should().BeSameAs(Resource(CellPaletteInstaller.CellDisabledForegroundBrushKey));
+	}
+
+	[AvaloniaFact]
+	public void ChangedCell_UsesChangedBackground()
+	{
+		var (_, stepListBox) = ShowView();
+		var row = _surface.StepColumns[0].Row;
+		var cells = FindCellBorders(stepListBox, 0);
+		var index = IndexOfDescriptor(descriptor =>
+			!descriptor.IsReadOnlyParameter && row.IsApplicable(descriptor.ParameterKey));
+
+		row.MarkChanged([_surface.ParameterDescriptors[index].ParameterKey]);
+		Dispatcher.UIThread.RunJobs();
+
+		cells[index].Background.Should().BeSameAs(Resource(CellPaletteInstaller.CellChangedBrushKey));
+	}
+
+	[AvaloniaFact]
+	public void Depth1EditableCell_UsesDepth1Background()
+	{
+		var (_, stepListBox) = ShowView();
+		var row = _surface.StepColumns[0].Row;
+		var index = IndexOfDescriptor(descriptor =>
+			!descriptor.IsReadOnlyParameter && row.IsApplicable(descriptor.ParameterKey));
+
+		row.ForDepth = 1;
+		Dispatcher.UIThread.RunJobs();
+
+		var cells = FindCellBorders(stepListBox, 0);
+		cells[index].Background.Should().BeSameAs(Resource(ExecutionPaletteInstaller.ExecRowDepth1BrushKey));
+	}
+
+	[AvaloniaFact]
+	public void ChangedAndSelectedCell_UsesChangedSelectedBackground()
+	{
+		var (_, stepListBox) = ShowView();
+		var row = _surface.StepColumns[0].Row;
+		var index = IndexOfDescriptor(descriptor =>
+			!descriptor.IsReadOnlyParameter && row.IsApplicable(descriptor.ParameterKey));
+
+		row.MarkChanged([_surface.ParameterDescriptors[index].ParameterKey]);
+		_surface.RequestSelection(0);
+		Dispatcher.UIThread.RunJobs();
+
+		var cells = FindCellBorders(stepListBox, 0);
+		cells[index].Background.Should().BeSameAs(
+			Resource(CellPaletteInstaller.CellChangedSelectedBackgroundBrushKey),
+			"changed outranks the plain selection tint when a cell is both changed and selected");
+	}
+
+	[AvaloniaFact]
+	public void SelectedColumn_EditableCell_UsesSelectionBackgroundAndForeground()
+	{
+		var (_, stepListBox) = ShowView();
+		var row = _surface.StepColumns[0].Row;
+		var index = IndexOfDescriptor(descriptor =>
+			!descriptor.IsReadOnlyParameter && row.IsApplicable(descriptor.ParameterKey));
+
+		_surface.RequestSelection(0);
+		Dispatcher.UIThread.RunJobs();
+
+		var cells = FindCellBorders(stepListBox, 0);
+		cells[index].Background.Should().BeSameAs(Resource(CellPaletteInstaller.SelectionBackgroundBrushKey));
+		cells[index].GetValue(TextElement.ForegroundProperty)
+			.Should().BeSameAs(Resource(CellPaletteInstaller.SelectionForegroundBrushKey));
+	}
+
+	[AvaloniaFact]
+	public void SelectedColumn_InapplicableCell_UsesSelectedDisabledBackground_AndSelectionForeground()
+	{
+		var (_, stepListBox) = ShowView();
+		var row = _surface.StepColumns[0].Row;
+		var index = IndexOfDescriptor(descriptor =>
+			!descriptor.IsReadOnlyParameter && !row.IsApplicable(descriptor.ParameterKey));
+
+		_surface.RequestSelection(0);
+		Dispatcher.UIThread.RunJobs();
+
+		var cells = FindCellBorders(stepListBox, 0);
+		cells[index].Background.Should().BeSameAs(Resource(CellPaletteInstaller.CellDisabledSelectedBackgroundBrushKey));
+		cells[index].GetValue(TextElement.ForegroundProperty)
+			.Should().BeSameAs(Resource(CellPaletteInstaller.SelectionForegroundBrushKey));
+	}
+
+	private IBrush Resource(string key)
+	{
+		_window!.TryFindResource(key, out var value).Should().BeTrue($"resource '{key}' must be installed");
+		return value.Should().BeAssignableTo<IBrush>().Subject;
+	}
+
+	private int IndexOfDescriptor(Func<ParameterDescriptor, bool> predicate)
+	{
+		var descriptors = _surface.ParameterDescriptors;
+		for (var i = 0; i < descriptors.Count; i++)
+		{
+			if (predicate(descriptors[i]))
+			{
+				return i;
+			}
+		}
+
+		throw new InvalidOperationException("No parameter descriptor matches the test predicate.");
+	}
+
+	private static List<Border> FindCellBorders(ListBox stepListBox, int columnIndex)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+		return container.GetVisualDescendants()
+			.OfType<Border>()
+			.Where(border => border.Classes.Contains(CellClass))
+			.ToList();
+	}
+
+	private (TransposedRecipeGridView View, ListBox StepListBox) ShowView()
+	{
+		var view = new TransposedRecipeGridView { DataContext = _surface };
+		_window = new Window
+		{
+			Width = 1200,
+			Height = 800,
+			Content = view,
+		};
+
+		CellPaletteInstaller.Install(_window.Resources, _fixture.AppConfiguration.GridStyle);
+		ExecutionPaletteInstaller.Install(_window.Resources, _fixture.AppConfiguration.GridStyle);
+
+		_window.Show();
+		Dispatcher.UIThread.RunJobs();
+
+		var stepListBox = view.FindControl<ListBox>("StepListBox");
+		stepListBox.Should().NotBeNull();
+
+		return (view, stepListBox!);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedEditingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedEditingTests.cs
@@ -97,6 +97,8 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 		Dispatcher.UIThread.RunJobs();
 
 		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(100f);
+		editor.Text.Should().Be(
+			"00:01:40", "a rejected edit must snap the editor back to the model's formatted value");
 	}
 
 	[AvaloniaFact]
@@ -307,6 +309,41 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 
 		editor.Text.Should().Be("00:01:40", "Escape must revert the typed-but-uncommitted text");
 		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(100f);
+	}
+
+	// Stale-guard: a recyclable TextBox pins its edit target on focus and must write ONLY to that
+	// captured cell, even after recycling rebinds it onto a different cell mid-edit. Rebinding the
+	// editor's DataContext to another column's cell simulates that recycle; the pending text must
+	// land on the captured cell, never leak into the rebind target.
+	[AvaloniaFact]
+	public void RecycledEditor_CommitsToCapturedCell_NotTheRebindTarget()
+	{
+		_fixture.Coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "10")
+			.IsSuccess.Should().BeTrue();
+		_fixture.Coordinator.UpdateStepProperty(1, RecipeTestDriver.StepDurationColumn, "20")
+			.IsSuccess.Should().BeTrue();
+		var (_, stepListBox) = ShowView();
+
+		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var capturedCell = (PropertyTextCellViewModel)editor.DataContext!;
+		var rebindCell = (PropertyTextCellViewModel)FindTextBox(
+			stepListBox, 1, RecipeTestDriver.StepDurationColumn).DataContext!;
+
+		editor.Focus();
+		Dispatcher.UIThread.RunJobs();
+
+		editor.DataContext = rebindCell;
+		Dispatcher.UIThread.RunJobs();
+		editor.DataContext.Should().BeSameAs(rebindCell, "the recycle simulation must actually rebind the editor");
+
+		editor.Text = "777";
+		_window!.FocusManager!.Focus(null);
+		Dispatcher.UIThread.RunJobs();
+
+		_surface.StepColumns[1].Row[RecipeTestDriver.StepDurationColumn].Should().Be(
+			20f, "a recycled editor must never write its pending text into the rebind-target cell");
+		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(
+			777f, "the commit must land on the cell captured when the editor was focused");
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedVirtualizationTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedVirtualizationTests.cs
@@ -98,6 +98,55 @@ public sealed class TransposedVirtualizationTests : IAsyncLifetime
 			"a container recycled from the current column must not leak its class");
 	}
 
+	// A focused editor holding uncommitted text that gets recycled across a scroll must never leak
+	// that text into any other column's cell. The recycle-out commit may write column 0 (asserted
+	// separately); every other column must keep its own value.
+	[AvaloniaFact]
+	public void FocusedEditorWithPendingText_RecycledAcrossScroll_DoesNotCorruptOtherCells()
+	{
+		var stepListBox = ShowView();
+		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+
+		var before = new object?[SeededStepCount];
+		for (var i = 0; i < SeededStepCount; i++)
+		{
+			before[i] = _surface.StepColumns[i].Row[RecipeTestDriver.StepDurationColumn];
+		}
+
+		editor.Focus();
+		editor.Text = "777";
+
+		ScrollToHorizontalEnd(stepListBox);
+		ScrollToHorizontalStart(stepListBox);
+
+		for (var i = 1; i < SeededStepCount; i++)
+		{
+			_surface.StepColumns[i].Row[RecipeTestDriver.StepDurationColumn].Should().Be(
+				before[i], $"recycling a focused editor must not write stale text into column {i}");
+		}
+	}
+
+	// After a recycled container is reused for a far column, its editor must show that column's own
+	// value (the OneWay display binding rebinds), never a stale value from the column it was built on.
+	[AvaloniaFact]
+	public void RecycledTextEditor_ShowsRebindTargetCellValue_AfterScroll()
+	{
+		var lastIndex = SeededStepCount - 1;
+		_fixture.Coordinator.UpdateStepProperty(lastIndex, RecipeTestDriver.StepDurationColumn, "125")
+			.IsSuccess.Should().BeTrue();
+		var stepListBox = ShowView();
+
+		ScrollToHorizontalEnd(stepListBox);
+
+		var editor = FindTextBox(stepListBox, lastIndex, RecipeTestDriver.StepDurationColumn);
+		var expected = PropertyTimeEditingConverter.FormatForDisplay(
+			_surface.StepColumns[lastIndex].Row[RecipeTestDriver.StepDurationColumn],
+			TimeFormatHelper.TimeHmsFormat);
+
+		editor.Text.Should().Be(expected);
+		editor.Text.Should().Be("00:02:05", "the recycled editor shows the rebind-target cell's formatted value");
+	}
+
 	private static int RealizedContainerCount(ListBox stepListBox)
 	{
 		return stepListBox.GetRealizedContainers().Count();

--- a/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeRowViewModelTests.cs
@@ -61,6 +61,42 @@ public sealed class RecipeRowViewModelTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
+	public void ActionMetadata_TwoRowsSameAction_ShareCachedDictionaries()
+	{
+		_session.AppendStep(RecipeTestDriver.WaitActionId);
+		var step = _session.Current.Steps[0];
+		var action = _recipeMetadataRegistry.GetAction(step.ActionKey).Value;
+		var inapplicable = BuildInapplicableColumns(action, step);
+
+		var first = new RecipeRowViewModel(1, step, action, _recipeMetadataRegistry, inapplicable);
+		var second = new RecipeRowViewModel(2, step, action, _recipeMetadataRegistry, inapplicable);
+
+		second.ColumnUnits.Should().BeSameAs(first.ColumnUnits);
+		second.ColumnFormatKinds.Should().BeSameAs(first.ColumnFormatKinds);
+		second.GroupItemsByColumn.Should().BeSameAs(first.GroupItemsByColumn);
+	}
+
+	[AvaloniaFact]
+	public void ActionMetadata_TwoRowsDifferentActions_GetDistinctDictionaries()
+	{
+		var waitAction = _recipeMetadataRegistry.GetAction(RecipeTestDriver.WaitActionId).Value;
+		var withGroupAction = _recipeMetadataRegistry.GetAction(RecipeTestDriver.WithGroupActionId).Value;
+		_session.AppendStep(RecipeTestDriver.WaitActionId);
+		_session.AppendStep(RecipeTestDriver.WithGroupActionId);
+		var waitStep = _session.Current.Steps[0];
+		var withGroupStep = _session.Current.Steps[1];
+
+		var waitRow = new RecipeRowViewModel(
+			1, waitStep, waitAction, _recipeMetadataRegistry, BuildInapplicableColumns(waitAction, waitStep));
+		var withGroupRow = new RecipeRowViewModel(
+			2, withGroupStep, withGroupAction, _recipeMetadataRegistry, BuildInapplicableColumns(withGroupAction, withGroupStep));
+
+		withGroupRow.ColumnUnits.Should().NotBeSameAs(waitRow.ColumnUnits);
+		withGroupRow.ColumnFormatKinds.Should().NotBeSameAs(waitRow.ColumnFormatKinds);
+		withGroupRow.GroupItemsByColumn.Should().NotBeSameAs(waitRow.GroupItemsByColumn);
+	}
+
+	[AvaloniaFact]
 	public void GetPropertyValue_Action_ReturnsActionId()
 	{
 		var row = CreateRow();

--- a/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeEditingConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/PropertyTimeEditingConverter.cs
@@ -9,6 +9,18 @@ internal sealed class PropertyTimeEditingConverter(string formatKind, bool allow
 {
 	public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 	{
+		return FormatForDisplay(value, formatKind);
+	}
+
+	public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+	{
+		return ParseForCommit(value, allowsEmpty);
+	}
+
+	// Units-less display formatting shared with the transposed recyclable text editor, which drives
+	// the same rendering through a stateless OneWay MultiBinding instead of a per-cell converter.
+	public static string FormatForDisplay(object? value, string? formatKind)
+	{
 		if (value is null)
 		{
 			return string.Empty;
@@ -23,7 +35,10 @@ internal sealed class PropertyTimeEditingConverter(string formatKind, bool allow
 		return TimeFormatHelper.FormatValue(rawString, formatKind, units: null);
 	}
 
-	public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+	// Commit-side parse shared with the transposed recyclable text editor, which owns the write in
+	// its LostFocus/KeyDown handlers (a MultiBinding has no ConvertBack). Returns
+	// BindingOperations.DoNothing when the edit must be rejected without touching the model.
+	public static object? ParseForCommit(object? value, bool allowsEmpty)
 	{
 		var text = value?.ToString()?.Trim();
 		if (string.IsNullOrEmpty(text))

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs
@@ -517,9 +517,9 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 		for (var i = fromIndex; i < Items.Count; i++)
 		{
 			string formattedTime;
-			if (stepStartTimes.TryGetValue(i, out var time))
+			if (i < stepStartTimes.Count)
 			{
-				var rawSeconds = time.TotalSeconds.ToString(CultureInfo.InvariantCulture);
+				var rawSeconds = stepStartTimes[i].TotalSeconds.ToString(CultureInfo.InvariantCulture);
 				formattedTime = TimeFormatHelper.FormatValue(
 					rawSeconds,
 					TimeFormatHelper.TimeHmsFormat,
@@ -560,14 +560,13 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 	// panel, and leaves the projection as-is.
 	private TItem CreateItemChecked(Step step, int stepNumber)
 	{
-		var actionResult = RecipeMetadataRegistry.GetAction(step.ActionKey);
-		if (actionResult.IsFailed)
+		if (!RecipeMetadataRegistry.TryGetAction(step.ActionKey, out var action))
 		{
 			throw new UnknownActionKeyException(
 				$"Step {stepNumber}: unknown action key '{step.ActionKey}'");
 		}
 
-		var item = CreateItem(stepNumber, step, actionResult.Value);
+		var item = CreateItem(stepNumber, step, action);
 
 		var row = RowOf(item);
 		row.PropertyValueChanged += (columnKey, value) => OnCellValueChanged(item, columnKey, value);

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Runtime.CompilerServices;
 
 using ReactiveUI;
 
@@ -17,11 +18,14 @@ public sealed class RecipeRowViewModel(
 {
 	private const string IndexerName = "Item";
 
-	private readonly (IReadOnlyDictionary<string, string?> Units, IReadOnlyDictionary<string, string> FormatKinds) _columnMetadata
-		= BuildColumnMetadata(action, recipeMetadataRegistry);
+	// The Units/FormatKinds/GroupItems dictionaries depend only on (ActionDefinition, registry) and
+	// are immutable once built, so they are cached per action instead of rebuilt for every row. The
+	// registry hands out a stable ActionDefinition instance per action id, so the reference key is
+	// safe; the weak table lets an entry fall away when its action is collected (e.g. a discarded
+	// registry in a test).
+	private static readonly ConditionalWeakTable<ActionDefinition, ActionColumnMetadata> _actionMetadataCache = new();
 
-	private readonly IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> _groupItemsByColumn
-		= BuildGroupItemsByColumn(action, recipeMetadataRegistry);
+	private readonly ActionColumnMetadata _actionMetadata = GetActionMetadata(action, recipeMetadataRegistry);
 
 	private Step _step = step;
 
@@ -90,11 +94,12 @@ public sealed class RecipeRowViewModel(
 		private set => this.RaiseAndSetIfChanged(ref field, value);
 	} = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-	public IReadOnlyDictionary<string, string?> ColumnUnits => _columnMetadata.Units;
+	public IReadOnlyDictionary<string, string?> ColumnUnits => _actionMetadata.Units;
 
-	public IReadOnlyDictionary<string, string> ColumnFormatKinds => _columnMetadata.FormatKinds;
+	public IReadOnlyDictionary<string, string> ColumnFormatKinds => _actionMetadata.FormatKinds;
 
-	public IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupItemsByColumn => _groupItemsByColumn;
+	public IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupItemsByColumn =>
+		_actionMetadata.GroupItemsByColumn;
 
 	public object? this[string columnKey]
 	{
@@ -351,6 +356,22 @@ public sealed class RecipeRowViewModel(
 		return propertyResult.IsSuccess ? propertyResult.Value : null;
 	}
 
+	private static ActionColumnMetadata GetActionMetadata(
+		ActionDefinition action,
+		RecipeMetadataRegistry recipeMetadataRegistry)
+	{
+		return _actionMetadataCache.GetValue(
+			action,
+			resolvedAction =>
+			{
+				var (units, formatKinds) = BuildColumnMetadata(resolvedAction, recipeMetadataRegistry);
+				return new ActionColumnMetadata(
+					units,
+					formatKinds,
+					BuildGroupItemsByColumn(resolvedAction, recipeMetadataRegistry));
+			});
+	}
+
 	private static IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> BuildGroupItemsByColumn(
 		ActionDefinition actionDefinition,
 		RecipeMetadataRegistry recipeMetadataRegistry)
@@ -410,4 +431,9 @@ public sealed class RecipeRowViewModel(
 
 		return (units, formatKinds);
 	}
+
+	private sealed record ActionColumnMetadata(
+		IReadOnlyDictionary<string, string?> Units,
+		IReadOnlyDictionary<string, string> FormatKinds,
+		IReadOnlyDictionary<string, IReadOnlyList<ComboBoxItemViewModel>> GroupItemsByColumn);
 }

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/ParameterCellViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/ParameterCellViewModel.cs
@@ -1,10 +1,8 @@
 ﻿using System.ComponentModel;
 
-using ReactiveUI;
-
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-public abstract class ParameterCellViewModel : ReactiveObject, IDisposable
+public abstract class ParameterCellViewModel : INotifyPropertyChanged, IDisposable
 {
 	private const string RowIndexerName = "Item";
 
@@ -14,6 +12,8 @@ public abstract class ParameterCellViewModel : ReactiveObject, IDisposable
 		Descriptor = parameterDescriptor;
 		Row.PropertyChanged += OnRowPropertyChanged;
 	}
+
+	public event PropertyChangedEventHandler? PropertyChanged;
 
 	public RecipeRowViewModel Row { get; }
 
@@ -45,22 +45,27 @@ public abstract class ParameterCellViewModel : ReactiveObject, IDisposable
 		Row[Descriptor.ParameterKey] = value;
 	}
 
+	protected void RaisePropertyChanged(string propertyName)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+
 	private void OnRowPropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
 		switch (e.PropertyName)
 		{
 			case RowIndexerName:
-				this.RaisePropertyChanged(nameof(Value));
+				RaisePropertyChanged(nameof(Value));
 				break;
 			case nameof(RecipeRowViewModel.StepStartTime)
 				when IsStepStartTimeParameter():
-				this.RaisePropertyChanged(nameof(Value));
+				RaisePropertyChanged(nameof(Value));
 				break;
 			case nameof(RecipeRowViewModel.InapplicableColumns):
-				this.RaisePropertyChanged(nameof(IsApplicable));
+				RaisePropertyChanged(nameof(IsApplicable));
 				break;
 			case nameof(RecipeRowViewModel.ChangedColumns):
-				this.RaisePropertyChanged(nameof(IsChanged));
+				RaisePropertyChanged(nameof(IsChanged));
 				break;
 		}
 	}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/PropertyTextEditingMultiConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/PropertyTextEditingMultiConverter.cs
@@ -1,0 +1,27 @@
+﻿using System.Globalization;
+
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Stateless OneWay display converter for the transposed recyclable text editor: (Value, FormatKind)
+// -> the units-less formatted string the per-cell PropertyTimeEditingConverter used to bake. Binding
+// FormatKind instead of baking it is what lets the TextBox be reused across recycled cells; the edit
+// commit is owned by the editor's LostFocus/KeyDown handlers (Avalonia MultiBinding has no ConvertBack).
+internal sealed class PropertyTextEditingMultiConverter : IMultiValueConverter
+{
+	public static readonly PropertyTextEditingMultiConverter Instance = new();
+
+	public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+	{
+		if (values.Count < 2
+			|| values[0] == AvaloniaProperty.UnsetValue
+			|| values[1] == AvaloniaProperty.UnsetValue)
+		{
+			return string.Empty;
+		}
+
+		return PropertyTimeEditingConverter.FormatForDisplay(values[0], values[1] as string);
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/StepColumnViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/StepColumnViewModel.cs
@@ -4,6 +4,8 @@ namespace SemiStep.UI.RecipeGrid.Transposed;
 
 public sealed class StepColumnViewModel : IDisposable
 {
+	private readonly Lazy<IReadOnlyList<ParameterCellViewModel>> _cells;
+
 	public StepColumnViewModel(
 		int stepNumber,
 		Step step,
@@ -14,18 +16,26 @@ public sealed class StepColumnViewModel : IDisposable
 	{
 		var inapplicableColumns = RecipeRowViewModel.BuildInapplicableColumns(action, step, recipeMetadataRegistry);
 		Row = new RecipeRowViewModel(stepNumber, step, action, recipeMetadataRegistry, inapplicableColumns);
-		Cells = parameterDescriptors.Select(descriptor => cellFactory(Row, descriptor)).ToList();
+
+		// A column never scrolled to or keyboard-traversed never builds its per-parameter cell VMs.
+		// Cells is UI-thread-only, so the default locking Lazy mode is unnecessary overhead.
+		_cells = new Lazy<IReadOnlyList<ParameterCellViewModel>>(
+			() => parameterDescriptors.Select(descriptor => cellFactory(Row, descriptor)).ToList(),
+			LazyThreadSafetyMode.None);
 	}
 
 	public RecipeRowViewModel Row { get; }
 
-	public IReadOnlyList<ParameterCellViewModel> Cells { get; }
+	public IReadOnlyList<ParameterCellViewModel> Cells => _cells.Value;
 
 	public void Dispose()
 	{
-		foreach (var cell in Cells)
+		if (_cells.IsValueCreated)
 		{
-			cell.Dispose();
+			foreach (var cell in _cells.Value)
+			{
+				cell.Dispose();
+			}
 		}
 
 		Row.Dispose();

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellBackgroundConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellBackgroundConverter.cs
@@ -1,0 +1,127 @@
+﻿using System.Globalization;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+using SemiStep.UI.Styles;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Collapses the transposed cell's background state matrix into one binding, replacing the 29
+// background setter rules that previously lived in TransposedGridStyles.axaml. The
+// winning brush reproduces those rules' document-order, last-match-wins precedence exactly:
+//   selected            -> changed > inapplicable > read-only > plain selection tint
+//   else changed        -> the changed highlight (beats depth/read-only/inapplicable, loses to selection)
+//   else inapplicable   -> disabled palette, per loop depth + past-step
+//   else read-only      -> read-only palette, per loop depth + past-step
+//   else                -> execution depth/past tint (depth-0 idle is the plain grid background)
+// Brushes resolve through the target Border as a resource host, so the same visual-tree + application
+// lookup {DynamicResource} used still applies (works for both app- and window-scoped palette installs).
+internal sealed class TransposedCellBackgroundConverter : IMultiValueConverter
+{
+	public static readonly TransposedCellBackgroundConverter Instance = new();
+
+	public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+	{
+		if (values.Count < 7 || values[0] is not Control host)
+		{
+			return AvaloniaProperty.UnsetValue;
+		}
+
+		var depth = values[1] as int? ?? 0;
+		var isPastStep = values[2] as bool? ?? false;
+		var isReadOnly = values[3] as bool? ?? false;
+		var isApplicable = values[4] as bool? ?? true;
+		var isChanged = values[5] as bool? ?? false;
+		var isSelected = values[6] as bool? ?? false;
+
+		var key = ResolveBrushKey(depth, isPastStep, isReadOnly, !isApplicable, isChanged, isSelected);
+
+		if (host.TryFindResource(key, out var value) && value is IBrush brush)
+		{
+			return brush;
+		}
+
+		return AvaloniaProperty.UnsetValue;
+	}
+
+	private static string ResolveBrushKey(
+		int depth,
+		bool past,
+		bool readOnly,
+		bool inapplicable,
+		bool changed,
+		bool selected)
+	{
+		depth = Math.Clamp(depth, 0, 3);
+
+		if (selected)
+		{
+			if (changed)
+			{
+				return CellPaletteInstaller.CellChangedSelectedBackgroundBrushKey;
+			}
+
+			if (inapplicable)
+			{
+				return CellPaletteInstaller.CellDisabledSelectedBackgroundBrushKey;
+			}
+
+			if (readOnly)
+			{
+				return CellPaletteInstaller.CellReadOnlySelectedBackgroundBrushKey;
+			}
+
+			return CellPaletteInstaller.SelectionBackgroundBrushKey;
+		}
+
+		if (changed)
+		{
+			return CellPaletteInstaller.CellChangedBrushKey;
+		}
+
+		if (inapplicable)
+		{
+			return depth switch
+			{
+				0 => past ? CellPaletteInstaller.CellDisabledDepth0PastBrushKey
+					: CellPaletteInstaller.CellDisabledDepth0BrushKey,
+				1 => past ? CellPaletteInstaller.CellDisabledDepth1PastBrushKey
+					: CellPaletteInstaller.CellDisabledDepth1BrushKey,
+				2 => past ? CellPaletteInstaller.CellDisabledDepth2PastBrushKey
+					: CellPaletteInstaller.CellDisabledDepth2BrushKey,
+				_ => past ? CellPaletteInstaller.CellDisabledDepth3PastBrushKey
+					: CellPaletteInstaller.CellDisabledDepth3BrushKey,
+			};
+		}
+
+		if (readOnly)
+		{
+			return depth switch
+			{
+				0 => past ? CellPaletteInstaller.CellReadOnlyDepth0PastBrushKey
+					: CellPaletteInstaller.CellReadOnlyDepth0BrushKey,
+				1 => past ? CellPaletteInstaller.CellReadOnlyDepth1PastBrushKey
+					: CellPaletteInstaller.CellReadOnlyDepth1BrushKey,
+				2 => past ? CellPaletteInstaller.CellReadOnlyDepth2PastBrushKey
+					: CellPaletteInstaller.CellReadOnlyDepth2BrushKey,
+				_ => past ? CellPaletteInstaller.CellReadOnlyDepth3PastBrushKey
+					: CellPaletteInstaller.CellReadOnlyDepth3BrushKey,
+			};
+		}
+
+		return depth switch
+		{
+			0 => past ? ExecutionPaletteInstaller.ExecRowDepth0PastBrushKey
+				: CellPaletteInstaller.GridBackgroundBrushKey,
+			1 => past ? ExecutionPaletteInstaller.ExecRowDepth1PastBrushKey
+				: ExecutionPaletteInstaller.ExecRowDepth1BrushKey,
+			2 => past ? ExecutionPaletteInstaller.ExecRowDepth2PastBrushKey
+				: ExecutionPaletteInstaller.ExecRowDepth2BrushKey,
+			_ => past ? ExecutionPaletteInstaller.ExecRowDepth3PastBrushKey
+				: ExecutionPaletteInstaller.ExecRowDepth3BrushKey,
+		};
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs
@@ -25,7 +25,15 @@ namespace SemiStep.UI.RecipeGrid.Transposed;
 internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface surface)
 {
 	private static readonly FuncValueConverter<bool, bool> _negateConverter = new(value => !value);
+	private static readonly FuncValueConverter<int?, int> _maxLengthConverter = new(maxLength => maxLength ?? 0);
 	private static readonly PropertyTimeMultiConverter _displayConverter = new();
+
+	// Per-editor edit target captured on GotFocus. The commit writes ONLY to this cell, so a
+	// still-focused TextBox recycled onto a different cell cannot push its pending text into the new
+	// cell; the OneWay display binding meanwhile keeps the new cell's rendered text intact.
+	private static readonly AttachedProperty<PropertyTextCellViewModel?> _editingCellProperty =
+		AvaloniaProperty.RegisterAttached<TransposedCellTemplateFactory, TextBox, PropertyTextCellViewModel?>(
+			"EditingCell");
 
 	public IReadOnlyList<IDataTemplate> CreateTemplates()
 	{
@@ -101,17 +109,20 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 		cell.Value = selected.Id.ToString(CultureInfo.InvariantCulture);
 	}
 
+	// supportsRecycling:true — the TextBox carries no per-cell baked state: display is a OneWay
+	// MultiBinding through a shared stateless converter, MaxLength is bound, and the edit commit reads
+	// its target from the cell captured on GotFocus (not a closure), so a recycled container safely
+	// rebinds onto the next cell instead of rebuilding the whole subtree.
 	private IDataTemplate CreatePropertyTextTemplate()
 	{
 		return new FuncDataTemplate<PropertyTextCellViewModel>(
-			(cell, _) => cell is null ? new TextBlock() : CreateTextBoxEditor(cell),
-			supportsRecycling: false);
+			(cell, _) => cell is null ? new TextBlock() : CreateTextBoxEditor(),
+			supportsRecycling: true);
 	}
 
-	private Control CreateTextBoxEditor(PropertyTextCellViewModel cell)
+	private Control CreateTextBoxEditor()
 	{
 		var gridStyle = surface.GridStyle;
-		var editingConverter = new PropertyTimeEditingConverter(cell.FormatKind, allowsEmpty: cell.MaxLength.HasValue);
 
 		var textBox = new TextBox
 		{
@@ -131,55 +142,66 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 		};
 		GridFontApplier.ApplyCellFont(textBox, gridStyle);
 
-		if (cell.MaxLength.HasValue)
+		// Bound, not baked: a null MaxLength maps to 0 (Semi's "unlimited"), matching the old
+		// leave-MaxLength-unset behavior while still tracking the recycled cell's descriptor.
+		textBox.Bind(TextBox.MaxLengthProperty, new Binding(nameof(PropertyTextCellViewModel.MaxLength))
 		{
-			textBox.MaxLength = cell.MaxLength.Value;
-		}
-
-		textBox.Bind(TextBox.TextProperty, new Binding(nameof(ParameterCellViewModel.Value))
-		{
-			Mode = BindingMode.TwoWay,
-			UpdateSourceTrigger = UpdateSourceTrigger.LostFocus,
-			Converter = editingConverter,
+			Mode = BindingMode.OneWay,
+			Converter = _maxLengthConverter,
 		});
 
-		// Subscribed after Bind so it runs once the LostFocus push has resolved: snap the display
-		// back to the view model. A rejected, read-only-dropped, or unparseable write leaves the
-		// source unchanged, and the binding's publish cache skips re-publishing an identical
-		// value, so the editor would otherwise keep showing the never-committed text.
-		textBox.LostFocus += (sender, _) =>
+		// OneWay display only (a MultiBinding cannot ConvertBack). FormatKind is bound so the shared
+		// converter formats each recycled cell correctly; the commit is owned by the handlers below.
+		textBox.Bind(TextBox.TextProperty, new MultiBinding
 		{
-			if (sender is TextBox senderTextBox)
+			Mode = BindingMode.OneWay,
+			Converter = PropertyTextEditingMultiConverter.Instance,
+			Bindings =
 			{
-				senderTextBox.Text = editingConverter.Convert(
-					cell.Value, typeof(string), null, CultureInfo.CurrentCulture) as string;
-			}
-		};
+				new Binding(nameof(ParameterCellViewModel.Value)) { Mode = BindingMode.OneWay },
+				new Binding(nameof(ParameterCellViewModel.FormatKind)) { Mode = BindingMode.OneWay },
+			},
+		});
 
 		// No read-only-parameter leg here: the cell factory routes read-only descriptors to
 		// ReadOnlyCellViewModel before the property-text kind, so a TextBox cell is never
 		// column-level read-only.
 		textBox.Bind(InputElement.IsEnabledProperty, CreateTextBoxEditableBinding());
 
+		textBox.GotFocus += (sender, _) => OnEditorGotFocus(sender);
+		textBox.LostFocus += (sender, _) => OnEditorLostFocus(sender);
 		textBox.AddHandler(
 			InputElement.KeyDownEvent,
-			(sender, e) => OnEditorKeyDown(sender, e, cell, editingConverter),
+			OnEditorKeyDown,
 			RoutingStrategies.Bubble,
 			handledEventsToo: true);
 
 		return textBox;
 	}
 
-	// Enter commits an always-live editor by moving focus off it; the LostFocus trigger pushes
-	// the pending text through the editing converter (canonical parity: Enter ends the cell
-	// edit). Escape overwrites the typed-but-uncommitted text with the view-model value before
-	// defocusing (canonical parity: Escape cancels the cell edit) — written directly to Text
-	// because the two-way binding withholds source-to-target updates while an edit is pending.
-	private static void OnEditorKeyDown(
-		object? sender,
-		KeyEventArgs e,
-		PropertyTextCellViewModel cell,
-		PropertyTimeEditingConverter editingConverter)
+	// Stale-guard capture: the cell being edited is pinned when the TextBox gains focus, so the
+	// commit targets it even if recycling later rebinds the control onto a different cell.
+	private static void OnEditorGotFocus(object? sender)
+	{
+		if (sender is TextBox textBox)
+		{
+			textBox.SetValue(_editingCellProperty, textBox.DataContext as PropertyTextCellViewModel);
+		}
+	}
+
+	private static void OnEditorLostFocus(object? sender)
+	{
+		if (sender is TextBox textBox)
+		{
+			CommitEditor(textBox);
+		}
+	}
+
+	// Enter commits an always-live editor by moving focus off it; the LostFocus handler parses and
+	// pushes the pending text (canonical parity: Enter ends the cell edit). Escape overwrites the
+	// typed-but-uncommitted text with the captured cell's value before defocusing (canonical parity:
+	// Escape cancels the cell edit) — the ensuing commit re-parses that reverted text to a no-op write.
+	private static void OnEditorKeyDown(object? sender, KeyEventArgs e)
 	{
 		if (sender is not TextBox textBox || e.Key is not (Key.Enter or Key.Escape))
 		{
@@ -188,19 +210,50 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 
 		if (e.Key == Key.Escape)
 		{
-			textBox.Text = editingConverter.Convert(
-				cell.Value, typeof(string), null, CultureInfo.CurrentCulture) as string;
+			var cell = textBox.GetValue(_editingCellProperty);
+			textBox.Text = PropertyTimeEditingConverter.FormatForDisplay(cell?.Value, cell?.FormatKind);
 		}
 
 		CommitByDefocusing(textBox);
 		e.Handled = true;
 	}
 
+	// Commit writes ONLY to the cell captured on GotFocus, never the current DataContext, so a
+	// recycled-out editor commits its edit to the cell the user was editing and a recycled-in editor
+	// never receives a stale write. The display is snapped back to the model value only while the
+	// editor still shows the captured cell — a rejected, read-only-dropped, or unchanged write leaves
+	// the source untouched, so the OneWay binding would otherwise keep showing the never-committed
+	// text; if the editor was recycled onto another cell, its binding already shows that cell and must
+	// not be overwritten.
+	private static void CommitEditor(TextBox textBox)
+	{
+		if (textBox.GetValue(_editingCellProperty) is not { } cell)
+		{
+			return;
+		}
+
+		var parsed = PropertyTimeEditingConverter.ParseForCommit(textBox.Text, cell.MaxLength.HasValue);
+		if (!ReferenceEquals(parsed, BindingOperations.DoNothing))
+		{
+			cell.Value = parsed;
+		}
+
+		if (ReferenceEquals(textBox.DataContext, cell))
+		{
+			textBox.Text = PropertyTimeEditingConverter.FormatForDisplay(cell.Value, cell.FormatKind);
+		}
+	}
+
+	// supportsRecycling:true — the read-only TextBlock holds no per-cell baked state: both the
+	// step-start-time and the display-converter legs are OneWay bindings. The step-start-time vs
+	// display split keys off the descriptor's ColumnType, which is invariant per recycled position
+	// (every column's cell at a given row shares one parameter descriptor), so the chosen leg stays
+	// correct across recycling.
 	private IDataTemplate CreateReadOnlyTemplate()
 	{
 		return new FuncDataTemplate<ReadOnlyCellViewModel>(
 			(cell, _) => cell is null ? new TextBlock() : CreateReadOnlyTextBlock(cell),
-			supportsRecycling: false);
+			supportsRecycling: true);
 	}
 
 	private Control CreateReadOnlyTextBlock(ReadOnlyCellViewModel cell)

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml
@@ -79,6 +79,22 @@
                                                     Classes.inapplicable="{Binding !IsApplicable}"
                                                     Classes.changed="{Binding IsChanged}"
                                                     Height="{DynamicResource TransposedCellHeight}">
+                                                <!-- Full cell-background state matrix (depth / past /
+                                                     read-only / inapplicable / changed / selection)
+                                                     resolved in one converter; a local Background value
+                                                     that outranks any style setter. -->
+                                                <Border.Background>
+                                                    <MultiBinding Converter="{x:Static transposed:TransposedCellBackgroundConverter.Instance}">
+                                                        <Binding RelativeSource="{RelativeSource Self}" />
+                                                        <Binding Path="Row.ForDepth" />
+                                                        <Binding Path="Row.IsPastStep" />
+                                                        <Binding Path="Descriptor.IsReadOnlyParameter" />
+                                                        <Binding Path="IsApplicable" />
+                                                        <Binding Path="IsChanged" />
+                                                        <Binding Path="IsSelected"
+                                                                 RelativeSource="{RelativeSource AncestorType=ListBoxItem}" />
+                                                    </MultiBinding>
+                                                </Border.Background>
                                                 <!-- Editor template resolved from the view's DataTemplates
                                                      (TransposedCellTemplateFactory) by cell-VM kind. -->
                                                 <ContentControl Content="{Binding}"

--- a/SemiStep/SemiStep.UI/Styles/TransposedGridStyles.axaml
+++ b/SemiStep/SemiStep.UI/Styles/TransposedGridStyles.axaml
@@ -5,13 +5,16 @@
     <!-- Transposed recipe grid (ListBox of step-       -->
     <!-- columns). All brushes come from the existing   -->
     <!-- CellPaletteInstaller / ExecutionPaletteInstaller -->
-    <!-- resources. Ordering discipline matches         -->
-    <!-- DataGridStyles.axaml: Avalonia applies matching -->
-    <!-- styles in document order and the LAST match    -->
-    <!-- wins, so chains go bare past-step first, then  -->
-    <!-- depth-N, then depth-N past, then changed, then -->
-    <!-- selection, with the current-step header rule   -->
-    <!-- last.                                          -->
+    <!-- resources. The per-cell BACKGROUND state matrix -->
+    <!-- (depth / past / read-only / inapplicable /     -->
+    <!-- changed / selection) is resolved by a single   -->
+    <!-- TransposedCellBackgroundConverter MultiBinding -->
+    <!-- on Border.transposed-cell.Background (see       -->
+    <!-- TransposedRecipeGridView.axaml); that local     -->
+    <!-- value outranks style setters, so no background -->
+    <!-- setters live here. Only FOREGROUND state and   -->
+    <!-- the current-step header tint remain as style   -->
+    <!-- setters, in document order (last match wins).  -->
     <!-- ============================================== -->
 
     <!-- Container reset: the grid paints its own cell chrome, so the ListBox and its item
@@ -53,117 +56,28 @@
         <Setter Property="BorderThickness" Value="0,0,1,0" />
     </Style>
 
-    <!-- Base cell. -->
+    <!-- Base cell chrome. Background is the TransposedCellBackgroundConverter MultiBinding set in
+         the view; only the grid-line border lives here. -->
     <Style Selector="Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource GridBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource GridLineBrush}" />
         <Setter Property="BorderThickness" Value="0,0,1,1" />
     </Style>
 
-    <!-- Read-only and inapplicable cells: two disjoint signals with their own palettes,
-         same as canonical (read-only from the column flag, inapplicable per cell). -->
+    <!-- Read-only and inapplicable foreground: two disjoint signals, inapplicable last so it wins
+         when a cell is both (parity with the background converter's precedence). Their backgrounds
+         are folded into the converter; only the text foreground remains as a style setter. -->
     <Style Selector="Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlyDepth0Brush}" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource CellReadOnlyForegroundBrush}" />
     </Style>
     <Style Selector="Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledDepth0Brush}" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource CellDisabledForegroundBrush}" />
     </Style>
 
-    <!-- Execution state: past and loop-depth column tints (classes stamped on the ListBoxItem
-         by TransposedStepColumnClassBinder). Bare .past-step before .for-depth-N.past-step so
-         the depth-specific past tints win. -->
-    <Style Selector="ListBoxItem.past-step Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource ExecRowDepth0PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-1 Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource ExecRowDepth1Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-1.past-step Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource ExecRowDepth1PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-2 Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource ExecRowDepth2Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-2.past-step Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource ExecRowDepth2PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-3 Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource ExecRowDepth3Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-3.past-step Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource ExecRowDepth3PastBrush}" />
-    </Style>
-
-    <!-- Read-only per-depth chain. -->
-    <Style Selector="ListBoxItem.past-step Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlyDepth0PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-1 Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlyDepth1Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-1.past-step Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlyDepth1PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-2 Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlyDepth2Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-2.past-step Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlyDepth2PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-3 Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlyDepth3Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-3.past-step Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlyDepth3PastBrush}" />
-    </Style>
-
-    <!-- Inapplicable per-depth chain. -->
-    <Style Selector="ListBoxItem.past-step Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledDepth0PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-1 Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledDepth1Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-1.past-step Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledDepth1PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-2 Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledDepth2Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-2.past-step Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledDepth2PastBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-3 Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledDepth3Brush}" />
-    </Style>
-    <Style Selector="ListBoxItem.for-depth-3.past-step Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledDepth3PastBrush}" />
-    </Style>
-
-    <!-- Changed-cell highlight: after the depth chains, before selection, so orange beats the
-         idle/depth tints and loses to selection. -->
-    <Style Selector="Border.transposed-cell.changed">
-        <Setter Property="Background" Value="{DynamicResource CellChangedBrush}" />
-    </Style>
-
-    <!-- Selection tint wins on every cell of the selected column; read-only / inapplicable /
-         changed selected variants keep both signals readable, mirroring canonical. -->
+    <!-- Selection foreground wins on every cell of the selected column. All four old selected
+         variants set the identical SelectionForegroundBrush, so one base rule covers them; the
+         selection BACKGROUND (including the read-only / inapplicable / changed variants) is folded
+         into the converter. -->
     <Style Selector="ListBoxItem:selected Border.transposed-cell">
-        <Setter Property="Background" Value="{DynamicResource SelectionBackgroundBrush}" />
-        <Setter Property="TextElement.Foreground" Value="{DynamicResource SelectionForegroundBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem:selected Border.transposed-cell.read-only-cell">
-        <Setter Property="Background" Value="{DynamicResource CellReadOnlySelectedBackgroundBrush}" />
-        <Setter Property="TextElement.Foreground" Value="{DynamicResource SelectionForegroundBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem:selected Border.transposed-cell.inapplicable">
-        <Setter Property="Background" Value="{DynamicResource CellDisabledSelectedBackgroundBrush}" />
-        <Setter Property="TextElement.Foreground" Value="{DynamicResource SelectionForegroundBrush}" />
-    </Style>
-    <Style Selector="ListBoxItem:selected Border.transposed-cell.changed">
-        <Setter Property="Background" Value="{DynamicResource CellChangedSelectedBackgroundBrush}" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource SelectionForegroundBrush}" />
     </Style>
 


### PR DESCRIPTION
Round 1 of the transposed grid perf work: cut allocation on the mutation hot path.

- Non-allocating action lookup on the analyze path
- Dense start-time array in the recipe snapshot
- Fewer enclosing-loop map allocations
- Lighter transposed cell view-model layer
- Recyclable text/read-only cell templates
- Converter-based cell background binding (kept deliberately; later weighted profiling confirmed the converter is allocation-friendlier than class selectors)
- Core allocation measurement probe

Verified: memory leveled out. This does NOT fix the felt scroll/add lag (that is a separate CPU cost, tracked separately). Base: `master`. First of three stacked PRs; merge this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
