### PR TITLE
perf: reuse transposed column cell subtrees on recycle

### DIFF
--- a/Docs/architecture/recipe-grid-surface.md
+++ b/Docs/architecture/recipe-grid-surface.md
@@ -36,14 +36,17 @@ The pieces:
 - `TransposedRecipeGridView` (`ReactiveUserControl<TransposedRecipeGridSurface>`) — a `ListBox`
   of step-columns over a horizontal `VirtualizingStackPanel` (no DataGrid): realized element
   count is viewport-bound regardless of recipe length, and whole-column selection comes from
-  `SelectionMode="Multiple"` natively. Cell templates are built in code by
-  `TransposedCellTemplateFactory` (a per-cell format kind is baked into each editing converter);
+  `SelectionMode="Multiple"` natively. Realized columns do not render cells through a
+  `FuncDataTemplate`; a view-owned pool hands each realized container a
+  `TransposedColumnCellsPresenter` whose fixed per-descriptor slots rebind on recycle, and
+  `TransposedCellTemplateFactory.CreateEditor` builds each slot's lazy display/editor cell (see
+  "Allocation characteristics" for the pool, the rebind-on-recycle reuse, and the lazy editor swap);
   `TransposedStepColumnClassBinder` stamps execution classes on item containers via
   `ContainerPrepared`/`ContainerClearing`. A tunnel pointer-pressed hook implements the
   select-then-edit press model (editors would otherwise swallow the bubbling press): a plain
   left click on a not-yet-selected column selects it and focuses the item container — keeping
-  Delete/Ctrl+C live — while a second click on the selected column falls through to the
-  always-live editor; Ctrl/Shift clicks toggle/extend the multi-selection; right/middle clicks
+  Delete/Ctrl+C live — while a second click on the selected column enters edit, building the
+  lazy editor for that cell; Ctrl/Shift clicks toggle/extend the multi-selection; right/middle clicks
   never change selection. A tunnel key-down handler implements the transposed arrow-key
   semantic (Right = next step, Down = next parameter), Enter commits by defocusing, and Escape
   reverts the pending text before defocusing.
@@ -234,8 +237,9 @@ Editing state is a view concern and is not on the interface. The chain:
 
 1. `CanonicalRecipeGridView.IsEditing` — set true in `BeginningEdit` (unless cancelled for an
    inapplicable column), false in `CellEditEnded`, reset to false on view deactivation.
-   `TransposedRecipeGridView.IsEditing` — true while an always-live cell editor holds keyboard
-   focus (the transposed view has no DataGrid edit lifecycle; focus is the editing signal).
+   `TransposedRecipeGridView.IsEditing` — true while the `TransposedTextEditCoordinator` holds an
+   active edit (its lazily-built editor focused). The transposed view has no DataGrid edit lifecycle;
+   the coordinator's single active edit is the editing signal.
 2. `RecipeGridHost.IsEditing` — forwards to whichever view is currently hosted as `Content`.
 3. `MainWindow.OnKeyDown` — suppresses the Delete/Ctrl+C/X/V global shortcuts while
    `RecipeGridHost.IsEditing` is true, so typing inside a cell editor never deletes or
@@ -263,14 +267,68 @@ same recipe and churned gen0 on every mutation. The reductions land in three pla
   the per-cell style-activator / dynamic-resource machinery those rules multiplied. The
   `TextElement.Foreground` setters stay as style setters (background stripped out), so foreground
   precedence is unchanged.
-- **Lighter cell VMs and recyclable templates.** Transposed cell view models are plain
-  `INotifyPropertyChanged`, not `ReactiveObject` (nothing observes a cell VM reactively);
-  `StepColumnViewModel.Cells` materialize lazily, so a column never scrolled to or keyboard-traversed
-  never builds its cell VMs; and the per-action metadata dictionaries (Units / FormatKinds /
-  GroupItems) are cached per `ActionDefinition` instead of rebuilt per row. The text and read-only
-  cell templates are `supportsRecycling: true`: the text editor displays through a OneWay converter
-  binding and commits in the focus/key handlers to a cell reference captured on `GotFocus` (a
-  stale-guard), so a still-focused recycled `TextBox` cannot write into the cell it was rebound onto.
+- **Lighter cell VMs.** Transposed cell view models are plain `INotifyPropertyChanged`, not
+  `ReactiveObject` (nothing observes a cell VM reactively); `StepColumnViewModel.Cells` materialize
+  lazily, so a column never scrolled to or keyboard-traversed never builds its cell VMs; and the
+  per-action metadata dictionaries (Units / FormatKinds / GroupItems) are cached per
+  `ActionDefinition` instead of rebuilt per row.
+
+- **Container recycling reuse (the source of canonical parity).** The dominant transient cost is
+  per-realized-column, not retained heap (six gcdumps confirmed the heap plateaus). The canonical
+  `DataGrid` is cheap on scroll not because its editors are lazy — its combo cells are always live —
+  but because it RECYCLES realized rows: a recycled row rebinds its subtree to the new data instead of
+  rebuilding it. The transposed grid previously defeated its own `supportsRecycling:true`: the inner
+  per-column `ItemsControl ItemsSource="{Binding Cells}"` received a fresh `Cells` list on every
+  container recycle and rebuilt every cell subtree from scratch, so a viewport jump that recycled
+  ~20-25 columns paid ~20-25 full column builds in one dispatcher frame. The fix rebinds instead of
+  rebuilds, mirroring the DataGrid.
+
+  A fixed-slot-in-`ItemTemplate` design (bind slot `i` to `Cells[i]` inside the container template)
+  cannot achieve this in Avalonia: `VirtualizingStackPanel` detaches a recycled container
+  (`RemoveInternalChild`), and on reattach `ContentPresenter` resets its recycling key, which forces a
+  full `ItemTemplate` rebuild (verified by decompiling `Avalonia.Base`/`Avalonia.Controls`). Reuse is
+  instead achieved with a **view-owned pool of direct-editor presenters** that live outside the
+  virtualization lifecycle: `TransposedColumnCellsPool` hands a `TransposedColumnCellsPresenter` (a
+  `StackPanel` subclass building one cell `Border` slot per `ParameterDescriptor`, no per-cell
+  `ContentControl`) to each realized container through `TransposedColumnCellsHost` (a `Decorator` in
+  the `ItemTemplate`). Because the presenters are pooled by the view and only injected into containers,
+  they survive detach/reattach; the `ListBox` still virtualizes. Each slot binds its `DataContext` to
+  `Cells[i]` via `CellSlotConverter` (index passed as `ConverterParameter`), so a container recycle
+  rebinds every slot from `columnA.Cells[i]` to `columnB.Cells[i]` and the subtree persists. Cell
+  height and the frozen left name-column alignment are unchanged; the execution-class binder and
+  current-step marker still operate at `ListBoxItem`/row level. Slots are only built for
+  actually-realized columns, so the never-realized-column `Lazy<>` optimization stays intact.
+
+- **Lazy display/editor swap for both cell kinds.** With reuse in place, live editors also leave the
+  jump hot path, and the remaining fresh-container weight is cut by rendering a display `TextBlock` by
+  default and building the `TextBox`/`ComboBox` editor only on edit entry. `TransposedLazyCellPresenter`
+  is the shared base; `TransposedTextCellPresenter` (display via `PropertyTextEditingMultiConverter`)
+  and `TransposedComboCellPresenter` (display via `ComboBoxDisplayTextConverter`, showing the selected
+  item's text) each build their editor lazily and swap back to the display on commit/blur. A single
+  view-level `TransposedTextEditCoordinator` owns the one active edit across both kinds — the
+  display→editor swap, focus, commit, and revert — so `IsEditing`/`GetActiveEditor`/`CloseActiveEditor`
+  and exit gating have one definition and one reset point on recycle. Read-only and inapplicable cells
+  stay display-only. The select-then-edit gesture is preserved: the first press selects the column
+  without editing, and a second press on the sole selected column (or F2 / a printable keystroke on a
+  focused display visual) enters edit; `FindFocusableEditor` targets the display presenters so arrow
+  navigation traverses cells and enters edit on demand. When no cell is in edit a realized column holds
+  only display `TextBlock`s — zero live `TextBox`/`ComboBox`.
+
+- **Commit-before-rebind hook.** Once editors persist across a rebind, the old commit path (editor
+  destroyed → `LostFocus` → commit) no longer fires reliably: a focused persistent editor whose
+  container rebinds in place raises no `LostFocus`, and the OneWay display binding would overwrite the
+  pending text — silent edit loss. An explicit commit runs before the slots rebind:
+  `TransposedColumnCellsPresenter.CommitActiveEditor` (invoked from its `OnDataContextBeginUpdate`,
+  which Avalonia calls top-down and stops at children whose `DataContext` is locally set, so it fires
+  while the editor still holds its pending text and captured cell) and from the host on recycle-out.
+  The `_editingCellProperty`/captured-cell stale-guard remains the backstop so a still-focused editor
+  cannot write into the cell it was rebound onto.
+
+- **Measured result.** On the viewport-jump metric (one `ScrollIntoView(last)` frame after a
+  round-trip, so it exercises container recycling), transposed bytes per realized column dropped from
+  ~14.5x the canonical recycled-row cost to ~1.03x (WideParams, 36 cells/column) and from ~2.3x to
+  ~0.69x (WithGroups, 5 cells/column); gen0/add fell from ~2.58 to ~0.17-0.25 (WideParams) and from
+  ~0.42 to ~0.00-0.08 (WithGroups). With no cell in edit the live-editor census is 0.
 
 ## Context menu placement
 

--- a/Docs/plans/completed/20260714-transposed-grid-realize-cost-reduction.md
+++ b/Docs/plans/completed/20260714-transposed-grid-realize-cost-reduction.md
@@ -1,0 +1,527 @@
+# Transposed Grid Column-Realize Cost Reduction
+
+## Overview
+
+The transposed recipe grid stutters ("тормозит") and churns ~50-100 MB of working set per added
+step column, with a gen0 GC roughly every second add. Two prior optimization rounds (Core allocation
+reductions in PR #132 and the `transposed-grid-allocation-reduction` branch) produced zero perceptible
+change, because both optimized paths that are not on the hot path the user feels: Core re-analysis and
+retained heap. The retained heap was never the problem (6 gcdumps confirmed it plateaus — no leak); the
+problem is transient per-realize churn plus UI-thread layout latency, which a gcdump erases by
+construction (it forces a full GC before capture and only shows live objects).
+
+A headless allocation probe that realizes the real view and measures allocation across an append
+*including the layout pass* (`TransposedViewAllocationProbe`) located the true cost, verified by two
+adversarial reviews with additive precision:
+
+- Per-add cost is CONSTANT in N (2.32 MB at N=20/60/120) — a fixed per-column realization cost, not a
+  leak and not O(N) accumulation.
+- Decomposition of 2,316 KB/add (WithGroups config, 5 cells/column): 755 KB realization chrome (cell
+  `Border` + 7-input background MultiBinding + `ContentControl` template resolve + `ListBoxItem`
+  container) + 647 KB for 2 live `ComboBox` + 915 KB for 3 live `TextBox`. Live editors are 67%.
+- The canonical grid is cheap (~382 KB/add at steady state) NOT because it lazy-builds editors (its
+  combo cells are also always-live) but because the DataGrid RECYCLES realized rows: a recycled row
+  rebinds at 382 KB versus a fresh build at ~970 KB. The transposed grid DEFEATS its own
+  `supportsRecycling:true`: on container recycle, the inner non-virtualized `ItemsControl`
+  (`TransposedRecipeGridView.axaml` `ItemsSource="{Binding Cells}"`) receives a fresh `Cells` list and
+  rebuilds every cell subtree from scratch.
+- The observed 50-100 MB + stutter is the real "add step" auto-scrolling to the inserted step: if the
+  viewport is far from the insertion point, the jump realizes a full viewport of columns (~20-25) in
+  one dispatcher frame. The one-column-shift probe does not reproduce this, so the probe must be
+  extended before and after the fix, and the viewport-jump number is the primary success metric.
+
+This plan applies two levers, in order of root-cause and risk:
+
+1. **Fix the container-recycling defeat first** (root cause, zero UX risk). Realized column containers
+   rebind their cell subtrees to the new column's data instead of rebuilding from scratch, the way the
+   canonical DataGrid does. The code is already engineered for rebind-on-recycle (the
+   `_editingCellProperty` stale-guard, OneWay display bindings, bound `MaxLength`). This turns the
+   viewport jump from ~20-25 fresh column builds into ~20-25 rebinds and is required for canonical
+   parity (even all-`TextBlock` columns cost ~2x a recycled canonical row without it).
+2. **Lazy display cells for both editor kinds, scoped by measurement.** A lightweight `TextBlock`
+   display by default, swapping in the `TextBox`/`ComboBox` editor only on edit entry. This removes the
+   67%-live-editor weight from the fresh-container build (first realize) and shrinks the live visual
+   tree the compositor carries. Its exact scope (both kinds, or only the heavier remaining one) is set
+   by the post-recycling measurement, since once containers rebind, live editors leave the jump hot
+   path. Click-and-type UX is preserved via the existing select-then-edit gesture, with the editor
+   built on the second (edit) press / keystroke.
+
+The two levers compose: recycling reuse removes the rebuild on every scroll-in; laziness reduces the
+weight of the remaining fresh builds and the resident visual tree.
+
+## Context (from discovery)
+
+- Files/components involved:
+  - `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml` (+ `.axaml.cs`) — the
+    view: outer vertical `ScrollViewer`, left parameter-name column, horizontal-virtualizing `ListBox`
+    of step columns; each column's inner `ItemsControl ItemsSource="{Binding Cells}"` (axaml:74) is the
+    rebuild-on-recycle site; cell `Border` carries the 7-input background MultiBinding and a
+    `ContentControl Content="{Binding}"`. The code-behind owns `GetActiveEditor` / `CloseActiveEditor` /
+    `IsEditing` and the arrow-key tunnel guard; these define "editing" as a focused editor and are
+    consumed by `RecipeGridHost`/`MainWindow` exit gating and the `EditorMustClose` subscription.
+  - `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs` — builds the per-kind
+    always-live editor templates; holds commit logic (`_editingCellProperty` stale-guard captured on
+    `GotFocus`, `LostFocus`/`KeyDown` commit, `OnComboBoxSelectionChanged` writeback), input-blocking
+    bindings for read-only/inapplicable.
+  - `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridNavigator.cs` — arrow-navigation via
+    `FindFocusableEditor`, which searches visual descendants for `TextBox`/`ComboBox` (lines ~152-167);
+    breaks if unfocused cells hold only `TextBlock`.
+  - `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridSelectionController.cs` — select-then-edit
+    gesture: first press selects the column and focuses the container WITHOUT an editor; second press on
+    the sole selected column falls through to the editor.
+  - `SemiStep/SemiStep.UI/RecipeGrid/Transposed/StepColumnViewModel.cs` — exposes `Cells` (a `Lazy<>`
+    list, one `ParameterCellViewModel` per `ParameterDescriptor`; cell count and row order are CONSTANT
+    across columns — this invariance is what enables slot reuse; the never-realized-column `Lazy<>`
+    optimization must be preserved).
+  - `SemiStep/SemiStep.UI/RecipeGrid/Transposed/ParameterCellViewModel.cs`, `ComboBoxCellViewModel.cs`,
+    `PropertyTextCellViewModel.cs`, `ReadOnlyCellViewModel.cs` — cell VMs.
+  - `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs` — `SetPropertyValue` already Ordinal-equality
+    guards writes (line ~182) and the action path guards `actionId == _step.ActionKey` (~172), so
+    same-value writeback no-ops at the model.
+  - `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs` — incremental mutation projection;
+    `RecipeCommandsViewModel` + `TransposedRecipeGridView.axaml.cs` drive `ScrollIntoView` on selection
+    after an add (the source of the viewport jump).
+  - `SemiStep/SemiStep.Tests/Performance/TransposedViewAllocationProbe.cs` — the measurement instrument.
+- Related patterns found: canonical `TextCellFactory` / `ComboBoxCellFactory` and DataGrid row
+  recycling; headless harness `UIFixture`, `TransposedVirtualizationTests`
+  (`PendingEdit_CommitsWhenItsColumnIsRecycledOut`, `RecycledContainer_CarriesExactlyOneSetOfExecutionClasses`,
+  `RecycledTextEditor_ShowsRebindTargetCellValue_AfterScroll`), `TransposedEditingTests`,
+  `TransposedGridSelectionController` tests (`PlainCellClick_SelectsColumn_WithoutFocusingEditor`,
+  `SecondClickOnSelectedColumn_FocusesEditor`, `IsEditing_TracksEditorFocus`).
+- Dependencies identified: `[AvaloniaFact]` headless tests; `Dispatcher.UIThread.RunJobs()` runs layout
+  on the calling thread, so `GC.GetAllocatedBytesForCurrentThread()` captures managed layout
+  allocations (not render/composition-thread cost); `Docs/architecture/recipe-grid-surface.md`.
+
+## Development Approach
+
+- **testing approach**: Regular (code-first), with mandatory parity/regression tests every task. This is
+  behavior-preserving refactoring guarded by strong existing UI tests; the risk is regressions in
+  edit/commit/recycling/navigation/selection correctness, so every task adds targeted headless tests and
+  must keep the full suite green.
+- complete each task fully before moving to the next; make small, focused changes.
+- **CRITICAL: every task MUST include new/updated tests** and they must pass before the next task.
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- Measurement discipline: each lever ends by re-running `TransposedViewAllocationProbe`
+  (`SEMISTEP_PROBE=1`) and recording the per-add / viewport-jump / gen0 deltas in Progress Tracking.
+- Behavior preservation is non-negotiable: select-then-edit gesture, click-and-type, keyboard
+  navigation, commit-on-blur, Enter/Escape, read-only/inapplicable gating, ComboBox writeback,
+  `IsEditing`/exit gating, and container recycling correctness must all stay identical in behavior.
+
+## Testing Strategy
+
+- **unit/headless tests**: required every task; `[AvaloniaFact]` tests realize the real view and assert
+  edit-entry, commit, cancel, selection, keyboard navigation, recycling, and parity.
+- **regression gate**: `TransposedVirtualizationTests`, `TransposedEditingTests`, and the selection-
+  controller tests must keep passing in behavior (adjust only where the display/editor split
+  legitimately changes the tree; the commit-on-recycle test moves from "LostFocus fires" to an explicit
+  commit-before-rebind hook — see Task 2).
+- **measurement gate (not CI-asserted)**: the allocation probe is a manual `SEMISTEP_PROBE=1` run; its
+  numbers are recorded here with ratio-based acceptance targets, not asserted in CI (byte counts are
+  environment/framework-version sensitive and would flake).
+- no e2e/browser test framework in this project.
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done.
+- add newly discovered tasks with plus prefix; document blockers with warning prefix.
+- record probe baselines and per-lever deltas here as they are measured.
+- **Baseline (Debug, WithGroups, 560x800, one-column shift)**: transposed ~2,316 KB/add, gen0/add ~0.42;
+  canonical ~382 KB/add, gen0/add ~0.08. Decomposition: chrome 755 KB, 2 ComboBox 647 KB, 3 TextBox
+  915 KB. Wide-config baseline and full-viewport-jump baseline: measured in Task 1.
+- **Task 1 measured baselines (Debug, `TransposedViewAllocationProbe`, per-add is bytes/add over 12
+  measured appends after 6 warmups; viewport-jump is one `ScrollIntoView(last)` frame after a warmup
+  round-trip so it exercises container recycling):**
+  - *WithGroups (560x800, 5 cells/column: ComboBox=2, TextBox=5, TextBlock=7):*
+    - transposed per-add: N=20 2,322,812 B (gen0/add 0.50); N=60 2,321,343 B (0.42); N=120 2,319,876 B
+      (0.42) — CONSTANT in N.
+    - canonical per-add: N=20 970,435 B (0.17); N=60 382,061 B (0.08); N=120 383,855 B (0.08) — recycled
+      steady state ~382 KB.
+    - viewport-jump N=120: total 11,518,432 B over 5 realized columns → **2,303,686 B per realized
+      column** (≈ full per-add cost per column: the transposed grid rebuilds cell subtrees on recycle).
+  - *WideParams (1400x800, 36 cells/column: ComboBox=4, TextBox=34, TextBlock=39):*
+    - transposed per-add: N=20 14,913,892 B (gen0/add 2.50); N=60 14,853,975 B (2.50); N=120 14,854,554 B
+      (2.58) — CONSTANT in N.
+    - canonical per-add: N=20 2,869,264 B (0.42); N=60 1,016,171 B (0.17); N=120 1,017,318 B (0.17) —
+      recycled steady state ~1,017 KB.
+    - viewport-jump N=120: total 207,011,992 B over 14 realized columns → **14,786,570 B per realized
+      column** (≈ full per-add cost per column; ~14.5x the canonical recycled per-add — the primary
+      target for the Task 2 container-reuse fix).
+- **Success criteria (ratio, vs same-run canonical)**: primary — viewport-jump bytes per realized
+  column <= ~2x the canonical recycled-row cost; secondary — transposed recycled per-add within ~2x
+  canonical per-add; gen0/add materially reduced. "Substantially reduced" is not a gate; ratios are.
+- **Task 2 measured post-recycling (Debug, `TransposedViewAllocationProbe`, pooled-presenter reuse):**
+  - *WithGroups (560x800):* transposed per-add ~638,060 B (was 2,321,343; **3.6x** less), gen0/add
+    0.08–0.25 (was 0.42); canonical per-add ~382,910 B → **~1.67x canonical**. Viewport-jump per
+    realized column **623,788 B** (was 2,303,686; **3.69x** less) → **~1.63x** the canonical recycled
+    cost — **meets the ≤2x primary target**.
+  - *WideParams (1400x800):* transposed per-add ~3,376,326 B (was 14,853,975; **4.4x** less), gen0/add
+    ~0.50–0.58 (was ~2.58); canonical per-add ~1,016,764 B → **~3.32x canonical**. Viewport-jump per
+    realized column **3,302,412 B** (was 14,786,570; **4.48x** less) → **~3.25x** the canonical recycled
+    cost — better than 14.5x, but **still above the ≤2x target**.
+  - *Mechanism note:* the fixed-slot-in-ItemTemplate design in the plan cannot work — Avalonia's
+    `VirtualizingStackPanel` detaches recycled containers (`RemoveInternalChild`) and `ContentPresenter`
+    resets its recycling key on reattach, so the ENTIRE ItemTemplate content (verified: the panel
+    instance changes on a one-column scroll) is rebuilt on every recycle. Reuse is achieved instead by a
+    view-owned POOL of `TransposedColumnCellsPresenter`s (direct editor controls, no per-cell
+    `ContentControl`, so they survive detach/reattach) injected into each realized container by
+    `TransposedColumnCellsHost`; the ListBox still virtualizes, the heavy cell subtrees are reused.
+- **Task 3 measured post-text-lazy (Debug, `TransposedViewAllocationProbe`, lazy TextBox display/editor
+  swap):**
+  - *WithGroups (560x800):* transposed per-add ~468,168 B (was post-Task-2 ~638,060; canonical ~384,197)
+    → **~1.22x canonical** (was 1.67x), gen0/add 0.08–0.17. Viewport-jump per realized column
+    **452,419 B** (was 623,788; **1.38x** less) → **~1.18x** the canonical recycled cost — well under the
+    ≤2x primary target. Realized-column census now ComboBox=2, TextBox=2 (combo-internal only),
+    TextBlock=7: the property-text editors are no longer live.
+  - *WideParams (1400x800):* transposed per-add ~1,456,493 B (was post-Task-2 ~3,376,326; canonical
+    ~1,018,231) → **~1.43x canonical** (was 3.32x), gen0/add 0.17–0.25 (was ~0.50–0.58). Viewport-jump
+    per realized column **1,418,376 B** (was 3,302,412; **2.33x** less) → **~1.39x** the canonical
+    recycled cost — **now under the ≤2x target** (was ~3.25x). Realized-column census now ComboBox=4,
+    TextBox=4 (combo-internal only), TextBlock=39: all 34 property-text editors are lazy.
+  - *Note:* text-lazy alone brings BOTH configs under the ≤2x primary target. The remaining >1x gap and
+    the 4 live `ComboBox` per wide column are the Task-4 combo-lazy target.
+- **Task 4 measured post-combo-lazy (Debug, `TransposedViewAllocationProbe`, lazy ComboBox display/editor
+  swap; both editor kinds now lazy):**
+  - *WithGroups (560x800):* transposed per-add ~284,107 B (was post-Task-3 ~468,168; canonical ~383,764)
+    → **~0.74x canonical** (below the recycled canonical row), gen0/add 0.00–0.08. Viewport-jump per
+    realized column **265,342 B** (was 452,419; **1.71x** less) → **~0.69x** the canonical recycled cost.
+    Realized-column census now **ComboBox=0, TextBox=0, TextBlock=6**: with no cell in edit the column
+    holds only display TextBlocks — every editor is lazy.
+  - *WideParams (1400x800):* transposed per-add ~1,088,428 B (was post-Task-3 ~1,456,493; canonical
+    ~1,017,700) → **~1.07x canonical** (was 1.43x), gen0/add 0.17–0.25. Viewport-jump per realized column
+    **1,049,855 B** (was 1,418,376; **1.35x** less) → **~1.03x** the canonical recycled cost (was ~1.39x).
+    Realized-column census now **ComboBox=0, TextBox=0, TextBlock=37**: all 4 combos + 34 text editors are
+    lazy — the realized column is now all-TextBlock chrome.
+  - *Result:* combo-lazy pulls BOTH configs to canonical parity (WithGroups ~0.69x, WideParams ~1.03x of
+    the canonical recycled row on the viewport-jump metric) — well inside the ≤2x primary target, and the
+    residual live-ComboBox weight is gone (0 combos when no cell is in edit; one is built only during an
+    active edit).
+- **Lazy-editor scope decision (Tasks 3-4)**: keep BOTH lazy levers. Post-recycling, WithGroups already
+  sits at ~1.63x canonical, but WideParams is still ~3.25x because each fresh-container build and each
+  jump still instantiates all live editors (34 `TextBox` + 4 `ComboBox` per wide column). `TextBox`
+  laziness (Task 3) is justified by COUNT (34/column drives the wide gap); `ComboBox` laziness (Task 4)
+  by per-instance WEIGHT (each combo is the heaviest single cell). Both are needed to pull WideParams
+  from ~3.25x down toward the ≤2x target; the user chose both, and the measurement confirms neither is
+  redundant.
+
+## Solution Overview
+
+- **Recycling reuse (Task 2, the root fix)**: the inner presenter's slot structure is stable because
+  every column has one cell per `ParameterDescriptor` in the same row order. Replace the rebuild-on-swap
+  inner `ItemsControl` with a fixed-slot presenter built once per container from `ParameterDescriptors`,
+  where slot i's data context resolves to `Cells[i]`. When the `ListBoxItem` recycles to a new
+  `StepColumnViewModel`, each slot rebinds `Cells[i]` and the subtree persists (rebind, not rebuild),
+  mirroring DataGrid row recycling. A recycled editor now persists and may keep focus, so commit-on-
+  recycle must move from the current "editor destroyed -> LostFocus -> commit" side effect to an
+  explicit commit-before-rebind hook (on container `DataContext` change / `ContainerClearing`), with the
+  `_editingCellProperty` stale-guard as backstop.
+- **Lazy cell (Tasks 3-4)**: a view-level edit coordinator (see Technical Details) owns the single
+  active edit. Cells render a display `TextBlock` by default; the editor is constructed only on edit
+  entry via the existing select-then-edit gesture (or F2 / typing on a focused display visual) and
+  released on commit. Read-only cells stay a `TextBlock` always. Display visuals are focusable so
+  keyboard navigation traverses cells; `FindFocusableEditor` is reworked to target display visuals and
+  enter edit on demand.
+- **Why this fits**: it converges the transposed grid onto the canonical reuse model, keeps the
+  router/surface projection untouched, and is contained to the view + template factory + navigator +
+  selection controller + a view-level edit coordinator.
+
+## Technical Details
+
+- **Edit-state ownership (pinned decision)**: a single view-level edit coordinator (owned by
+  `TransposedRecipeGridView`) holds the one active edit (its container/cell and the built editor),
+  performs the display->editor swap, and commits/reverts on exit, on entering another cell, and before a
+  container rebind/recycle. Cells hold NO `IsEditing` state (at most a coordinator-driven projection).
+  This gives one place to reset on recycle and one definition of `IsEditing` for exit gating.
+- **Recycling reuse mechanism**: fixed-slot presenter; slot count built once per container from the
+  config-constant `ParameterDescriptors`, not per rebind. Slot i binds `Cells[i]`; verify the
+  `Classes.*` bindings, the 7-input background MultiBinding, and the `IsSelected`
+  `RelativeSource AncestorType=ListBoxItem` leg all rebind cleanly on leaf `DataContext` change. The
+  execution-class binder and current-step marker operate at `ListBoxItem`/Row level and are unaffected.
+  Preserve the never-realized-column `Lazy<>` optimization in `StepColumnViewModel`.
+- **Task 2 spike finding (chosen mechanism, verified against Avalonia 12.0.5 by decompiling
+  `Avalonia.Base`/`Avalonia.Controls`)**: the inner `ItemsControl` is replaced by
+  `TransposedColumnCellsPanel` (a vertical `StackPanel` subclass). It builds N cell-`Border` slots
+  ONCE (N = `Cells.Count`, which equals the config-constant `ParameterDescriptors.Count`, and only
+  ever realizes on an actually-realized container so the `Lazy<>` stays intact). Each slot's
+  `DataContext` binds to `Cells[i]` via `CellSlotConverter` (index passed as `ConverterParameter`),
+  so a container recycle rebinds every slot from `columnA.Cells[i]` to `columnB.Cells[i]` with the
+  subtree persisting. The cell `Border` keeps its exact structure — `Classes.*` bindings, the 7-input
+  background MultiBinding, and the inner `ContentControl Content="{Binding}"` editor. `ContentPresenter`
+  reuses the realized editor across the DataContext change because the same recycling `FuncDataTemplate`
+  re-resolves (`ContentPresenter.CreateChild`: `recyclingDataTemplate == _recyclingDataTemplate` →
+  passes `oldChild` as `existing`), and the cell kind is constant per slot (descriptor-determined). The
+  commit-before-rebind hook is `TransposedColumnCellsPanel.OnDataContextBeginUpdate`, which Avalonia
+  calls top-down and (per `StyledElement.DataContextNotifying`) stops at children whose `DataContext`
+  is locally set (the bound slot Borders), so the panel's hook fires while the still-focused editor
+  holds its pending text and old cell, before any slot rebinds. The editor re-captures its stale-guard
+  cell on `DataContextChanged` while focused, so an edit after an in-place recycle targets the shown
+  cell.
+- **Commit-before-rebind**: an explicit hook fires before a container is rebound to a new column; it
+  commits the active edit to the captured cell (stale-guard target), then the slots rebind. Without
+  this, a focused persistent editor never raises `LostFocus` and the OneWay display binding overwrites
+  pending text — silent edit loss.
+- **Select-then-edit under lazy**: first press selects the column and focuses the container without
+  entering edit; second press on the sole selected column (or F2 / a printable keystroke on a focused
+  display visual) enters edit — the coordinator builds and focuses the editor. Do NOT enter edit on raw
+  first pointer-press (that would break column selection).
+- **Click-and-type / first-keystroke fidelity**: prefer synchronous editor construction and focus inside
+  the input handler so the first character is not dropped or doubled; if a `Dispatcher.Post` is
+  unavoidable, buffer `TextInput` during the pending swap. Cover both the `TextInput` and `KeyDown`
+  routes.
+- **ComboBox writeback**: same-value writes already no-op at the model (`RecipeRowViewModel`), and the
+  initial `SelectionChanged` already fires on every always-live realize today; the deliverable is a test
+  proving the lazy-open initial selection produces no recipe edit and no dirty marking, not new guard
+  code (handler-level guard is optional hardening).
+- **Row alignment**: the slot reuse and the display/editor swap must not change cell height or the
+  header/marker/row alignment across the frozen left name column and the step columns.
+
+## What Goes Where
+
+- **Implementation Steps** (checkboxes): probe extension, recycling reuse, lazy text cells, lazy combo
+  cells, verification, documentation — all in this repo.
+- **Post-Completion** (no checkboxes): the user runs the probe against their real PLC YAML config in a
+  Release build and captures a `dotnet-counters`/Rider snapshot of a real "add step while scrolled away"
+  to confirm the render/composition-side reduction that headless cannot measure.
+
+## Implementation Steps
+
+### Task 1: Extend the allocation probe with real-scale config and the viewport-jump scenario
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/Performance/TransposedViewAllocationProbe.cs`
+- Create: a wide test config fixture under `SemiStep/SemiStep.Tests/YamlConfigs/` (e.g. `WideParams/`)
+  approximating real scale (~30-40 parameters, several combo columns), or extend a config helper to seed
+  a high parameter count.
+- Create: `SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedViewportJumpTests.cs`
+
+- [x] Parameterize the probe over config name and window width so it runs WithGroups (5 cells) and a
+      wide config; keep the existing per-add + gen0 + column-composition output.
+- [x] Add a "viewport-jump" measurement: seed N, realize, scroll to horizontal start, then measure the
+      allocation of a single `ScrollIntoView(last)` jump (start -> end); report bytes, bytes per
+      realized column, and realized-container count for that one frame.
+- [x] Add the wide config fixture and confirm the probe realizes multiple combo + text columns with it.
+      (`YamlConfigs/WideParams/`, 36 cells/column: probe reports ComboBox=4, TextBox=34, TextBlock=39.)
+- [x] Run `SEMISTEP_PROBE=1 dotnet test ... --filter "FullyQualifiedName~TransposedViewAllocationProbe"`;
+      record WithGroups, wide-config, and viewport-jump baselines in Progress Tracking.
+- [x] Write a suite-resident headless test asserting the viewport-jump path keeps realized-container
+      count within a viewport bound after the jump (reuse the `TransposedVirtualizationTests` bound
+      pattern); run tests - must pass before Task 2.
+      (`TransposedViewportJumpTests.cs`, 2 tests, no SEMISTEP_PROBE gate, both green.)
+
+### Task 2: Reuse column-container cell subtrees on recycle (root fix: rebind, not rebuild)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml` (+ `.axaml.cs`)
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/StepColumnViewModel.cs` (only if a stable slot
+  projection / indexer access is needed; preserve the `Lazy<>` optimization)
+
+- [x] Time-boxed spike (default to the fixed-slot presenter; do not spend time confirming that a plain
+      `ItemsControl` resets on `ItemsSource` ref change — it does): verify the `Classes.*` bindings, the
+      7-input background MultiBinding, and the `IsSelected` `RelativeSource` leg rebind cleanly on leaf
+      `DataContext` change, and that slot count is built once from `ParameterDescriptors`. Record the
+      chosen mechanism in this plan.
+      (Spike DISPROVED the fixed-slot-in-ItemTemplate mechanism: Avalonia detaches recycled containers
+      and rebuilds the whole ItemTemplate content on recycle — see the mechanism note in Progress
+      Tracking. Chosen mechanism: a view-owned pool of direct-editor presenters injected via a host.)
+- [x] Replace the rebuild-on-swap inner `ItemsControl` with the fixed-slot presenter so a recycled
+      container rebinds slot i from the old column's `Cells[i]` to the new column's `Cells[i]`; keep cell
+      height and row alignment identical.
+      (`TransposedColumnCellsPresenter` + `TransposedColumnCellsPool` + `TransposedColumnCellsHost`;
+      `CellSlotConverter` binds each slot to `Cells[i]`; cell height/row alignment unchanged.)
+- [x] Implement the explicit commit-before-rebind hook (container `DataContext` change /
+      `ContainerClearing`) so an in-progress edit commits to the captured cell before slots rebind; keep
+      the `_editingCellProperty` stale-guard as backstop.
+      (`TransposedCellTemplateFactory.CommitFocusedEditorWithin`, called from the host on recycle-out and
+      from the presenter's `OnDataContextBeginUpdate`; `_editingCellProperty` stale-guard kept.)
+- [x] Preserve the background-state converter, execution-class binding, current-step marker, and frozen
+      left name-column alignment across reuse; preserve the never-realized-column `Lazy<>` optimization.
+      (Header/marker/name column stay in the ItemTemplate; presenters only touch `Cells` for realized
+      columns; `TransposedCellStyleRenderTests` + execution-class tests stay green.)
+- [x] Write headless tests: scroll a column out and a new one in reuses the SAME container/editor
+      instance (assert reference identity before/after) and shows correct per-cell data; a focused editor
+      with pending text whose container rebinds IN PLACE (no focus move) commits to the captured cell
+      then shows the rebind-target value; no execution-class or handler leakage. Update
+      `PendingEdit_CommitsWhenItsColumnIsRecycledOut` to the commit-before-rebind mechanism.
+      (`RecycledContainer_ReusesSameEditorInstance_ReboundToNewColumn`,
+      `FocusedEditor_PendingText_CommitsToCapturedCell_ThenReusedEditorShowsRebindTarget`;
+      `PendingEdit_CommitsWhenItsColumnIsRecycledOut` reworded to commit-before-rebind. Note: Avalonia
+      blurs the detached editor on recycle, so commit fires via LostFocus + the explicit hook, not an
+      in-place no-focus-move rebind.)
+- [x] Run the probe; record post-recycling per-add + viewport-jump deltas vs canonical. Decide and record
+      the remaining lazy-editor scope (which cell kinds still justify laziness given the measured
+      fresh-container and compositor-tree cost). Run full tests - must pass before Task 3.
+      (Numbers + lazy-scope decision recorded in Progress Tracking; full suite green: 1331 passed, 2
+      skipped, 0 failed.)
+
+### Task 3: Lazy display/editor swap for property-text (TextBox) cells
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml` (+ `.axaml.cs`,
+  the view-level edit coordinator)
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridNavigator.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridSelectionController.cs`
+
+- [x] Add the view-level edit coordinator (single active edit; owns display->editor swap, focus, commit,
+      revert, and reset on exit / entering another cell / before recycle). Redefine `IsEditing` /
+      `GetActiveEditor` / `CloseActiveEditor` in terms of the coordinator; keep `EditorMustClose` and
+      exit gating behavior intact.
+      (`TransposedTextEditCoordinator` owns the one active edit; `GetActiveEditor` returns the
+      coordinator's active editor first, then a focused ComboBox; `_editCoordinator.Reset()` on surface
+      rebind. Host/MainWindow exit-gating and `EditorMustClose`→`CloseActiveEditor` unchanged.)
+- [x] Render a display `TextBlock` (shared display converter) by default for property-text cells; build
+      the `TextBox` editor only on edit entry, and release it on commit.
+      (`TransposedTextCellPresenter`: display `TextBlock` via `PropertyTextEditingMultiConverter`; editor
+      lazily built by `CreateTextBoxEditor` on first edit and swapped back to display on blur/commit.)
+- [x] Preserve the select-then-edit gesture: first press selects column without editing; second press on
+      the sole selected column enters edit; make display visuals focusable and rework
+      `FindFocusableEditor` so arrow navigation traverses cells and a keystroke/F2 enters edit.
+      (Selection controller reports fall-through on the second press; `TryEnterTextEditFromPointer` opens
+      the editor; presenter is `Focusable`; `FindFocusableEditor` targets `TransposedTextCellPresenter or
+      ComboBox`; F2/printable keystroke on a focused display enters edit.)
+- [x] Preserve commit semantics: Enter/LostFocus commit through the existing parse path, Escape reverts;
+      read-only/inapplicable and surface read-only block entry; reset via coordinator on recycle.
+      (Enter/LostFocus → `CommitEditor` (ParseForCommit); Escape reverts and exits; `CanEnterEdit` gates on
+      `IsEffectivelyEnabled`; commit-before-rebind via `CommitEdit` on detach + `CommitActiveEditor` on
+      the pooled presenter, replacing the focus-based `CommitFocusedEditorWithin`.)
+- [x] Write headless tests: select-then-edit (first press selects, second enters edit — mirror
+      `PlainCellClick_SelectsColumn_WithoutFocusingEditor` / `SecondClickOnSelectedColumn_FocusesEditor`);
+      keyboard traversal focuses display visuals and F2/typing enters edit; click-and-type keeps EXACTLY
+      one first character (no drop, no double) over both TextInput and KeyDown, including a rapid
+      two-character burst in order; Enter commits, Escape reverts, blur commits; read-only/inapplicable
+      does not enter edit; recycle across scroll leaks no editor or stale text; `IsEditing` tracks the
+      coordinator.
+      (Editing/Navigation/Virtualization tests reworked to the display+F2 gesture; new tests:
+      `PrintableKeyThenTextInput_EntersEdit_KeepsExactlyOneCharacter`,
+      `TextInputWithoutKeyDown_EntersEdit_KeepsExactlyOneCharacter`, `RapidTwoCharacterBurst_TypesBothInOrder`,
+      `KeyboardTraversal_FocusesDisplayPresenter_ThenF2EntersEdit`, `InapplicableTextCell_DoesNotEnterEdit`,
+      `SurfaceReadOnly_TextCell_DoesNotEnterEdit`; `EscapeKey_RevertsPendingText` asserts the display + exit;
+      `IsEditing_TransposedArm_TracksEditorFocus_ThroughHostForwarding` enters edit via the gesture.)
+- [x] Run the probe; record post-text-lazy per-add + viewport-jump delta. Run full tests - must pass
+      before Task 4.
+      (Numbers recorded in Progress Tracking: WithGroups viewport-jump ~1.18x canonical, WideParams ~1.39x
+      — both under the ≤2x target. Full suite green: 1337 passed, 2 skipped, 0 failed.)
+
+### Task 4: Lazy display/editor swap for ComboBox cells
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml` (+ `.axaml.cs`)
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/ComboBoxCellViewModel.cs` (only if a selected-
+  display projection is needed)
+
+- [x] Render a display `TextBlock` showing the selected item's text by default for combo cells; build
+      the `ComboBox` only on edit entry (second press / focus / dropdown-open intent) via the coordinator.
+      (`TransposedComboCellPresenter` shares the `TransposedLazyCellPresenter` base + the one edit
+      coordinator with the text path; display TextBlock binds (Value, Items) through
+      `ComboBoxDisplayTextConverter`; `TransposedCellTemplateFactory.CreateComboCellPresenter` builds the
+      ComboBox lazily via `CreateComboBox` and opens its dropdown on entry.)
+- [x] Keep the display text correct across recycling (rebind shows the new cell's selection) and across
+      external value changes (selector edit / action change).
+      (The OneWay (Value, Items) MultiBinding rebinds on the slot DataContext change and re-fires on any
+      Value PropertyChanged; tests `RecycledComboCell_ShowsRebindTargetSelection_NotStale` and
+      `ExternalActionChange_UpdatesComboDisplay`.)
+- [x] Preserve read-only/inapplicable gating (non-hit-testable, non-focusable when column read-only) and
+      surface read-only state; reset edit state via the coordinator on recycle.
+      (Presenter binds IsHitTestVisible/Focusable to the interactive expression and IsEnabled to the
+      editable expression, so a read-only/inapplicable/surface-read-only combo cannot enter edit;
+      `CommitActiveEditor` reverts a combo slot on recycle via the shared base.)
+- [x] Write headless tests: entering a combo cell builds the ComboBox and shows the current selection;
+      the lazy-open initial selection produces NO recipe edit and NO dirty/IsChanged marking; changing
+      selection writes back once; read-only combo does not enter edit; recycle shows the rebind-target
+      selection.
+      (`TransposedComboEditingTests`: `ComboCell_RendersDisplayText_NoLiveComboBox_ByDefault`,
+      `SecondClickOnSelectedComboColumn_EntersEdit_BuildsComboBox_ShowsSelection`,
+      `F2OnFocusedComboDisplay_EntersEdit_BuildsComboBox`,
+      `LazyComboOpen_InitialSelection_ProducesNoRecipeEditOrDirtyMarking`,
+      `ComboSelectionChange_WritesBackExactlyOnce`, `InapplicableCombo_DoesNotEnterEdit`,
+      `SurfaceReadOnly_Combo_DoesNotEnterEdit`, `ExternalActionChange_UpdatesComboDisplay`,
+      `RecycledComboCell_ShowsRebindTargetSelection_NotStale`. Editing/Navigation tests reworked to the
+      combo display + F2/second-click gesture.)
+- [x] Run the probe; record post-combo-lazy per-add + viewport-jump delta. Run full tests - must pass
+      before Task 5.
+      (Numbers recorded in Progress Tracking: WithGroups viewport-jump ~0.69x canonical, WideParams ~1.03x
+      — both at parity, ComboBox census 0 when not editing. Full suite green: 1346 passed, 2 skipped, 0
+      failed.)
+
+### Task 5: Verify acceptance criteria
+
+- [x] Verify success criteria by ratio (Progress Tracking): viewport-jump bytes per realized column
+      <= ~2x canonical recycled-row cost (primary); transposed recycled per-add within ~2x canonical
+      per-add (secondary); gen0/add materially reduced. Record final numbers for WithGroups and wide
+      config.
+      (Fresh `SEMISTEP_PROBE=1` run confirms the recorded post-Task-4 numbers. **WithGroups:** viewport-jump
+      265,385 B/realized-col vs canonical recycled 382,499 B → **0.69x** (primary, ≤2x met); transposed
+      per-add 283,992 B vs canonical 382,499 → **0.74x** (secondary, ≤2x met); gen0/add 0.00–0.08 vs
+      baseline 0.42 — materially reduced. Realized-column census ComboBox=0 TextBox=0 TextBlock=6.
+      **WideParams:** viewport-jump 1,050,096 B/realized-col vs canonical 1,017,256 B → **1.03x** (primary);
+      transposed per-add 1,084,161 B vs canonical 1,017,256 → **1.07x** (secondary); gen0/add 0.17–0.25 vs
+      baseline ~2.58 — materially reduced. Census ComboBox=0 TextBox=0 TextBlock=37. Both configs at
+      canonical parity, well inside every gate.)
+- [x] Verify behavior parity: select-then-edit, click-and-type, keyboard navigation, commit/cancel,
+      read-only/inapplicable, ComboBox writeback, `IsEditing`/exit gating, recycling correctness — all
+      unchanged.
+      (Confirmed by test inventory + full green run. select-then-edit: `PlainCellClick_SelectsColumn_WithoutFocusingEditor`,
+      `SecondClickOnSelectedColumn_FocusesEditor`, `SecondClickOnSelectedComboColumn_EntersEdit_BuildsComboBox_ShowsSelection`.
+      click-and-type first-keystroke fidelity: `PrintableKeyThenTextInput_EntersEdit_KeepsExactlyOneCharacter`,
+      `TextInputWithoutKeyDown_EntersEdit_KeepsExactlyOneCharacter`, `RapidTwoCharacterBurst_TypesBothInOrder`.
+      keyboard nav: `TransposedNavigationTests` (13 tests). commit/cancel: `TypeAndCommitWithEnter_UpdatesCoordinator`,
+      `EscapeKey_RevertsPendingText`, `ClickOnOtherColumn_CommitsPendingEditByDefocusing`,
+      `Down_FromTextBox_CommitsPendingEditByDefocusing`. read-only/inapplicable: `InapplicableCell_EditorIsDisabled`,
+      `ReadOnlyMode_DisablesEditors_AndEditorMustCloseDefocusesActiveOne`, `Inapplicable{Text,Combo}Cell_DoesNotEnterEdit`,
+      `SurfaceReadOnly_{TextCell,Combo}_DoesNotEnterEdit`. ComboBox writeback: `LazyComboOpen_InitialSelection_ProducesNoRecipeEditOrDirtyMarking`,
+      `ComboSelectionChange_WritesBackExactlyOnce`. IsEditing/exit gating: `IsEditing_TracksEditorFocus`,
+      `EditorMustClose_ClosesOpenComboBoxDropdown`. recycling correctness: `RecycledContainer_ReusesSamePresenterInstance_ReboundToNewColumn`,
+      `FocusedEditor_PendingText_CommitsToCapturedCell_ThenReusedSlotShowsRebindTarget`,
+      `PendingEdit_CommitsWhenItsColumnIsRecycledOut`. No gaps found — no new parity tests needed.)
+- [x] Verify edge cases: read-only surface state, inapplicable cells, action change / selector edit,
+      empty recipe, single-step recipe, rapid add-while-scrolled-away.
+      (Already covered: read-only surface `SurfaceReadOnly_*`/`ReadOnlySurface_BlocksSelectorEdit`;
+      inapplicable `Inapplicable*_DoesNotEnterEdit`; action change / selector edit
+      `ActionCombo_SelectionChange_ChangesStepAction_AndMarksCells`, `ExternalActionChange_UpdatesComboDisplay`,
+      `TransposedSelectorEditTests` (4 tests). Added `TransposedEdgeCaseTests` (3 view-level tests) to close
+      the remaining gaps: `EmptyRecipe_View_RendersNameColumn_AndNoStepContainers` (empty recipe: name
+      column renders, zero realized containers, no crash), `SingleStepRecipe_View_RealizesOneColumn_WithAllEditorsLazy`
+      (single step: one column, zero live TextBox/ComboBox, display presenters only),
+      `AddStepWhileScrolledFarAway_RealizesNewColumn_ShowsItsValue_AndStaysViewportBound` (rapid
+      add-while-scrolled: realized count stays viewport-bound after auto-scroll, pooled slot rebinds to the
+      new column's own value). All 3 green.)
+- [x] Run the full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`.
+      (**1349 passed, 2 skipped, 0 failed** — +3 vs the post-Task-4 1346 from the new edge-case tests. The 2
+      skips are the env-gated allocation probes.)
+- [x] Run `dotnet format SemiStep/SemiStep.slnx` (pre-commit hook enforces it).
+      (`dotnet format SemiStep/SemiStep.slnx` ran on this toolchain; it fixed a CHARSET issue on the new
+      test file, then `--verify-no-changes` passes clean. No other formatting drift.)
+
+### Task 6: Update documentation
+
+- [x] Update `Docs/architecture/recipe-grid-surface.md` allocation section: document the container-reuse
+      model (canonical parity comes from recycling, not lazy editors alone), the view-level edit
+      coordinator + lazy swap, and the commit-before-rebind hook.
+      (Rewrote the "Allocation characteristics" section: container recycling reuse via the view-owned
+      pool of `TransposedColumnCellsPresenter`/`Pool`/`Host` + `CellSlotConverter` and why fixed-slot-in-
+      ItemTemplate is not viable in Avalonia; the lazy display/editor swap for both kinds
+      (`TransposedLazyCellPresenter` base, `TransposedText`/`ComboCellPresenter`, shared
+      `TransposedTextEditCoordinator`); the commit-before-rebind hook; final ratios (WithGroups ~0.69x,
+      WideParams ~1.03x). Also corrected the now-stale "always-live editor" mentions in the overview and
+      the IsEditing chain.)
+- [x] Update `CLAUDE.md` only if a new durable convention emerged (e.g., the edit-coordinator pattern).
+      (No new durable convention; skipped. The project CLAUDE.md explicitly forbids specifics — "do not
+      add specifics here. See the human readable docs in Docs\*." The edit-coordinator / pooled lazy-cell
+      pattern is a grid-specific detail, now documented in recipe-grid-surface.md.)
+- [x] Move this plan to `Docs/plans/completed/`.
+      ([x] harness moves the plan after finalize (not moved here).)
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems - no checkboxes, informational only*
+
+**Manual verification**:
+- Run `TransposedViewAllocationProbe` against the real PLC YAML config in a **Release** build with a
+  realistic wide window; the headless number omits render/composition-thread cost and the test config is
+  smaller than production, so the real reduction is confirmed on the running app.
+- Capture a Rider Timeline (CPU + allocations with stacks) or `dotnet-counters` (gen0 count, allocation
+  rate) of a real "add step while scrolled far away" before/after to confirm the stutter and working-set
+  churn are gone on the compositor side, which headless cannot measure.
+- Sanity-check click-and-type latency and first-keystroke fidelity by hand in the running app (the
+  swap-on-edit path is the main UX risk).

--- a/SemiStep/SemiStep.Tests/Performance/TransposedViewAllocationProbe.cs
+++ b/SemiStep/SemiStep.Tests/Performance/TransposedViewAllocationProbe.cs
@@ -1,0 +1,308 @@
+﻿using System.Linq;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid;
+using SemiStep.UI.RecipeGrid.Transposed;
+
+using Xunit;
+
+namespace SemiStep.Tests.Performance;
+
+// Manual measurement tool, NOT part of the normal suite. Run it directly with the real headless view
+// realized in a window so the layout/realization pass is included in the measurement:
+//   SEMISTEP_PROBE=1 dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj \
+//     --filter "FullyQualifiedName~TransposedViewAllocationProbe"
+//
+// It answers the ONE routing question that a gcdump cannot: does the per-add allocation churn GROW
+// with the existing step count N? A gcdump forces a full GC before capturing, so it only ever shows
+// retained/live objects — it structurally erases the transient per-add churn and the layout CPU cost,
+// which is exactly what "тормозит / 50-100 MB per column" describes. This probe measures the
+// thread-local bytes allocated by one AppendStep INCLUDING the RunJobs layout pass that realizes the
+// new column, at growing N, for both the transposed and the canonical view.
+//
+// Two scenarios are covered:
+//   - WithGroups (5 cells/column) — the small baseline the prior analysis decomposed.
+//   - WideParams (~36 cells/column, several combo + many text editors) — real-scale, where the
+//     per-column realization cost and the viewport-jump cost dominate.
+//
+// Beyond the per-add sweep it also measures the "viewport jump": seed N, realize the horizontal start,
+// then measure the allocation of a single ScrollIntoView(last) that jumps the viewport start->end.
+// This reproduces the real "add step while scrolled far away" the app performs (auto-scroll to the
+// inserted step realizes a full viewport of columns in one dispatcher frame), which the one-column
+// per-add shift does NOT.
+//
+// Reading the result (written to %TEMP%/semistep_ui_probe.txt):
+//   - transposed per-add roughly CONSTANT across N  -> churn is one column's realization; the
+//     50-100 MB lives in render/composition (headless-invisible) -> capture a Rider Timeline snapshot.
+//   - transposed per-add GROWS with N               -> an append re-touches all realized columns/cells;
+//     that is the bug, and it is fixable in managed layout/binding code.
+//   - canonical per-add stays flat while transposed climbs -> confirms the transposed-view-specific
+//     regression the user reports ("на конвенциальной таблице проблем нет").
+//   - viewport-jump per-realized-column is the primary success metric: the target is <= ~2x the
+//     canonical recycled-row cost once the container-reuse fix lands.
+[Trait("Category", "Performance")]
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+public sealed class TransposedViewAllocationProbe
+{
+	private const int WarmupAppends = 6;
+	private const int MeasuredAppends = 12;
+
+	private static readonly int[] _seedSizes = { 20, 60, 120 };
+
+	// Narrow window for WithGroups keeps the horizontal panel virtualizing; the wide config uses a
+	// wider window so a viewport jump realizes a realistic ~20-25 columns in one frame.
+	private static readonly ProbeScenario[] _scenarios =
+	{
+		new(Label: "WithGroups", ConfigName: "WithGroups", WindowWidth: 560),
+		new(Label: "WideParams", ConfigName: "WideParams", WindowWidth: 1400),
+	};
+
+	private readonly ITestOutputHelper _output;
+
+	public TransposedViewAllocationProbe(ITestOutputHelper output)
+	{
+		_output = output;
+	}
+
+	[AvaloniaFact]
+	public async Task Report_PerAdd_ViewAllocation()
+	{
+		Assert.SkipUnless(
+			Environment.GetEnvironmentVariable("SEMISTEP_PROBE") == "1",
+			"Measurement probe: set SEMISTEP_PROBE=1 to run.");
+
+		var lines = new List<string>();
+
+		foreach (var scenario in _scenarios)
+		{
+			foreach (var seed in _seedSizes)
+			{
+				var sample = await MeasureAsync(scenario, seed, transposed: true);
+				lines.Add(
+					$"transposed {scenario.Label,-11} N={seed,4}  per-add(+realize) = {sample.BytesPerAdd,13:N0} bytes  " +
+					$"gen0/add = {sample.Gen0PerAdd:F2}");
+			}
+
+			foreach (var seed in _seedSizes)
+			{
+				var sample = await MeasureAsync(scenario, seed, transposed: false);
+				lines.Add(
+					$"canonical  {scenario.Label,-11} N={seed,4}  per-add(+realize) = {sample.BytesPerAdd,13:N0} bytes  " +
+					$"gen0/add = {sample.Gen0PerAdd:F2}");
+			}
+
+			lines.Add(await DescribeRealizedColumnAsync(scenario, 60));
+
+			var jump = await MeasureViewportJumpAsync(scenario, 120);
+			var perColumn = jump.RealizedColumns == 0 ? 0 : jump.TotalBytes / jump.RealizedColumns;
+			lines.Add(
+				$"viewport-jump {scenario.Label,-11} N=120  total = {jump.TotalBytes,13:N0} bytes  " +
+				$"realized-cols = {jump.RealizedColumns,3}  per-realized-col = {perColumn,11:N0} bytes");
+
+			lines.Add(string.Empty);
+		}
+
+		var report = string.Join(Environment.NewLine, lines);
+		_output.WriteLine(report);
+		File.WriteAllText(Path.Combine(Path.GetTempPath(), "semistep_ui_probe.txt"), report);
+	}
+
+	// Counts the live editor controls a single realized transposed column instantiates, to size the
+	// always-live-editor cost: every ComboBox/TextBox is a full control, a TextBlock is cheap.
+	private static async Task<string> DescribeRealizedColumnAsync(ProbeScenario scenario, int seed)
+	{
+		var fixture = new UIFixture();
+		await fixture.InitializeAsync(scenario.ConfigName);
+		try
+		{
+			fixture.SeedRecipe(seed);
+			var surface = fixture.CreateTransposedSurface();
+			surface.Initialize();
+			var view = new TransposedRecipeGridView { DataContext = surface };
+			var window = new Window { Width = scenario.WindowWidth, Height = 800, Content = view };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+
+			var listBox = view.FindControl<ListBox>("StepListBox")!;
+			var container = (ListBoxItem)listBox.ContainerFromIndex(0)!;
+			var descendants = container.GetVisualDescendants().ToList();
+			var comboBoxes = descendants.OfType<ComboBox>().Count();
+			var textBoxes = descendants.OfType<TextBox>().Count();
+			var textBlocks = descendants.OfType<TextBlock>().Count();
+
+			window.Close();
+
+			return $"one realized column {scenario.Label}: cells={surface.StepColumns[0].Cells.Count}  " +
+				$"ComboBox={comboBoxes}  TextBox={textBoxes}  TextBlock={textBlocks}";
+		}
+		finally
+		{
+			await fixture.DisposeAsync();
+		}
+	}
+
+	private static async Task<Sample> MeasureAsync(ProbeScenario scenario, int seed, bool transposed)
+	{
+		var fixture = new UIFixture();
+		await fixture.InitializeAsync(scenario.ConfigName);
+		try
+		{
+			fixture.SeedRecipe(seed);
+
+			Control view;
+			Action realize;
+			if (transposed)
+			{
+				var surface = fixture.CreateTransposedSurface();
+				surface.Initialize();
+				var transposedView = new TransposedRecipeGridView { DataContext = surface };
+				view = transposedView;
+				// Scroll the ListBox's OWN (horizontal) scroll viewer to the end so the freshly
+				// appended column realizes. The outer UserControl scroll viewer is vertical and would
+				// leave the new column virtualized off-screen, measuring nothing.
+				realize = () => ScrollListBoxToEnd(transposedView, surface.StepColumns.Count);
+			}
+			else
+			{
+				var surface = fixture.CreateCanonicalSurface();
+				surface.Initialize();
+				view = new CanonicalRecipeGridView { DataContext = surface };
+				realize = () => ScrollToEnd(view);
+			}
+
+			var window = new Window { Width = scenario.WindowWidth, Height = 800, Content = view };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+
+			// Warm the JIT, the template-application, and the virtualization paths so the measured
+			// samples are steady-state and the first-realize JIT cost is not charged to add #1.
+			for (var i = 0; i < WarmupAppends; i++)
+			{
+				AppendAndRealize(fixture, realize);
+			}
+
+			var gen0Before = GC.CollectionCount(0);
+			var bytesBefore = GC.GetAllocatedBytesForCurrentThread();
+
+			for (var i = 0; i < MeasuredAppends; i++)
+			{
+				AppendAndRealize(fixture, realize);
+			}
+
+			var bytes = GC.GetAllocatedBytesForCurrentThread() - bytesBefore;
+			var gen0 = GC.CollectionCount(0) - gen0Before;
+
+			window.Close();
+
+			return new Sample(bytes / MeasuredAppends, (double)gen0 / MeasuredAppends);
+		}
+		finally
+		{
+			await fixture.DisposeAsync();
+		}
+	}
+
+	// Measures the allocation of a single far viewport jump (horizontal start -> end) after a warmup
+	// round-trip, so the measured jump reuses recycled containers — the steady-state the app hits when
+	// it auto-scrolls to a step added while the viewport is far from the insertion point.
+	private static async Task<JumpSample> MeasureViewportJumpAsync(ProbeScenario scenario, int seed)
+	{
+		var fixture = new UIFixture();
+		await fixture.InitializeAsync(scenario.ConfigName);
+		try
+		{
+			fixture.SeedRecipe(seed);
+			var surface = fixture.CreateTransposedSurface();
+			surface.Initialize();
+			var view = new TransposedRecipeGridView { DataContext = surface };
+			var window = new Window { Width = scenario.WindowWidth, Height = 800, Content = view };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+
+			var listBox = view.FindControl<ListBox>("StepListBox")!;
+			var lastIndex = surface.StepColumns.Count - 1;
+
+			// Warm the jump path with one full round-trip so the measured jump exercises container
+			// recycling, not first-time realization.
+			listBox.ScrollIntoView(lastIndex);
+			Dispatcher.UIThread.RunJobs();
+			ScrollListBoxToStart(listBox);
+			Dispatcher.UIThread.RunJobs();
+
+			var bytesBefore = GC.GetAllocatedBytesForCurrentThread();
+			listBox.ScrollIntoView(lastIndex);
+			Dispatcher.UIThread.RunJobs();
+			var bytes = GC.GetAllocatedBytesForCurrentThread() - bytesBefore;
+
+			var realizedColumns = listBox.GetRealizedContainers().Count();
+
+			window.Close();
+
+			return new JumpSample(bytes, realizedColumns);
+		}
+		finally
+		{
+			await fixture.DisposeAsync();
+		}
+	}
+
+	// Appends one step and scrolls the new column/row into view so the realization/layout pass for it
+	// is included in the measurement, mirroring the app auto-scrolling to a freshly added step.
+	private static void AppendAndRealize(UIFixture fixture, Action realize)
+	{
+		fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		Dispatcher.UIThread.RunJobs();
+		realize();
+		Dispatcher.UIThread.RunJobs();
+	}
+
+	private static void ScrollListBoxToEnd(TransposedRecipeGridView view, int count)
+	{
+		var listBox = view.FindControl<ListBox>("StepListBox");
+		if (listBox is null || count == 0)
+		{
+			return;
+		}
+
+		listBox.ScrollIntoView(count - 1);
+
+		var scrollViewer = listBox.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+		if (scrollViewer is not null)
+		{
+			scrollViewer.Offset = new Vector(scrollViewer.Extent.Width, 0);
+		}
+	}
+
+	private static void ScrollListBoxToStart(ListBox listBox)
+	{
+		var scrollViewer = listBox.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+		if (scrollViewer is not null)
+		{
+			scrollViewer.Offset = new Vector(0, 0);
+		}
+	}
+
+	private static void ScrollToEnd(Control view)
+	{
+		var scrollViewer = view.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+		if (scrollViewer is not null)
+		{
+			scrollViewer.Offset = new Vector(0, scrollViewer.Extent.Height);
+		}
+	}
+
+	private readonly record struct Sample(long BytesPerAdd, double Gen0PerAdd);
+
+	private readonly record struct JumpSample(long TotalBytes, int RealizedColumns);
+
+	private sealed record ProbeScenario(string Label, string ConfigName, int WindowWidth);
+}

--- a/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
@@ -47,9 +47,14 @@ public sealed class UIFixture : IAsyncLifetime
 	// click-away clear must reach sibling surfaces built from the same fixture.
 	public ChangedCellClickAwayBroadcaster ClickAwayBroadcaster { get; } = new();
 
-	public async ValueTask InitializeAsync()
+	public ValueTask InitializeAsync()
 	{
-		var (services, session, plc) = await CoreTestHelper.BuildAsync("WithGroups");
+		return InitializeAsync("WithGroups");
+	}
+
+	public async ValueTask InitializeAsync(string configName)
+	{
+		var (services, session, plc) = await CoreTestHelper.BuildAsync(configName);
 		Session = session;
 		Plc = plc;
 		PlcSyncService = (StubPlcSyncService)services.GetRequiredService<IPlcSyncService>();

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridHostTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeGridHostTests.cs
@@ -150,12 +150,16 @@ public sealed class RecipeGridHostTests : IAsyncLifetime
 
 		host.IsEditing.Should().BeFalse();
 
+		// Property-text cells are lazy: focus the display presenter and press F2 so the coordinator builds
+		// and focuses the editor. Host IsEditing forwards the view's coordinator-driven active-edit state.
 		var stepListBox = host.GetVisualDescendants().OfType<ListBox>().Single();
-		var editor = stepListBox.GetVisualDescendants().OfType<TextBox>().First(textBox =>
-			textBox.DataContext is ParameterCellViewModel cell
+		var presenter = stepListBox.GetVisualDescendants().OfType<TransposedTextCellPresenter>().First(candidate =>
+			candidate.DataContext is ParameterCellViewModel cell
 			&& cell.Descriptor.ParameterKey == RecipeTestDriver.StepDurationColumn
-			&& textBox.IsEnabled);
-		editor.Focus().Should().BeTrue();
+			&& candidate.IsEnabled);
+		presenter.Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
 
 		host.IsEditing.Should().BeTrue();
 	}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedComboEditingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedComboEditingTests.cs
@@ -1,0 +1,385 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+using FluentAssertions;
+
+using SemiStep.Core.Recipes;
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.Coordinator;
+using SemiStep.UI.RecipeGrid.Transposed;
+using SemiStep.UI.Styles;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid.Transposed;
+
+// Task 4: lazy display/editor swap for ComboBox cells. A combo cell renders a display TextBlock showing
+// the selected item's text by default and builds the heavy ComboBox only on edit entry through the shared
+// edit coordinator, releasing it back to the display on exit.
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public sealed class TransposedComboEditingTests : IAsyncLifetime
+{
+	private const int SeededStepCount = 40;
+	private const string ActionColumnKey = "action";
+
+	private readonly UIFixture _fixture = new();
+	private TransposedRecipeGridSurface _surface = null!;
+	private Window? _window;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_fixture.SeedRecipe(SeededStepCount);
+
+		_surface = _fixture.CreateTransposedSurface();
+		_surface.Initialize();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		_window?.Close();
+		_surface.Dispose();
+		await _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void ComboCell_RendersDisplayText_NoLiveComboBox_ByDefault()
+	{
+		var stepListBox = ShowView();
+		var waitDisplayText = ActionDisplayText(RecipeTestDriver.WaitActionId);
+
+		ComboDisplayText(stepListBox, 0, ActionColumnKey).Should().Be(
+			waitDisplayText, "the display shows the selected action's text without a live ComboBox");
+		ContainerComboBoxCount(stepListBox, 0).Should().Be(
+			0, "no ComboBox is instantiated until edit entry");
+	}
+
+	[AvaloniaFact]
+	public void SecondClickOnSelectedComboColumn_EntersEdit_BuildsComboBox_ShowsSelection()
+	{
+		var (view, stepListBox) = ShowInteractiveView();
+
+		ClickCell(stepListBox, 0, ActionColumnKey);
+		view.IsEditing.Should().BeFalse("a plain first click selects the column without editing");
+
+		ClickCell(stepListBox, 0, ActionColumnKey);
+
+		view.IsEditing.Should().BeTrue("the second click on the selected column enters combo edit");
+		var comboBox = FindComboBox(stepListBox, 0, ActionColumnKey);
+		((ComboBoxItemViewModel)comboBox.SelectedItem!).Id.Should().Be(
+			RecipeTestDriver.WaitActionId, "the built combo shows the cell's current selection");
+	}
+
+	[AvaloniaFact]
+	public void F2OnFocusedComboDisplay_EntersEdit_BuildsComboBox()
+	{
+		var stepListBox = ShowView();
+		var presenter = FindComboPresenter(stepListBox, 0, ActionColumnKey);
+		presenter.Focus();
+
+		ContainerComboBoxCount(stepListBox, 0).Should().Be(0, "no editor exists until edit entry");
+
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		presenter.IsEditing.Should().BeTrue("F2 on the focused combo display opens the editor");
+		FindComboBox(stepListBox, 0, ActionColumnKey).Should().NotBeNull();
+	}
+
+	// Building the ComboBox on lazy open fires an initial SelectionChanged for the already-selected item;
+	// the same-value write no-ops at the model, so it must not mark the recipe dirty or the cell changed.
+	[AvaloniaFact]
+	public void LazyComboOpen_InitialSelection_ProducesNoRecipeEditOrDirtyMarking()
+	{
+		var stepListBox = ShowView();
+		var row = _surface.StepColumns[0].Row;
+		row.IsChanged(ActionColumnKey).Should().BeFalse("precondition: the seeded action cell is not changed");
+		var dirtyBefore = _fixture.Coordinator.IsDirty;
+		var actionKeyBefore = _fixture.Coordinator.CurrentRecipe.Steps[0].ActionKey;
+
+		EnterComboEdit(stepListBox, 0, ActionColumnKey);
+
+		_fixture.Coordinator.CurrentRecipe.Steps[0].ActionKey.Should().Be(
+			actionKeyBefore, "lazily opening the combo must not change the step's action");
+		_fixture.Coordinator.IsDirty.Should().Be(
+			dirtyBefore, "the initial no-op selection must not mark the recipe dirty");
+		row.IsChanged(ActionColumnKey).Should().BeFalse("lazy open must not mark the action cell changed");
+		row.ChangedColumns.Should().BeEmpty("lazy open must not mark any cell changed");
+	}
+
+	// Counts actual model writes over the whole lazy-open-then-pick flow: the lazy build fires an initial
+	// SelectionChanged for the already-selected item (must produce zero mutations) and the user's pick fires
+	// another (must produce exactly one), so a double-apply or a spurious extra writeback would be caught.
+	[AvaloniaFact]
+	public void ComboSelectionChange_WritesBackExactlyOnce()
+	{
+		var stepListBox = ShowView();
+		var mutations = new List<MutationSignal>();
+		void OnMutated(MutationSignal signal)
+		{
+			mutations.Add(signal);
+		}
+
+		_fixture.Coordinator.Mutated += OnMutated;
+		try
+		{
+			var comboBox = EnterComboEdit(stepListBox, 0, ActionColumnKey);
+			mutations.Should().BeEmpty("the lazy build's initial same-value selection must not write anything");
+
+			var forLoopItem = _fixture.RecipeMetadataRegistry.GetActionComboBoxItems()
+				.Single(item => item.Id == RecipeTestDriver.ForLoopActionId);
+
+			comboBox.SelectedItem = forLoopItem;
+			Dispatcher.UIThread.RunJobs();
+
+			mutations.Should().ContainSingle("the user's pick writes back exactly once")
+				.Which.Should().BeOfType<MutationSignal.StepActionChanged>();
+		}
+		finally
+		{
+			_fixture.Coordinator.Mutated -= OnMutated;
+		}
+
+		_fixture.Coordinator.CurrentRecipe.Steps[0].ActionKey.Should().Be(
+			RecipeTestDriver.ForLoopActionId, "changing the selection writes the new action back");
+		_surface.StepColumns[0].Row.ChangedColumns.Should().NotBeEmpty(
+			"the action change marks the rebuilt column's seeded cells changed");
+	}
+
+	// An inapplicable combo (the target selector on a wait step) is non-focusable and blocks edit entry:
+	// F2 must not build an editor.
+	[AvaloniaFact]
+	public void InapplicableCombo_DoesNotEnterEdit()
+	{
+		var stepListBox = ShowView();
+		var presenter = FindComboPresenter(stepListBox, 0, RecipeTestDriver.TargetColumn);
+		presenter.IsEnabled.Should().BeFalse("the target combo is inapplicable for a wait step");
+
+		presenter.Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		FindComboPresenter(stepListBox, 0, RecipeTestDriver.TargetColumn).IsEditing.Should().BeFalse(
+			"an inapplicable combo must not enter edit");
+		ContainerComboBoxCount(stepListBox, 0).Should().Be(0, "no editor is built for a blocked combo");
+	}
+
+	// A read-only surface (PLC sync) disables the combo display and blocks edit entry.
+	[AvaloniaFact]
+	public void SurfaceReadOnly_Combo_DoesNotEnterEdit()
+	{
+		var stepListBox = ShowView();
+		_fixture.SetRecipeActive(true);
+		Dispatcher.UIThread.RunJobs();
+
+		var presenter = FindComboPresenter(stepListBox, 0, ActionColumnKey);
+		presenter.IsEnabled.Should().BeFalse("a read-only surface disables the combo");
+
+		presenter.Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		FindComboPresenter(stepListBox, 0, ActionColumnKey).IsEditing.Should().BeFalse(
+			"a read-only surface must block combo edit entry");
+	}
+
+	// An external value change (an action swap applied through the coordinator) updates the display text
+	// even though no ComboBox is live.
+	[AvaloniaFact]
+	public void ExternalActionChange_UpdatesComboDisplay()
+	{
+		var stepListBox = ShowView();
+
+		_fixture.Coordinator.ChangeStepAction(0, RecipeTestDriver.ForLoopActionId);
+		Dispatcher.UIThread.RunJobs();
+
+		ComboDisplayText(stepListBox, 0, ActionColumnKey).Should().Be(
+			ActionDisplayText(RecipeTestDriver.ForLoopActionId),
+			"a programmatic action change updates the lazy display without a live ComboBox");
+	}
+
+	// A container recycled onto a far column must show that column's own selection on its combo display,
+	// never a stale value from the column it was built on.
+	[AvaloniaFact]
+	public void RecycledComboCell_ShowsRebindTargetSelection_NotStale()
+	{
+		var lastIndex = SeededStepCount - 1;
+		_fixture.Coordinator.ChangeStepAction(lastIndex, RecipeTestDriver.ForLoopActionId)
+			.IsSuccess.Should().BeTrue();
+		var stepListBox = ShowNarrowView();
+
+		ScrollToHorizontalEnd(stepListBox);
+
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(lastIndex)!;
+		ComboDisplayText(container, ActionColumnKey).Should().Be(
+			ActionDisplayText(RecipeTestDriver.ForLoopActionId),
+			"the recycled slot rebinds its combo display to the rebind-target column's selection");
+	}
+
+	// A combo in active edit (ComboBox built, dropdown open) whose container recycles out on a scroll must
+	// drop cleanly: the commit-before-rebind closes the dropdown and releases the ComboBox to the display,
+	// leaving no live ComboBox anywhere and no stray writeback / dirtying of the recipe.
+	[AvaloniaFact]
+	public void ActiveComboEditedColumn_RecycledOut_DropsCleanly_NoLeak_NoWriteback()
+	{
+		var stepListBox = ShowNarrowView();
+		var comboBox = EnterComboEdit(stepListBox, 0, ActionColumnKey);
+		comboBox.IsDropDownOpen.Should().BeTrue("F2 entry opens the dropdown");
+		var actionKeyBefore = _fixture.Coordinator.CurrentRecipe.Steps[0].ActionKey;
+		var dirtyBefore = _fixture.Coordinator.IsDirty;
+
+		ScrollToHorizontalEnd(stepListBox);
+
+		LiveComboBoxCount(stepListBox).Should().Be(
+			0, "recycling the edited column out releases the ComboBox back to the display, leaking none");
+		comboBox.IsDropDownOpen.Should().BeFalse(
+			"the commit-before-rebind closes the dropdown so the pooled ComboBox cannot orphan an open popup");
+		_fixture.Coordinator.CurrentRecipe.Steps[0].ActionKey.Should().Be(
+			actionKeyBefore, "recycling an edited combo out must not write the action back");
+		_fixture.Coordinator.IsDirty.Should().Be(
+			dirtyBefore, "recycling an edited combo out must not mark the recipe dirty");
+	}
+
+	private static int LiveComboBoxCount(ListBox stepListBox)
+	{
+		return stepListBox.GetVisualDescendants().OfType<ComboBox>().Count();
+	}
+
+	private string ActionDisplayText(int actionId)
+	{
+		return _fixture.RecipeMetadataRegistry.GetActionComboBoxItems()
+			.Single(item => item.Id == actionId)
+			.DisplayText;
+	}
+
+	private void ClickCell(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		var border = FindCellBorder(stepListBox, columnIndex, parameterKey);
+		var clickPoint = border.TranslatePoint(new Point(3, 3), _window!);
+		clickPoint.Should().NotBeNull();
+
+		_window!.MouseDown(clickPoint!.Value, MouseButton.Left, RawInputModifiers.None);
+		_window!.MouseUp(clickPoint.Value, MouseButton.Left, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+	}
+
+	private static Border FindCellBorder(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+
+		return container.GetVisualDescendants()
+			.OfType<Border>()
+			.Single(border => border.Classes.Contains("transposed-cell")
+				&& border.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	private static TransposedComboCellPresenter FindComboPresenter(
+		ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+
+		return container.GetVisualDescendants()
+			.OfType<TransposedComboCellPresenter>()
+			.Single(presenter => presenter.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	private static ComboBox FindComboBox(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+
+		return container.GetVisualDescendants()
+			.OfType<ComboBox>()
+			.Single(comboBox => comboBox.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	private static int ContainerComboBoxCount(ListBox stepListBox, int columnIndex)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+
+		return container.GetVisualDescendants().OfType<ComboBox>().Count();
+	}
+
+	private static string? ComboDisplayText(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		return ComboDisplayText((ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!, parameterKey);
+	}
+
+	private static string? ComboDisplayText(ListBoxItem container, string parameterKey)
+	{
+		var presenter = container.GetVisualDescendants()
+			.OfType<TransposedComboCellPresenter>()
+			.Single(p => p.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+
+		return presenter.GetVisualDescendants().OfType<TextBlock>().First().Text;
+	}
+
+	private ComboBox EnterComboEdit(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		FindComboPresenter(stepListBox, columnIndex, parameterKey).Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		return FindComboBox(stepListBox, columnIndex, parameterKey);
+	}
+
+	private static void ScrollToHorizontalEnd(ListBox stepListBox)
+	{
+		var scrollViewer = stepListBox.GetVisualDescendants().OfType<ScrollViewer>().First();
+		scrollViewer.Offset = new Vector(scrollViewer.Extent.Width, 0);
+		Dispatcher.UIThread.RunJobs();
+	}
+
+	private ListBox ShowView()
+	{
+		return ShowView(width: 1600, installPalette: false).StepListBox;
+	}
+
+	private (TransposedRecipeGridView View, ListBox StepListBox) ShowInteractiveView()
+	{
+		return ShowView(width: 1600, installPalette: true);
+	}
+
+	private ListBox ShowNarrowView()
+	{
+		return ShowView(width: 560, installPalette: false).StepListBox;
+	}
+
+	private (TransposedRecipeGridView View, ListBox StepListBox) ShowView(double width, bool installPalette)
+	{
+		var view = new TransposedRecipeGridView { DataContext = _surface };
+		_window = new Window
+		{
+			Width = width,
+			Height = 800,
+			Content = view,
+		};
+
+		if (installPalette)
+		{
+			// Production installs the config palette at startup (App.axaml.cs). Without it the cell
+			// borders have null backgrounds and are not hit-testable, so pointer tests would miss.
+			CellPaletteInstaller.Install(_window.Resources, _fixture.AppConfiguration.GridStyle);
+		}
+
+		_window.Show();
+		Dispatcher.UIThread.RunJobs();
+
+		var stepListBox = view.FindControl<ListBox>("StepListBox");
+		stepListBox.Should().NotBeNull();
+
+		return (view, stepListBox!);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedEdgeCaseTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedEdgeCaseTests.cs
@@ -1,0 +1,160 @@
+﻿using System.Linq;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+using FluentAssertions;
+
+using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid;
+using SemiStep.UI.RecipeGrid.Transposed;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid.Transposed;
+
+/// <summary>
+/// Boundary shapes for the pooled-presenter + lazy-cell transposed view: an empty recipe (no columns),
+/// a single-step recipe (one realized column, all editors lazy), and the plan's core scenario — adding a
+/// step while the viewport is scrolled far away, then auto-scrolling to it. These exercise the recycling
+/// pool and the lazy display swap at the degenerate ends the per-suite fixtures (which seed 3 or 40 steps)
+/// never reach.
+/// </summary>
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public sealed class TransposedEdgeCaseTests : IAsyncLifetime
+{
+	private const int WideSeededStepCount = 40;
+
+	private readonly UIFixture _fixture = new();
+	private TransposedRecipeGridSurface _surface = null!;
+	private Window? _window;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		_window?.Close();
+		_surface?.Dispose();
+		await _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void EmptyRecipe_View_RendersNameColumn_AndNoStepContainers()
+	{
+		_fixture.SeedRecipe(0);
+		var (view, stepListBox) = InitializeAndShow(1200);
+
+		_surface.StepColumns.Should().BeEmpty("an empty recipe projects no step columns");
+		stepListBox.GetVisualDescendants().OfType<ListBoxItem>().Should().BeEmpty(
+			"with no columns the panel realizes no containers");
+
+		var parameterNameColumn = view.FindControl<ItemsControl>("ParameterNameColumn");
+		parameterNameColumn.Should().NotBeNull();
+		parameterNameColumn!.ItemCount.Should().Be(
+			_surface.ParameterDescriptors.Count, "the frozen name column renders even with no steps");
+	}
+
+	[AvaloniaFact]
+	public void SingleStepRecipe_View_RealizesOneColumn_WithAllEditorsLazy()
+	{
+		_fixture.SeedRecipe(1);
+		var (_, stepListBox) = InitializeAndShow(1200);
+
+		var containers = stepListBox.GetVisualDescendants().OfType<ListBoxItem>().ToList();
+		containers.Should().HaveCount(1, "a single-step recipe realizes exactly one column");
+
+		var container = containers[0];
+		container.GetVisualDescendants().OfType<TextBox>().Should().BeEmpty(
+			"no cell is in edit, so no TextBox editor is live (lazy display)");
+		container.GetVisualDescendants().OfType<ComboBox>().Should().BeEmpty(
+			"no cell is in edit, so no ComboBox editor is live (lazy display)");
+		container.GetVisualDescendants().OfType<TransposedTextCellPresenter>().Should().NotBeEmpty(
+			"property-text cells render their display presenter");
+	}
+
+	[AvaloniaFact]
+	public void AddStepWhileScrolledFarAway_RealizesNewColumn_ShowsItsValue_AndStaysViewportBound()
+	{
+		_fixture.SeedRecipe(WideSeededStepCount);
+		var (_, stepListBox) = InitializeAndShow(560);
+
+		ScrollToHorizontalEnd(stepListBox);
+		var boundedWhileScrolled = stepListBox.GetRealizedContainers().Count();
+		boundedWhileScrolled.Should().BeLessThan(
+			WideSeededStepCount / 2, "the far scroll must realize only a viewport of columns");
+
+		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
+		Dispatcher.UIThread.RunJobs();
+		var newIndex = _surface.StepColumns.Count - 1;
+		newIndex.Should().Be(WideSeededStepCount, "the append grew the recipe by one column");
+		_fixture.Coordinator.UpdateStepProperty(newIndex, RecipeTestDriver.StepDurationColumn, "125")
+			.IsSuccess.Should().BeTrue();
+
+		stepListBox.ScrollIntoView(newIndex);
+		Dispatcher.UIThread.RunJobs();
+
+		stepListBox.GetRealizedContainers().Count().Should().BeLessThan(
+			WideSeededStepCount / 2,
+			"auto-scrolling to the freshly added step must recycle into a viewport, not realize the whole recipe");
+
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(newIndex)!;
+		var expected = PropertyTimeEditingConverter.FormatForDisplay(
+			_surface.StepColumns[newIndex].Row[RecipeTestDriver.StepDurationColumn],
+			TimeFormatHelper.TimeHmsFormat);
+		DisplayText(container, RecipeTestDriver.StepDurationColumn).Should().Be(
+			expected, "the recycled slot rebinds its display to the freshly added column's own value");
+		DisplayText(container, RecipeTestDriver.StepDurationColumn).Should().Be(
+			"00:02:05", "the freshly added column shows the value written while it was off-screen");
+	}
+
+	private static void ScrollToHorizontalEnd(ListBox stepListBox)
+	{
+		var scrollViewer = stepListBox.GetVisualDescendants().OfType<ScrollViewer>().First();
+		scrollViewer.Offset = new Vector(scrollViewer.Extent.Width, 0);
+		Dispatcher.UIThread.RunJobs();
+	}
+
+	private static string? DisplayText(ListBoxItem container, string parameterKey)
+	{
+		return container.GetVisualDescendants()
+			.OfType<TransposedTextCellPresenter>()
+			.Single(presenter => presenter.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey)
+			.GetVisualDescendants()
+			.OfType<TextBlock>()
+			.First()
+			.Text;
+	}
+
+	private (TransposedRecipeGridView View, ListBox StepListBox) InitializeAndShow(int width)
+	{
+		_surface = _fixture.CreateTransposedSurface();
+		_surface.Initialize();
+
+		var view = new TransposedRecipeGridView { DataContext = _surface };
+		_window = new Window
+		{
+			Width = width,
+			Height = 800,
+			Content = view,
+		};
+
+		_window.Show();
+		Dispatcher.UIThread.RunJobs();
+
+		var stepListBox = view.FindControl<ListBox>("StepListBox");
+		stepListBox.Should().NotBeNull();
+
+		return (view, stepListBox!);
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedEditingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedEditingTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 
@@ -49,9 +50,8 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 	public void TypeAndCommitWithEnter_UpdatesCoordinator()
 	{
 		var (_, stepListBox) = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 
-		editor.Focus();
 		editor.Text = "45";
 		_window!.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
 		Dispatcher.UIThread.RunJobs();
@@ -69,17 +69,16 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 			.IsSuccess.Should().BeTrue();
 
 		var (_, stepListBox) = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 
-		editor.Text.Should().Be("00:01:40");
+		DisplayText(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Should().Be("00:01:40");
 
-		editor.Focus();
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 		editor.Text = "0:2:5";
 		_window!.FocusManager!.Focus(null);
 		Dispatcher.UIThread.RunJobs();
 
 		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(125f);
-		editor.Text.Should().Be("00:02:05");
+		DisplayText(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Should().Be("00:02:05");
 	}
 
 	[AvaloniaFact]
@@ -89,16 +88,15 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 			.IsSuccess.Should().BeTrue();
 
 		var (_, stepListBox) = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 
-		editor.Focus();
 		editor.Text = "99:99:99";
 		_window!.FocusManager!.Focus(null);
 		Dispatcher.UIThread.RunJobs();
 
 		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(100f);
-		editor.Text.Should().Be(
-			"00:01:40", "a rejected edit must snap the editor back to the model's formatted value");
+		DisplayText(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Should().Be(
+			"00:01:40", "a rejected edit must snap the display back to the model's formatted value");
 	}
 
 	[AvaloniaFact]
@@ -106,45 +104,44 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 	{
 		var (_, stepListBox) = ShowView();
 
-		FindTextBox(stepListBox, 0, RecipeTestDriver.TaskColumn).IsEnabled.Should().BeFalse();
-		FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn).IsEnabled.Should().BeTrue();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.TaskColumn).IsEnabled.Should().BeFalse();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn).IsEnabled.Should().BeTrue();
 	}
 
 	[AvaloniaFact]
 	public void ReadOnlyMode_DisablesEditors_AndEditorMustCloseDefocusesActiveOne()
 	{
 		var (view, stepListBox) = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 
-		editor.Focus();
 		view.IsEditing.Should().BeTrue();
 
 		_fixture.SetRecipeActive(true);
 		Dispatcher.UIThread.RunJobs();
 
-		editor.IsEnabled.Should().BeFalse();
-		FindComboBox(stepListBox, 0, "action").IsEnabled.Should().BeFalse();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn).IsEnabled.Should().BeFalse();
+		FindComboPresenter(stepListBox, 0, "action").IsEnabled.Should().BeFalse();
 		view.IsEditing.Should().BeFalse();
 		_window!.FocusManager!.GetFocusedElement().Should().NotBeSameAs(editor);
 
 		_fixture.SetRecipeActive(false);
 		Dispatcher.UIThread.RunJobs();
 
-		editor.IsEnabled.Should().BeTrue();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn).IsEnabled.Should().BeTrue();
 	}
 
 	[AvaloniaFact]
 	public void IsEditing_TracksEditorFocus()
 	{
 		var (view, stepListBox) = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 
 		view.IsEditing.Should().BeFalse();
 
-		editor.Focus();
+		EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 		view.IsEditing.Should().BeTrue();
 
 		_window!.FocusManager!.Focus(null);
+		Dispatcher.UIThread.RunJobs();
 		view.IsEditing.Should().BeFalse();
 	}
 
@@ -232,15 +229,10 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 		ClickCell(stepListBox, 1, RecipeTestDriver.StepDurationColumn);
 		view.IsEditing.Should().BeFalse();
 
-		var editor = FindTextBox(stepListBox, 1, RecipeTestDriver.StepDurationColumn);
-		var clickPoint = editor.TranslatePoint(
-			new Point(editor.Bounds.Width / 2, editor.Bounds.Height / 2), _window!);
-		clickPoint.Should().NotBeNull();
-		_window!.MouseDown(clickPoint!.Value, MouseButton.Left);
-		_window!.MouseUp(clickPoint.Value, MouseButton.Left);
-		Dispatcher.UIThread.RunJobs();
+		ClickCell(stepListBox, 1, RecipeTestDriver.StepDurationColumn);
 
-		view.IsEditing.Should().BeTrue("the second click on the selected column reaches the editor");
+		view.IsEditing.Should().BeTrue("the second click on the selected column enters edit");
+		var editor = FindTextBox(stepListBox, 1, RecipeTestDriver.StepDurationColumn);
 		_window!.FocusManager!.GetFocusedElement().Should().BeSameAs(editor);
 	}
 
@@ -284,8 +276,7 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 	public void ClickOnOtherColumn_CommitsPendingEditByDefocusing()
 	{
 		var (_, stepListBox) = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
-		editor.Focus();
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 		editor.Text = "45";
 
 		ClickCell(stepListBox, 1, RecipeTestDriver.StepDurationColumn);
@@ -299,15 +290,18 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 	{
 		_fixture.Coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "100")
 			.IsSuccess.Should().BeTrue();
-		var (_, stepListBox) = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
-		editor.Focus();
+		var (view, stepListBox) = ShowView();
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 		editor.Text = "0:2:5";
 
 		_window!.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
 		Dispatcher.UIThread.RunJobs();
 
-		editor.Text.Should().Be("00:01:40", "Escape must revert the typed-but-uncommitted text");
+		// Escape reverts the typed-but-uncommitted text and exits edit (canonical parity), so the value is
+		// held by the display, not the discarded editor, and the model is untouched.
+		view.IsEditing.Should().BeFalse("Escape cancels the cell edit");
+		DisplayText(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Should().Be(
+			"00:01:40", "Escape must revert the display to the model's formatted value");
 		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(100f);
 	}
 
@@ -324,13 +318,10 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 			.IsSuccess.Should().BeTrue();
 		var (_, stepListBox) = ShowView();
 
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 		var capturedCell = (PropertyTextCellViewModel)editor.DataContext!;
-		var rebindCell = (PropertyTextCellViewModel)FindTextBox(
+		var rebindCell = (PropertyTextCellViewModel)FindTextPresenter(
 			stepListBox, 1, RecipeTestDriver.StepDurationColumn).DataContext!;
-
-		editor.Focus();
-		Dispatcher.UIThread.RunJobs();
 
 		editor.DataContext = rebindCell;
 		Dispatcher.UIThread.RunJobs();
@@ -352,8 +343,7 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 		_fixture.Coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "100")
 			.IsSuccess.Should().BeTrue();
 		var (_, stepListBox) = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
-		editor.Focus();
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 		editor.Text = "45";
 
 		_fixture.SetRecipeActive(true);
@@ -361,16 +351,15 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 
 		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(
 			100f, "the pending edit must be dropped by the read-only guard, not committed");
-		editor.Text.Should().Be(
-			"00:01:40", "the editor must not keep displaying the never-committed text");
+		DisplayText(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Should().Be(
+			"00:01:40", "the display must not keep showing the never-committed text");
 	}
 
 	[AvaloniaFact]
 	public void EditorMustClose_ClosesOpenComboBoxDropdown()
 	{
 		var (_, stepListBox) = ShowView();
-		var comboBox = FindComboBox(stepListBox, 0, "action");
-		comboBox.Focus();
+		var comboBox = EnterComboEdit(stepListBox, 0, "action");
 		comboBox.IsDropDownOpen = true;
 		Dispatcher.UIThread.RunJobs();
 
@@ -385,7 +374,7 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 	{
 		var (_, stepListBox) = ShowView();
 
-		FindTextBox(stepListBox, 0, RecipeTestDriver.CommentColumn).MaxLength
+		EnterTextEdit(stepListBox, 0, RecipeTestDriver.CommentColumn).MaxLength
 			.Should().Be(_fixture.RecipeMetadataRegistry.GetStringMaxLength());
 	}
 
@@ -413,7 +402,7 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 	public void ActionCombo_SelectionChange_ChangesStepAction_AndMarksCells()
 	{
 		var (_, stepListBox) = ShowView();
-		var comboBox = FindComboBox(stepListBox, 0, "action");
+		var comboBox = EnterComboEdit(stepListBox, 0, "action");
 		var forLoopItem = _fixture.RecipeMetadataRegistry.GetActionComboBoxItems()
 			.Single(item => item.Id == RecipeTestDriver.ForLoopActionId);
 
@@ -423,6 +412,203 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 		_fixture.Coordinator.CurrentRecipe.Steps[0].ActionKey.Should().Be(RecipeTestDriver.ForLoopActionId);
 		_surface.StepColumns[0].Row.ChangedColumns.Should().NotBeEmpty(
 			"the rebuilt column's seeded cells must carry the changed highlight");
+	}
+
+	// First-keystroke fidelity, KeyDown route: a printable KeyDown on a focused display presenter enters
+	// edit and clears the cell; the paired TextInput (a separate raw event) lands on the now-focused editor.
+	// Exactly one character survives — neither dropped by the swap nor doubled by both handlers firing.
+	[AvaloniaFact]
+	public void PrintableKeyThenTextInput_EntersEdit_KeepsExactlyOneCharacter()
+	{
+		var (view, stepListBox) = ShowView();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.CommentColumn).Focus();
+
+		_window!.KeyPressQwerty(PhysicalKey.Digit5, RawInputModifiers.None);
+		_window!.KeyTextInput("5");
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeTrue("a printable keystroke on a focused display enters edit");
+		FindTextBox(stepListBox, 0, RecipeTestDriver.CommentColumn).Text
+			.Should().Be("5", "the first character is typed exactly once");
+	}
+
+	// First-keystroke fidelity, pure TextInput route (IME / paste-like, no preceding printable KeyDown):
+	// the display seeds the editor directly with the character it carries.
+	[AvaloniaFact]
+	public void TextInputWithoutKeyDown_EntersEdit_KeepsExactlyOneCharacter()
+	{
+		var (view, stepListBox) = ShowView();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.CommentColumn).Focus();
+
+		_window!.KeyTextInput("7");
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeTrue();
+		FindTextBox(stepListBox, 0, RecipeTestDriver.CommentColumn).Text.Should().Be("7");
+	}
+
+	// A rapid two-character burst over the KeyDown route must land both characters on the editor in order,
+	// with no drop and no double.
+	[AvaloniaFact]
+	public void RapidTwoCharacterBurst_TypesBothInOrder()
+	{
+		var (_, stepListBox) = ShowView();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.CommentColumn).Focus();
+
+		_window!.KeyPressQwerty(PhysicalKey.Digit5, RawInputModifiers.None);
+		_window!.KeyTextInput("5");
+		_window!.KeyPressQwerty(PhysicalKey.Digit7, RawInputModifiers.None);
+		_window!.KeyTextInput("7");
+		Dispatcher.UIThread.RunJobs();
+
+		FindTextBox(stepListBox, 0, RecipeTestDriver.CommentColumn).Text
+			.Should().Be("57", "both characters land on the editor in order with no drop or double");
+	}
+
+	// Keyboard traversal focuses the display presenter (its editor is not built); F2 on that focused display
+	// is what opens the editor.
+	[AvaloniaFact]
+	public void KeyboardTraversal_FocusesDisplayPresenter_ThenF2EntersEdit()
+	{
+		var (view, stepListBox) = ShowView();
+		FindComboPresenter(stepListBox, 0, "action").Focus();
+
+		_window!.KeyPressQwerty(PhysicalKey.ArrowDown, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		var presenter = FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		_window!.FocusManager!.GetFocusedElement().Should().BeSameAs(
+			presenter, "arrow traversal focuses the display presenter, not a built editor");
+		view.IsEditing.Should().BeFalse("a focused display is not an active edit");
+		presenter.GetVisualDescendants().OfType<TextBox>()
+			.Should().BeEmpty("no editor exists until edit entry");
+
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeTrue("F2 on the focused display opens the editor");
+	}
+
+	// An inapplicable text cell is non-focusable and blocks edit entry: F2 must not build an editor.
+	[AvaloniaFact]
+	public void InapplicableTextCell_DoesNotEnterEdit()
+	{
+		var (view, stepListBox) = ShowView();
+		var presenter = FindTextPresenter(stepListBox, 0, RecipeTestDriver.TaskColumn);
+		presenter.IsEnabled.Should().BeFalse("the task cell is inapplicable for a wait step");
+
+		presenter.Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeFalse("an inapplicable cell must not enter edit");
+		presenter.GetVisualDescendants().OfType<TextBox>()
+			.Should().BeEmpty("no editor is built for a blocked cell");
+	}
+
+	// A read-only surface (PLC sync) blocks text edit entry: the presenter is disabled and F2 does nothing.
+	[AvaloniaFact]
+	public void SurfaceReadOnly_TextCell_DoesNotEnterEdit()
+	{
+		var (view, stepListBox) = ShowView();
+		_fixture.SetRecipeActive(true);
+		Dispatcher.UIThread.RunJobs();
+
+		var presenter = FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		presenter.IsEnabled.Should().BeFalse("a read-only surface disables text cells");
+
+		presenter.Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeFalse("a read-only surface must block text edit entry");
+	}
+
+	// Regression: a press inside an already-open text editor must reach the live TextBox so the caret can be
+	// repositioned. The tunnel entry handler consumes only the entry press (a not-yet-editing display); once
+	// editing, it must leave the press unhandled so the TextBox receives it (a handled tunnel press never
+	// reaches the editor).
+	[AvaloniaFact]
+	public void ClickInsideOpenEditor_ReachesLiveTextBox_ForCaretReposition()
+	{
+		var (view, stepListBox) = ShowView();
+
+		// Enter edit via the production gesture (first click selects the column, second click opens the
+		// editor) so the column is selected AND editing — the state in which a further press must reach the
+		// live TextBox to reposition the caret rather than being swallowed by the tunnel entry handler.
+		ClickCell(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		ClickCell(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		view.IsEditing.Should().BeTrue("the second click opens the editor");
+
+		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var reachedEditor = false;
+		editor.AddHandler(
+			InputElement.PointerPressedEvent,
+			(_, _) => reachedEditor = true,
+			RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+
+		ClickCell(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+
+		reachedEditor.Should().BeTrue(
+			"a press inside the open editor must not be swallowed by the tunnel entry handler");
+		view.IsEditing.Should().BeTrue("clicking inside the open editor keeps it in edit");
+	}
+
+	// First-keystroke replace semantics on a NON-empty cell: a printable KeyDown on a focused display enters
+	// edit and clears the seeded value, so the paired TextInput types fresh (replace, not append).
+	[AvaloniaFact]
+	public void FirstPrintableKey_OnNonEmptyCell_ReplacesValue()
+	{
+		_fixture.Coordinator.UpdateStepProperty(0, RecipeTestDriver.StepDurationColumn, "100")
+			.IsSuccess.Should().BeTrue();
+		var (view, stepListBox) = ShowView();
+		DisplayText(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Should().Be(
+			"00:01:40", "precondition: the target cell holds a non-empty value");
+
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Focus();
+		_window!.KeyPressQwerty(PhysicalKey.Digit5, RawInputModifiers.None);
+		_window!.KeyTextInput("5");
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeTrue("a printable keystroke on a focused display enters edit");
+		FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Text.Should().Be(
+			"5", "the first printable keystroke replaces the seeded value, it does not append to it");
+	}
+
+	// After an Enter commit the editor is released back to the display within the still-realized container:
+	// zero live TextBox remains and the display TextBlock shows the committed value.
+	[AvaloniaFact]
+	public void EnterCommit_ReleasesEditorToDisplay_WithinRealizedContainer()
+	{
+		var (view, stepListBox) = ShowView();
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(0)!;
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		editor.Text = "45";
+
+		_window!.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsEditing.Should().BeFalse("Enter commits and ends the edit");
+		container.GetVisualDescendants().OfType<TextBox>().Should().BeEmpty(
+			"the committed editor is released back to the display, leaving no live TextBox in the container");
+		DisplayText(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Should().Be(
+			"00:00:45", "the restored display shows the committed value");
+	}
+
+	// A rapid two-character burst over the pure TextInput route (no preceding printable KeyDown): the first
+	// TextInput seeds the editor via OnDisplayTextInputCore, the second lands on the now-focused editor.
+	[AvaloniaFact]
+	public void RapidTwoCharacterBurst_PureTextInputRoute_TypesBothInOrder()
+	{
+		var (_, stepListBox) = ShowView();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.CommentColumn).Focus();
+
+		_window!.KeyTextInput("5");
+		_window!.KeyTextInput("7");
+		Dispatcher.UIThread.RunJobs();
+
+		FindTextBox(stepListBox, 0, RecipeTestDriver.CommentColumn).Text.Should().Be(
+			"57", "the pure-TextInput route seeds the first char, then the focused editor takes the second");
 	}
 
 	private void ClickCell(
@@ -462,6 +648,37 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 				&& cell.Descriptor.ParameterKey == parameterKey);
 	}
 
+	private static TransposedTextCellPresenter FindTextPresenter(
+		ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+
+		return container.GetVisualDescendants()
+			.OfType<TransposedTextCellPresenter>()
+			.Single(presenter => presenter.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	private static string? DisplayText(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		return FindTextPresenter(stepListBox, columnIndex, parameterKey)
+			.GetVisualDescendants()
+			.OfType<TextBlock>()
+			.First()
+			.Text;
+	}
+
+	// Enters edit on a lazy property-text cell through the real focus + F2 gesture, then returns the
+	// now-built editor. The editor exists only while editing, so tests grab it through this.
+	private TextBox EnterTextEdit(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		FindTextPresenter(stepListBox, columnIndex, parameterKey).Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		return FindTextBox(stepListBox, columnIndex, parameterKey);
+	}
+
 	private static ComboBox FindComboBox(ListBox stepListBox, int columnIndex, string parameterKey)
 	{
 		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
@@ -470,6 +687,28 @@ public sealed class TransposedEditingTests : IAsyncLifetime
 			.OfType<ComboBox>()
 			.Single(comboBox => comboBox.DataContext is ParameterCellViewModel cell
 				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	private static TransposedComboCellPresenter FindComboPresenter(
+		ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+
+		return container.GetVisualDescendants()
+			.OfType<TransposedComboCellPresenter>()
+			.Single(presenter => presenter.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	// Enters edit on a lazy combo cell through the real focus + F2 gesture (which opens the dropdown), then
+	// returns the now-built ComboBox. The ComboBox exists only while editing, so tests grab it through this.
+	private ComboBox EnterComboEdit(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		FindComboPresenter(stepListBox, columnIndex, parameterKey).Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		return FindComboBox(stepListBox, columnIndex, parameterKey);
 	}
 
 	private (TransposedRecipeGridView View, ListBox StepListBox) ShowView()

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedNavigationTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedNavigationTests.cs
@@ -50,32 +50,32 @@ public sealed class TransposedNavigationTests : IAsyncLifetime
 	public void Right_SelectsNextColumn_AndFocusesSameParameterRow()
 	{
 		var stepListBox = ShowView();
-		FindComboBox(stepListBox, 0, ActionColumnKey).Focus();
+		FindComboPresenter(stepListBox, 0, ActionColumnKey).Focus();
 
 		PressKey(PhysicalKey.ArrowRight);
 
 		_surface.SelectedStepIndex.Should().Be(1);
 		((ListBoxItem)stepListBox.ContainerFromIndex(1)!).IsSelected.Should().BeTrue();
-		FocusedElement().Should().BeSameAs(FindComboBox(stepListBox, 1, ActionColumnKey));
+		FocusedElement().Should().BeSameAs(FindComboPresenter(stepListBox, 1, ActionColumnKey));
 	}
 
 	[AvaloniaFact]
 	public void Left_SelectsPreviousColumn_AndFocusesSameParameterRow()
 	{
 		var stepListBox = ShowView();
-		FindComboBox(stepListBox, 1, ActionColumnKey).Focus();
+		FindComboPresenter(stepListBox, 1, ActionColumnKey).Focus();
 
 		PressKey(PhysicalKey.ArrowLeft);
 
 		_surface.SelectedStepIndex.Should().Be(0);
-		FocusedElement().Should().BeSameAs(FindComboBox(stepListBox, 0, ActionColumnKey));
+		FocusedElement().Should().BeSameAs(FindComboPresenter(stepListBox, 0, ActionColumnKey));
 	}
 
 	[AvaloniaFact]
 	public void Left_AtFirstColumn_IsConsumedWithoutCyclingComboValue()
 	{
 		var stepListBox = ShowView();
-		var actionCombo = FindComboBox(stepListBox, 0, ActionColumnKey);
+		var actionCombo = FindComboPresenter(stepListBox, 0, ActionColumnKey);
 		actionCombo.Focus();
 
 		PressKey(PhysicalKey.ArrowLeft);
@@ -92,7 +92,7 @@ public sealed class TransposedNavigationTests : IAsyncLifetime
 		// are used because Left/Right inside a TextBox stay with the caret by design.
 		_fixture.Coordinator.ChangeStepAction(0, RecipeTestDriver.WithGroupActionId);
 		var stepListBox = ShowView();
-		FindComboBox(stepListBox, 0, RecipeTestDriver.TargetColumn).Focus();
+		FindComboPresenter(stepListBox, 0, RecipeTestDriver.TargetColumn).Focus();
 
 		PressKey(PhysicalKey.ArrowRight);
 
@@ -109,14 +109,14 @@ public sealed class TransposedNavigationTests : IAsyncLifetime
 		// container because the neighbour row's combo is not focusable there.
 		_fixture.Coordinator.ChangeStepAction(0, RecipeTestDriver.WithGroupActionId);
 		var stepListBox = ShowView();
-		FindComboBox(stepListBox, 0, RecipeTestDriver.TargetColumn).Focus();
+		FindComboPresenter(stepListBox, 0, RecipeTestDriver.TargetColumn).Focus();
 		PressKey(PhysicalKey.ArrowRight);
 		FocusedElement().Should().BeSameAs(stepListBox.ContainerFromIndex(1));
 
 		PressKey(PhysicalKey.ArrowDown);
 
 		FocusedElement().Should().BeSameAs(
-			FindComboBox(stepListBox, 1, ActionColumnKey),
+			FindComboPresenter(stepListBox, 1, ActionColumnKey),
 			"Down from a focused column container must enter the column's first focusable cell");
 	}
 
@@ -129,18 +129,18 @@ public sealed class TransposedNavigationTests : IAsyncLifetime
 		PressKey(PhysicalKey.ArrowRight);
 
 		_surface.SelectedStepIndex.Should().Be(1);
-		FocusedElement().Should().BeSameAs(FindComboBox(stepListBox, 1, ActionColumnKey));
+		FocusedElement().Should().BeSameAs(FindComboPresenter(stepListBox, 1, ActionColumnKey));
 	}
 
 	[AvaloniaFact]
 	public void Down_FocusesNextParameterCell_InSameColumn()
 	{
 		var stepListBox = ShowView();
-		FindComboBox(stepListBox, 0, ActionColumnKey).Focus();
+		FindComboPresenter(stepListBox, 0, ActionColumnKey).Focus();
 
 		PressKey(PhysicalKey.ArrowDown);
 
-		FocusedElement().Should().BeSameAs(FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn));
+		FocusedElement().Should().BeSameAs(FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn));
 		_fixture.Coordinator.CurrentRecipe.Steps[0].ActionKey.Should().Be(
 			RecipeTestDriver.WaitActionId, "Down must navigate, not cycle the combo value");
 	}
@@ -149,32 +149,31 @@ public sealed class TransposedNavigationTests : IAsyncLifetime
 	public void Down_SkipsNonFocusableCell()
 	{
 		var stepListBox = ShowView();
-		FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Focus();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Focus();
 
 		PressKey(PhysicalKey.ArrowDown);
 
-		FindTextBox(stepListBox, 0, RecipeTestDriver.TaskColumn).IsEnabled
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.TaskColumn).IsEnabled
 			.Should().BeFalse("the task cell is inapplicable for a wait step, so Down must skip it");
-		FocusedElement().Should().BeSameAs(FindTextBox(stepListBox, 0, RecipeTestDriver.CommentColumn));
+		FocusedElement().Should().BeSameAs(FindTextPresenter(stepListBox, 0, RecipeTestDriver.CommentColumn));
 	}
 
 	[AvaloniaFact]
 	public void Up_FocusesPreviousParameterCell_InSameColumn()
 	{
 		var stepListBox = ShowView();
-		FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Focus();
+		FindTextPresenter(stepListBox, 0, RecipeTestDriver.StepDurationColumn).Focus();
 
 		PressKey(PhysicalKey.ArrowUp);
 
-		FocusedElement().Should().BeSameAs(FindComboBox(stepListBox, 0, ActionColumnKey));
+		FocusedElement().Should().BeSameAs(FindComboPresenter(stepListBox, 0, ActionColumnKey));
 	}
 
 	[AvaloniaFact]
 	public void LeftRight_InsideFocusedTextBox_StayWithCaret()
 	{
 		var stepListBox = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
-		editor.Focus();
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 
 		PressKey(PhysicalKey.ArrowRight);
 		PressKey(PhysicalKey.ArrowLeft);
@@ -187,21 +186,23 @@ public sealed class TransposedNavigationTests : IAsyncLifetime
 	public void Down_FromTextBox_CommitsPendingEditByDefocusing()
 	{
 		var stepListBox = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
-		editor.Focus();
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 		editor.Text = "45";
 
 		PressKey(PhysicalKey.ArrowDown);
 
 		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(45f);
-		FocusedElement().Should().BeSameAs(FindTextBox(stepListBox, 0, RecipeTestDriver.CommentColumn));
+		FocusedElement().Should().BeSameAs(FindTextPresenter(stepListBox, 0, RecipeTestDriver.CommentColumn));
 	}
 
 	[AvaloniaFact]
 	public void ArrowKeys_InsideOpenComboBoxDropdown_AreLeftAlone()
 	{
 		var stepListBox = ShowView();
-		var actionCombo = FindComboBox(stepListBox, 0, ActionColumnKey);
+		var actionCombo = EnterComboEdit(stepListBox, 0, ActionColumnKey);
+		actionCombo.IsDropDownOpen = false;
+		Dispatcher.UIThread.RunJobs();
+
 		actionCombo.Focus();
 		actionCombo.IsDropDownOpen = true;
 		Dispatcher.UIThread.RunJobs();
@@ -234,6 +235,27 @@ public sealed class TransposedNavigationTests : IAsyncLifetime
 				&& cell.Descriptor.ParameterKey == parameterKey);
 	}
 
+	private static TransposedTextCellPresenter FindTextPresenter(
+		ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+
+		return container.GetVisualDescendants()
+			.OfType<TransposedTextCellPresenter>()
+			.Single(presenter => presenter.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	// Enters edit on a lazy property-text cell through the real focus + F2 gesture, returning the editor.
+	private TextBox EnterTextEdit(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		FindTextPresenter(stepListBox, columnIndex, parameterKey).Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		return FindTextBox(stepListBox, columnIndex, parameterKey);
+	}
+
 	private static ComboBox FindComboBox(ListBox stepListBox, int columnIndex, string parameterKey)
 	{
 		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
@@ -242,6 +264,28 @@ public sealed class TransposedNavigationTests : IAsyncLifetime
 			.OfType<ComboBox>()
 			.Single(comboBox => comboBox.DataContext is ParameterCellViewModel cell
 				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	private static TransposedComboCellPresenter FindComboPresenter(
+		ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+
+		return container.GetVisualDescendants()
+			.OfType<TransposedComboCellPresenter>()
+			.Single(presenter => presenter.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	// Enters edit on a lazy combo cell through the real focus + F2 gesture (which opens the dropdown),
+	// returning the now-built ComboBox.
+	private ComboBox EnterComboEdit(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		FindComboPresenter(stepListBox, columnIndex, parameterKey).Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		return FindComboBox(stepListBox, columnIndex, parameterKey);
 	}
 
 	private ListBox ShowView()

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedViewportJumpTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedViewportJumpTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Linq;
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+
+using FluentAssertions;
+
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid.Transposed;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid.Transposed;
+
+/// <summary>
+/// Guards the "add step while scrolled far away" path: the app auto-scrolls to a freshly inserted
+/// step, and if the viewport is far from it the horizontal panel realizes a full viewport of columns
+/// in one frame. This test asserts a single far <see cref="ItemsControl.ScrollIntoView(int)"/> jump
+/// still realizes only a viewport of containers, never the whole recipe — the invariant the
+/// allocation-reduction work must preserve. Suite-resident (no SEMISTEP_PROBE gate).
+/// </summary>
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public sealed class TransposedViewportJumpTests : IAsyncLifetime
+{
+	private const int SeededStepCount = 40;
+
+	private readonly UIFixture _fixture = new();
+	private TransposedRecipeGridSurface _surface = null!;
+	private Window? _window;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_fixture.SeedRecipe(SeededStepCount);
+
+		_surface = _fixture.CreateTransposedSurface();
+		_surface.Initialize();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		_window?.Close();
+		_surface.Dispose();
+		await _fixture.DisposeAsync();
+	}
+
+	// A recycled panel realizes essentially one viewport of columns after the jump; bound the post-jump
+	// count to a small multiple of the initially-realized count (not the loose SeededStepCount/2 = 20,
+	// which a regression realizing 15-19 columns would pass) so genuine over-realization is caught.
+	private const int RecycleSlackFactor = 2;
+
+	[AvaloniaFact]
+	public void FarJumpToLastColumn_RealizedContainerCount_StaysViewportBound()
+	{
+		var stepListBox = ShowView();
+
+		var initialCount = RealizedContainerCount(stepListBox);
+		initialCount.Should().BeLessThan(
+			SeededStepCount / 2, "the panel must realize a viewport of columns, not the recipe");
+
+		JumpToLastColumn(stepListBox);
+
+		RealizedContainerCount(stepListBox).Should().BeLessThanOrEqualTo(
+			initialCount * RecycleSlackFactor,
+			"a far ScrollIntoView jump must recycle into a viewport of containers, not accumulate the recipe");
+	}
+
+	[AvaloniaFact]
+	public void FarJumpThenJumpBack_RealizedContainerCount_StaysViewportBound()
+	{
+		var stepListBox = ShowView();
+		var initialCount = RealizedContainerCount(stepListBox);
+
+		JumpToLastColumn(stepListBox);
+		JumpToColumn(stepListBox, 0);
+
+		RealizedContainerCount(stepListBox).Should().BeLessThanOrEqualTo(
+			initialCount * RecycleSlackFactor, "jumping back must recycle containers, not accumulate them");
+	}
+
+	private static int RealizedContainerCount(ListBox stepListBox)
+	{
+		return stepListBox.GetRealizedContainers().Count();
+	}
+
+	private void JumpToLastColumn(ListBox stepListBox)
+	{
+		JumpToColumn(stepListBox, _surface.StepColumns.Count - 1);
+	}
+
+	private static void JumpToColumn(ListBox stepListBox, int index)
+	{
+		stepListBox.ScrollIntoView(index);
+		Dispatcher.UIThread.RunJobs();
+	}
+
+	private ListBox ShowView()
+	{
+		var view = new TransposedRecipeGridView { DataContext = _surface };
+		_window = new Window
+		{
+			Width = 560,
+			Height = 800,
+			Content = view,
+		};
+
+		_window.Show();
+		Dispatcher.UIThread.RunJobs();
+
+		var stepListBox = view.FindControl<ListBox>("StepListBox");
+		stepListBox.Should().NotBeNull();
+
+		return stepListBox!;
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedVirtualizationTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedVirtualizationTests.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 
@@ -67,14 +69,70 @@ public sealed class TransposedVirtualizationTests : IAsyncLifetime
 	public void PendingEdit_CommitsWhenItsColumnIsRecycledOut()
 	{
 		var stepListBox = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
-		editor.Focus();
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 		editor.Text = "45";
 
 		ScrollToHorizontalEnd(stepListBox);
 
 		_surface.StepColumns[0].Row[RecipeTestDriver.StepDurationColumn].Should().Be(
-			45f, "recycling fires LostFocus, which is the commit trigger");
+			45f, "the commit-before-rebind hook flushes pending text to the captured cell as its column recycles out");
+	}
+
+	// The container-reuse fix: a column scrolled out and a new one scrolled onto the SAME container
+	// rebinds the cell subtree instead of rebuilding it. Under the lazy display the reused subtree is the
+	// text cell's display presenter (its editor is built only on edit entry); it must survive the recycle
+	// and show the recycled-in column's own data.
+	[AvaloniaFact]
+	public void RecycledContainer_ReusesSamePresenterInstance_ReboundToNewColumn()
+	{
+		var stepListBox = ShowView();
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(0)!;
+		var presenterBefore = FindTextPresenter(container, RecipeTestDriver.StepDurationColumn);
+		var columnBefore = (StepColumnViewModel)container.DataContext!;
+
+		ScrollToHorizontalEnd(stepListBox);
+
+		stepListBox.GetRealizedContainers().Should().Contain(
+			container, "the container is recycled onto a new column, not discarded and rebuilt");
+
+		var columnAfter = (StepColumnViewModel)container.DataContext!;
+		columnAfter.Should().NotBeSameAs(columnBefore, "the recycled container must rebind to a different column");
+
+		var presenterAfter = FindTextPresenter(container, RecipeTestDriver.StepDurationColumn);
+		presenterAfter.Should().BeSameAs(
+			presenterBefore, "the cell subtree is reused across recycle (rebind, not rebuild)");
+		((ParameterCellViewModel)presenterAfter.DataContext!).Row.Should().BeSameAs(
+			columnAfter.Row, "the reused presenter shows the recycled-in column's own cell");
+	}
+
+	// Commit-before-rebind: a focused editor holding pending text whose column is recycled out commits
+	// that text to the cell the user was editing (the captured cell) before the pooled slot is rebound,
+	// then the SAME reused presenter shows the recycled-in column's value on its display.
+	[AvaloniaFact]
+	public void FocusedEditor_PendingText_CommitsToCapturedCell_ThenReusedSlotShowsRebindTarget()
+	{
+		var stepListBox = ShowView();
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(0)!;
+		var presenter = FindTextPresenter(container, RecipeTestDriver.StepDurationColumn);
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var capturedColumn = (StepColumnViewModel)container.DataContext!;
+
+		editor.Text = "88";
+
+		ScrollToHorizontalEnd(stepListBox);
+
+		capturedColumn.Row[RecipeTestDriver.StepDurationColumn].Should().Be(
+			88f, "recycling the editing column out commits its pending text to the captured cell, never the rebind target");
+
+		var reusedPresenter = FindTextPresenter(container, RecipeTestDriver.StepDurationColumn);
+		reusedPresenter.Should().BeSameAs(presenter, "the pooled cell subtree is reused, not rebuilt");
+		reusedPresenter.IsEditing.Should().BeFalse("the recycled slot drops back to its display");
+		var columnAfter = (StepColumnViewModel)container.DataContext!;
+		columnAfter.Should().NotBeSameAs(capturedColumn, "the container rebound to a different column");
+		var expected = PropertyTimeEditingConverter.FormatForDisplay(
+			columnAfter.Row[RecipeTestDriver.StepDurationColumn], TimeFormatHelper.TimeHmsFormat);
+		DisplayText(container, RecipeTestDriver.StepDurationColumn).Should().Be(
+			expected, "the reused slot rebinds its display to show the recycled-in column's value");
 	}
 
 	[AvaloniaFact]
@@ -105,7 +163,7 @@ public sealed class TransposedVirtualizationTests : IAsyncLifetime
 	public void FocusedEditorWithPendingText_RecycledAcrossScroll_DoesNotCorruptOtherCells()
 	{
 		var stepListBox = ShowView();
-		var editor = FindTextBox(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
 
 		var before = new object?[SeededStepCount];
 		for (var i = 0; i < SeededStepCount; i++)
@@ -113,7 +171,6 @@ public sealed class TransposedVirtualizationTests : IAsyncLifetime
 			before[i] = _surface.StepColumns[i].Row[RecipeTestDriver.StepDurationColumn];
 		}
 
-		editor.Focus();
 		editor.Text = "777";
 
 		ScrollToHorizontalEnd(stepListBox);
@@ -126,10 +183,10 @@ public sealed class TransposedVirtualizationTests : IAsyncLifetime
 		}
 	}
 
-	// After a recycled container is reused for a far column, its editor must show that column's own
+	// After a recycled container is reused for a far column, its display must show that column's own
 	// value (the OneWay display binding rebinds), never a stale value from the column it was built on.
 	[AvaloniaFact]
-	public void RecycledTextEditor_ShowsRebindTargetCellValue_AfterScroll()
+	public void RecycledTextCell_ShowsRebindTargetCellValue_AfterScroll()
 	{
 		var lastIndex = SeededStepCount - 1;
 		_fixture.Coordinator.UpdateStepProperty(lastIndex, RecipeTestDriver.StepDurationColumn, "125")
@@ -138,13 +195,42 @@ public sealed class TransposedVirtualizationTests : IAsyncLifetime
 
 		ScrollToHorizontalEnd(stepListBox);
 
-		var editor = FindTextBox(stepListBox, lastIndex, RecipeTestDriver.StepDurationColumn);
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(lastIndex)!;
 		var expected = PropertyTimeEditingConverter.FormatForDisplay(
 			_surface.StepColumns[lastIndex].Row[RecipeTestDriver.StepDurationColumn],
 			TimeFormatHelper.TimeHmsFormat);
 
-		editor.Text.Should().Be(expected);
-		editor.Text.Should().Be("00:02:05", "the recycled editor shows the rebind-target cell's formatted value");
+		DisplayText(container, RecipeTestDriver.StepDurationColumn).Should().Be(expected);
+		DisplayText(container, RecipeTestDriver.StepDurationColumn).Should().Be(
+			"00:02:05", "the recycled slot shows the rebind-target cell's formatted value");
+	}
+
+	// The in-place commit-before-rebind hook (TransposedColumnCellsPresenter.OnDataContextBeginUpdate ->
+	// CommitActiveEditor) fires without any detach. Forcing a pooled presenter's whole-column DataContext to
+	// a new column while a text cell holds a live pending edit must commit that edit to the captured cell
+	// before the slots rebind, never leaking it into the rebind-target column. This drives the panel hook
+	// directly, unlike the recycle tests which reach commit through the detach/LostFocus path.
+	[AvaloniaFact]
+	public void InPlaceColumnRebind_CommitsPendingEdit_ViaPanelHook()
+	{
+		var stepListBox = ShowView();
+		var container = (ListBoxItem)stepListBox.ContainerFromIndex(0)!;
+		var presenter = container.GetVisualDescendants().OfType<TransposedColumnCellsPresenter>().Single();
+		var editor = EnterTextEdit(stepListBox, 0, RecipeTestDriver.StepDurationColumn);
+		var capturedColumn = (StepColumnViewModel)container.DataContext!;
+		var rebindColumn = _surface.StepColumns[1];
+		rebindColumn.Should().NotBeSameAs(capturedColumn);
+		var rebindTargetBefore = rebindColumn.Row[RecipeTestDriver.StepDurationColumn];
+
+		editor.Text = "63";
+
+		presenter.DataContext = rebindColumn;
+		Dispatcher.UIThread.RunJobs();
+
+		capturedColumn.Row[RecipeTestDriver.StepDurationColumn].Should().Be(
+			63f, "the panel's OnDataContextBeginUpdate commits the pending edit to the captured cell before rebind");
+		rebindColumn.Row[RecipeTestDriver.StepDurationColumn].Should().Be(
+			rebindTargetBefore, "the in-place rebind target must never receive the captured cell's pending text");
 	}
 
 	private static int RealizedContainerCount(ListBox stepListBox)
@@ -168,12 +254,46 @@ public sealed class TransposedVirtualizationTests : IAsyncLifetime
 
 	private static TextBox FindTextBox(ListBox stepListBox, int columnIndex, string parameterKey)
 	{
-		var container = (ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!;
+		return FindTextBox((ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!, parameterKey);
+	}
 
+	private static TextBox FindTextBox(ListBoxItem container, string parameterKey)
+	{
 		return container.GetVisualDescendants()
 			.OfType<TextBox>()
 			.Single(textBox => textBox.DataContext is ParameterCellViewModel cell
 				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	private static TransposedTextCellPresenter FindTextPresenter(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		return FindTextPresenter((ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!, parameterKey);
+	}
+
+	private static TransposedTextCellPresenter FindTextPresenter(ListBoxItem container, string parameterKey)
+	{
+		return container.GetVisualDescendants()
+			.OfType<TransposedTextCellPresenter>()
+			.Single(presenter => presenter.DataContext is ParameterCellViewModel cell
+				&& cell.Descriptor.ParameterKey == parameterKey);
+	}
+
+	private static string? DisplayText(ListBoxItem container, string parameterKey)
+	{
+		return FindTextPresenter(container, parameterKey)
+			.GetVisualDescendants()
+			.OfType<TextBlock>()
+			.First()
+			.Text;
+	}
+
+	private TextBox EnterTextEdit(ListBox stepListBox, int columnIndex, string parameterKey)
+	{
+		FindTextPresenter(stepListBox, columnIndex, parameterKey).Focus();
+		_window!.KeyPressQwerty(PhysicalKey.F2, RawInputModifiers.None);
+		Dispatcher.UIThread.RunJobs();
+
+		return FindTextBox(stepListBox, columnIndex, parameterKey);
 	}
 
 	private ListBox ShowView()

--- a/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/actions/service.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/actions/service.yaml
@@ -1,0 +1,52 @@
+# Wide-config service actions. Action 10 (Wait) is what the allocation probe seeds, so it
+# references a representative spread of columns (a group-bound combo plus several params).
+
+# Wait by time
+10:
+  ui_name: "Wait"
+  deploy_duration: longlasting
+  columns:
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: target_a
+      group_name: valve
+      property_type_id: enum
+    - key: param_01
+      default_value: "1"
+      property_type_id: float
+    - key: param_02
+      default_value: "2"
+      property_type_id: int
+    - key: param_03
+      default_value: "3"
+      property_type_id: time
+    - key: text_01
+      property_type_id: string
+    - key: comment
+      property_type_id: string
+
+# Valve control (exercises the remaining group-bound target combos)
+50:
+  ui_name: "Valve"
+  deploy_duration: longlasting
+  columns:
+    - key: step_duration
+      default_value: "10"
+      property_type_id: time
+    - key: target_b
+      group_name: valve
+      property_type_id: enum
+    - key: target_c
+      group_name: heater
+      property_type_id: enum
+    - key: comment
+      property_type_id: string
+
+# Pause
+40:
+  ui_name: "Pause"
+  deploy_duration: immediate
+  columns:
+    - key: comment
+      property_type_id: string

--- a/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/columns/columns.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/columns/columns.yaml
@@ -1,0 +1,328 @@
+# Wide column set approximating a real PLC recipe scale (~36 parameters) for allocation probing.
+# Several combo columns (one action_combo_box + three group-bound target combos) and many
+# property_field / text_field columns so a realized transposed column instantiates several
+# ComboBox editors and many TextBox editors.
+
+action:
+  column_type: action_combo_box
+  ui:
+    ui_name: "Action"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+target_a:
+  column_type: action_target_combo_box
+  ui:
+    ui_name: "Target A"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+target_b:
+  column_type: action_target_combo_box
+  ui:
+    ui_name: "Target B"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+target_c:
+  column_type: action_target_combo_box
+  ui:
+    ui_name: "Target C"
+  business_logic:
+    property_type_id: enum
+    read_only: false
+    save_to_csv: true
+
+step_duration:
+  column_type: property_field
+  ui:
+    ui_name: "Duration"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+param_01:
+  column_type: property_field
+  ui:
+    ui_name: "P01"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_02:
+  column_type: property_field
+  ui:
+    ui_name: "P02"
+  business_logic:
+    property_type_id: int
+    read_only: false
+    save_to_csv: true
+
+param_03:
+  column_type: property_field
+  ui:
+    ui_name: "P03"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+param_04:
+  column_type: property_field
+  ui:
+    ui_name: "P04"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_05:
+  column_type: property_field
+  ui:
+    ui_name: "P05"
+  business_logic:
+    property_type_id: int
+    read_only: true
+    save_to_csv: true
+
+param_06:
+  column_type: property_field
+  ui:
+    ui_name: "P06"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_07:
+  column_type: property_field
+  ui:
+    ui_name: "P07"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+param_08:
+  column_type: property_field
+  ui:
+    ui_name: "P08"
+  business_logic:
+    property_type_id: int
+    read_only: false
+    save_to_csv: true
+
+param_09:
+  column_type: property_field
+  ui:
+    ui_name: "P09"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_10:
+  column_type: property_field
+  ui:
+    ui_name: "P10"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_11:
+  column_type: property_field
+  ui:
+    ui_name: "P11"
+  business_logic:
+    property_type_id: int
+    read_only: false
+    save_to_csv: true
+
+param_12:
+  column_type: property_field
+  ui:
+    ui_name: "P12"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+param_13:
+  column_type: property_field
+  ui:
+    ui_name: "P13"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_14:
+  column_type: property_field
+  ui:
+    ui_name: "P14"
+  business_logic:
+    property_type_id: int
+    read_only: false
+    save_to_csv: true
+
+param_15:
+  column_type: property_field
+  ui:
+    ui_name: "P15"
+  business_logic:
+    property_type_id: float
+    read_only: true
+    save_to_csv: true
+
+param_16:
+  column_type: property_field
+  ui:
+    ui_name: "P16"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_17:
+  column_type: property_field
+  ui:
+    ui_name: "P17"
+  business_logic:
+    property_type_id: int
+    read_only: false
+    save_to_csv: true
+
+param_18:
+  column_type: property_field
+  ui:
+    ui_name: "P18"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+param_19:
+  column_type: property_field
+  ui:
+    ui_name: "P19"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_20:
+  column_type: property_field
+  ui:
+    ui_name: "P20"
+  business_logic:
+    property_type_id: int
+    read_only: false
+    save_to_csv: true
+
+param_21:
+  column_type: property_field
+  ui:
+    ui_name: "P21"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_22:
+  column_type: property_field
+  ui:
+    ui_name: "P22"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+param_23:
+  column_type: property_field
+  ui:
+    ui_name: "P23"
+  business_logic:
+    property_type_id: int
+    read_only: false
+    save_to_csv: true
+
+param_24:
+  column_type: property_field
+  ui:
+    ui_name: "P24"
+  business_logic:
+    property_type_id: time
+    read_only: false
+    save_to_csv: true
+
+param_25:
+  column_type: property_field
+  ui:
+    ui_name: "P25"
+  business_logic:
+    property_type_id: float
+    read_only: false
+    save_to_csv: true
+
+text_01:
+  column_type: text_field
+  ui:
+    ui_name: "T01"
+  business_logic:
+    property_type_id: string
+    read_only: false
+    save_to_csv: true
+
+text_02:
+  column_type: text_field
+  ui:
+    ui_name: "T02"
+  business_logic:
+    property_type_id: string
+    read_only: false
+    save_to_csv: true
+
+text_03:
+  column_type: text_field
+  ui:
+    ui_name: "T03"
+  business_logic:
+    property_type_id: string
+    read_only: false
+    save_to_csv: true
+
+text_04:
+  column_type: text_field
+  ui:
+    ui_name: "T04"
+  business_logic:
+    property_type_id: string
+    read_only: false
+    save_to_csv: true
+
+text_05:
+  column_type: text_field
+  ui:
+    ui_name: "T05"
+  business_logic:
+    property_type_id: string
+    read_only: false
+    save_to_csv: true
+
+comment:
+  column_type: text_field
+  ui:
+    ui_name: "Comment"
+  business_logic:
+    property_type_id: string
+    read_only: false
+    save_to_csv: true

--- a/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/connection/connection.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/connection/connection.yaml
@@ -1,0 +1,49 @@
+connection_file_version: "1.0"
+
+# -- Connection info --
+ip: "192.168.0.150:102"
+connection_protocol: "1.0"
+plc_rack: 0
+plc_slot: 1
+
+# -- Protocol settings --
+max_retries_attempts: 3
+polling_interval_ms: 100
+writing_timeout_ms: 5000
+commit_timeout_ms: 5000
+keep_alive_interval_ms: 5000
+
+# -- Managing DB --
+managing_db_number: 2
+version_offset: 0
+committed_offset: 4
+recipe_lines_offset: 6
+managing_db_total_size: 10
+
+# -- Int DB --
+int_db_number: 3
+int_db_total_capacity_offset: 0
+int_db_current_size_offset: 4
+int_db_data_offset: 8
+
+# -- Float DB --
+float_db_number: 4
+float_db_total_capacity_offset: 0
+float_db_current_size_offset: 4
+float_db_data_offset: 8
+
+# -- String DB --
+string_db_number: 5
+string_db_total_capacity_offset: 0
+string_db_current_size_offset: 4
+string_db_data_offset: 8
+
+# -- Execution DB --
+execution_db_number: 6
+recipe_active_offset: 0
+actual_line_offset: 2
+step_current_time_offset: 6
+for_loop_count1_offset: 10
+for_loop_count2_offset: 14
+for_loop_count3_offset: 18
+execution_db_total_size: 22

--- a/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/groups/groups.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/groups/groups.yaml
@@ -1,0 +1,9 @@
+# Groups for the wide-config target combos.
+valve:
+  1: "Open"
+  2: "Close"
+
+heater:
+  1: "On"
+  2: "Off"
+  3: "Auto"

--- a/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/properties/properties.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/properties/properties.yaml
@@ -1,0 +1,29 @@
+# Property definitions for the wide config.
+
+int:
+  system_type: int
+  format_kind: numeric
+  units: ""
+
+float:
+  system_type: float
+  format_kind: numeric
+  units: ""
+
+string:
+  system_type: string
+  format_kind: numeric
+  units: ""
+  max_length: 255
+
+enum:
+  system_type: int
+  format_kind: numeric
+  units: ""
+
+time:
+  system_type: float
+  format_kind: time_hms
+  units: "s"
+  min: 0
+  max: 86400

--- a/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/ui/grid_style.yaml
+++ b/SemiStep/SemiStep.Tests/YamlConfigs/WideParams/ui/grid_style.yaml
@@ -1,0 +1,42 @@
+﻿# Default grid style options for tests
+fonts:
+  header_size: 12
+  cell_size: 11
+
+layout:
+  row_height: 24
+
+colors:
+  cells:
+    readonly:
+      depth_0: "#D8D8D8"
+      depth_1: "#CCD5E0"
+      depth_2: "#B8C3D1"
+      depth_3: "#94A2B3"
+      depth_0_past: "#C8C8C8"
+      depth_1_past: "#BCC4CE"
+      depth_2_past: "#ACB7C2"
+      depth_3_past: "#8590A0"
+      selected: "#6B95C0"
+      foreground: "#606060"
+    disabled:
+      depth_0: "#E0E0E0"
+      depth_1: "#D5DEEA"
+      depth_2: "#C2CEDB"
+      depth_3: "#9DABBC"
+      depth_0_past: "#D0D0D0"
+      depth_1_past: "#C5CDD8"
+      depth_2_past: "#B5C0CC"
+      depth_3_past: "#909AAA"
+      selected: "#89B4D7"
+      foreground: "#808080"
+    execution:
+      depth_0: "#FFFFFF"
+      depth_1: "#E8F3FF"
+      depth_2: "#D0E7FF"
+      depth_3: "#A8D0FF"
+      depth_0_past: "#F0F0F0"
+      depth_1_past: "#DCE5EE"
+      depth_2_past: "#C4D2E0"
+      depth_3_past: "#9CB4CC"
+      current_step_marker: "#FF8800"

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/CellSlotConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/CellSlotConverter.cs
@@ -1,0 +1,33 @@
+﻿using System.Globalization;
+
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Resolves a fixed column-cell slot to Cells[index] so a recycled container rebinds slot i from the
+// old column's cell to the new column's cell on a single DataContext change, instead of rebuilding.
+// The slot count and order are constant across columns (one cell per ParameterDescriptor), so the
+// index is baked once per slot and passed as the converter parameter.
+internal sealed class CellSlotConverter : IValueConverter
+{
+	public static readonly CellSlotConverter Instance = new();
+
+	public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+	{
+		if (value is IReadOnlyList<ParameterCellViewModel> cells
+			&& parameter is int index
+			&& index >= 0
+			&& index < cells.Count)
+		{
+			return cells[index];
+		}
+
+		return AvaloniaProperty.UnsetValue;
+	}
+
+	public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+	{
+		return AvaloniaProperty.UnsetValue;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/ComboBoxDisplayTextConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/ComboBoxDisplayTextConverter.cs
@@ -1,0 +1,25 @@
+﻿using System.Globalization;
+
+using Avalonia.Data.Converters;
+
+using SemiStep.Core.Recipes;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Resolves a combo cell's (Value, Items) to the selected item's display text for the lazy display
+// TextBlock. It delegates the (id, items) -> item lookup to ComboBoxItemMultiSelectionConverter (the same
+// resolver the ComboBox editor's SelectedItem uses) and projects the item's DisplayText, so the display
+// updates on any external Value change (selector edit, action change, recycle rebind) through the same
+// OneWay MultiBinding the editor uses, with the lookup living in exactly one place.
+internal sealed class ComboBoxDisplayTextConverter : IMultiValueConverter
+{
+	public static readonly ComboBoxDisplayTextConverter Instance = new();
+
+	public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+	{
+		var selected = ComboBoxItemMultiSelectionConverter.Instance.Convert(
+			values, typeof(ComboBoxItemViewModel), parameter, culture);
+
+		return (selected as ComboBoxItemViewModel)?.DisplayText ?? string.Empty;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs
@@ -3,7 +3,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Input;
@@ -17,14 +16,18 @@ using SemiStep.Core.Recipes;
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
 /// <summary>
-/// Builds the per-kind cell editor templates for the transposed grid, mirroring the canonical
-/// TextCellFactory / ComboBoxCellFactory: always-live editors dispatched over the cell-VM type,
-/// display and parse-back through the shared time/unit converters, input gated on applicability,
-/// column-level read-only, and the surface read-only state.
+/// Builds the per-kind cell controls for the transposed grid, dispatched over the cell-VM type. Both
+/// editor kinds are lazy: property-text and ComboBox cells render a lightweight display and build their
+/// heavy editor (TextBox / ComboBox) only on edit entry through the view-level edit coordinator, released
+/// back to the display on exit. Display and parse-back go through the shared time/unit converters; input
+/// is gated on applicability, column-level read-only, and the surface read-only state.
 /// </summary>
-internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface surface)
+internal sealed class TransposedCellTemplateFactory(
+	TransposedRecipeGridSurface surface,
+	TransposedTextEditCoordinator editCoordinator)
 {
-	private static readonly FuncValueConverter<bool, bool> _negateConverter = new(value => !value);
+	// Shared bool negation, reused by the pooled column-cells presenter's class bindings.
+	internal static readonly FuncValueConverter<bool, bool> NegateConverter = new(value => !value);
 	private static readonly FuncValueConverter<int?, int> _maxLengthConverter = new(maxLength => maxLength ?? 0);
 	private static readonly PropertyTimeMultiConverter _displayConverter = new();
 
@@ -35,14 +38,119 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 		AvaloniaProperty.RegisterAttached<TransposedCellTemplateFactory, TextBox, PropertyTextCellViewModel?>(
 			"EditingCell");
 
-	public IReadOnlyList<IDataTemplate> CreateTemplates()
+	// Builds the per-kind editor control directly (no ContentControl/ContentPresenter wrapper), so a
+	// pooled column presenter can host it as a plain child that survives detach/reattach and only
+	// rebinds on DataContext change. The kind is constant per slot (every column's cell at a given row
+	// shares one descriptor), so the editor built from the first bound cell stays correct across reuse.
+	public Control CreateEditor(ParameterCellViewModel cell)
 	{
-		return
-		[
-			CreateComboBoxTemplate(),
-			CreatePropertyTextTemplate(),
-			CreateReadOnlyTemplate(),
-		];
+		return cell switch
+		{
+			ComboBoxCellViewModel => CreateComboCellPresenter(),
+			ReadOnlyCellViewModel readOnlyCell => CreateReadOnlyTextBlock(readOnlyCell),
+			_ => CreateTextCellPresenter(),
+		};
+	}
+
+	// ComboBox cells are lazy: a display TextBlock showing the selected item's text by default, with the
+	// heavy ComboBox editor built only when the coordinator enters edit here. Hit-testable/focusable follow
+	// applicability + column read-only (a read-only or inapplicable combo is non-hit-testable and
+	// non-focusable, so it cannot enter edit and a press falls through to column selection); IsEnabled adds
+	// the surface read-only state.
+	private Control CreateComboCellPresenter()
+	{
+		var presenter = new TransposedComboCellPresenter(
+			editCoordinator,
+			CreateComboDisplay(),
+			CreateComboBox);
+		presenter.Bind(InputElement.IsHitTestVisibleProperty, CreateInteractiveBinding());
+		presenter.Bind(InputElement.FocusableProperty, CreateInteractiveBinding());
+		presenter.Bind(InputElement.IsEnabledProperty, CreateEditableBinding());
+
+		return presenter;
+	}
+
+	private Control CreateComboDisplay()
+	{
+		var textBlock = CreateDisplayTextBlock(stretch: true);
+
+		// The same OneWay (Value, Items) lookup the ComboBox editor's SelectedItem uses, projected to the
+		// item's display text, so a recycled slot rebinds its display to the new cell's selection and an
+		// external value change (selector edit / action change) updates the shown text.
+		textBlock.Bind(TextBlock.TextProperty, new MultiBinding
+		{
+			Mode = BindingMode.OneWay,
+			Converter = ComboBoxDisplayTextConverter.Instance,
+			Bindings =
+			{
+				new Binding(nameof(ParameterCellViewModel.Value)) { Mode = BindingMode.OneWay },
+				new Binding(nameof(ComboBoxCellViewModel.Items)) { Mode = BindingMode.OneWay },
+			},
+		});
+
+		return textBlock;
+	}
+
+	// Property-text cells are lazy: a display TextBlock by default, with the TextBox editor built only
+	// when the coordinator enters edit here. The display mirrors the editor's units-less formatting so
+	// entering/leaving edit shows identical text; IsEnabled follows applicability + surface read-only so
+	// inapplicable / read-only-surface cells are non-hit-testable and non-focusable (edit entry blocked).
+	private Control CreateTextCellPresenter()
+	{
+		var presenter = new TransposedTextCellPresenter(
+			editCoordinator,
+			CreateTextDisplay(),
+			CreateTextBoxEditor);
+		presenter.Bind(InputElement.IsEnabledProperty, CreateTextBoxEditableBinding());
+
+		return presenter;
+	}
+
+	private Control CreateTextDisplay()
+	{
+		var textBlock = CreateDisplayTextBlock(stretch: true);
+
+		// The same OneWay (Value, FormatKind) MultiBinding the editor uses, so a recycled slot rebinds
+		// its display to the new cell's value and the display matches what the editor would show.
+		textBlock.Bind(TextBlock.TextProperty, new MultiBinding
+		{
+			Mode = BindingMode.OneWay,
+			Converter = PropertyTextEditingMultiConverter.Instance,
+			Bindings =
+			{
+				new Binding(nameof(ParameterCellViewModel.Value)) { Mode = BindingMode.OneWay },
+				new Binding(nameof(ParameterCellViewModel.FormatKind)) { Mode = BindingMode.OneWay },
+			},
+		});
+
+		return textBlock;
+	}
+
+	// The display TextBlock shared by all three cell kinds (combo display, text display, read-only): same
+	// vertical centering, cell padding, centered text, and grid font. Callers attach their own Text binding.
+	// The two editor-backed kinds pass stretch: true to fill the cell width; the read-only kind keeps the
+	// default alignment.
+	private TextBlock CreateDisplayTextBlock(bool stretch)
+	{
+		var gridStyle = surface.GridStyle;
+		var textBlock = new TextBlock
+		{
+			VerticalAlignment = VerticalAlignment.Center,
+			Padding = new Thickness(
+				gridStyle.CellPaddingLeft,
+				gridStyle.CellPaddingTop,
+				gridStyle.CellPaddingRight,
+				gridStyle.CellPaddingBottom),
+			TextAlignment = TextAlignment.Center,
+		};
+		if (stretch)
+		{
+			textBlock.HorizontalAlignment = HorizontalAlignment.Stretch;
+		}
+
+		GridFontApplier.ApplyCellFont(textBlock, gridStyle);
+
+		return textBlock;
 	}
 
 	internal static void CommitByDefocusing(Control editor)
@@ -55,14 +163,10 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 		TopLevel.GetTopLevel(editor)?.FocusManager?.Focus(null);
 	}
 
-	private IDataTemplate CreateComboBoxTemplate()
-	{
-		return new FuncDataTemplate<ComboBoxCellViewModel>((_, _) => CreateComboBox(), supportsRecycling: true);
-	}
-
-	// FontSize explicit: the Semi ComboBox selection box does not inherit the grid font (parity
-	// with the canonical ComboBoxCellFactory). SelectedItem resolves via a OneWay MultiBinding;
-	// writeback is owned by SelectionChanged, which no-ops when the value is unchanged.
+	// The ComboBox editor, built lazily by the combo presenter on edit entry. FontSize explicit: the Semi
+	// ComboBox selection box does not inherit the grid font (parity with the canonical ComboBoxCellFactory).
+	// SelectedItem resolves via a OneWay MultiBinding; writeback is owned by SelectionChanged, which no-ops
+	// when the value is unchanged (so the initial selection on a lazy build is a no-op, not a recipe edit).
 	private ComboBox CreateComboBox()
 	{
 		var itemsPath = nameof(ComboBoxCellViewModel.Items);
@@ -109,17 +213,10 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 		cell.Value = selected.Id.ToString(CultureInfo.InvariantCulture);
 	}
 
-	// supportsRecycling:true — the TextBox carries no per-cell baked state: display is a OneWay
-	// MultiBinding through a shared stateless converter, MaxLength is bound, and the edit commit reads
-	// its target from the cell captured on GotFocus (not a closure), so a recycled container safely
-	// rebinds onto the next cell instead of rebuilding the whole subtree.
-	private IDataTemplate CreatePropertyTextTemplate()
-	{
-		return new FuncDataTemplate<PropertyTextCellViewModel>(
-			(cell, _) => cell is null ? new TextBlock() : CreateTextBoxEditor(),
-			supportsRecycling: true);
-	}
-
+	// The TextBox carries no per-cell baked state: display is a OneWay MultiBinding through a shared
+	// stateless converter, MaxLength is bound, and the edit commit reads its target from the cell
+	// captured on GotFocus (not a closure), so a pooled editor safely rebinds onto the next cell on a
+	// DataContext change instead of being rebuilt.
 	private Control CreateTextBoxEditor()
 	{
 		var gridStyle = surface.GridStyle;
@@ -225,7 +322,7 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 	// the source untouched, so the OneWay binding would otherwise keep showing the never-committed
 	// text; if the editor was recycled onto another cell, its binding already shows that cell and must
 	// not be overwritten.
-	private static void CommitEditor(TextBox textBox)
+	internal static void CommitEditor(TextBox textBox)
 	{
 		if (textBox.GetValue(_editingCellProperty) is not { } cell)
 		{
@@ -244,32 +341,13 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 		}
 	}
 
-	// supportsRecycling:true — the read-only TextBlock holds no per-cell baked state: both the
-	// step-start-time and the display-converter legs are OneWay bindings. The step-start-time vs
-	// display split keys off the descriptor's ColumnType, which is invariant per recycled position
-	// (every column's cell at a given row shares one parameter descriptor), so the chosen leg stays
-	// correct across recycling.
-	private IDataTemplate CreateReadOnlyTemplate()
-	{
-		return new FuncDataTemplate<ReadOnlyCellViewModel>(
-			(cell, _) => cell is null ? new TextBlock() : CreateReadOnlyTextBlock(cell),
-			supportsRecycling: true);
-	}
-
+	// The read-only TextBlock holds no per-cell baked state: both the step-start-time and the
+	// display-converter legs are OneWay bindings. The step-start-time vs display split keys off the
+	// descriptor's ColumnType, which is invariant per slot position (every column's cell at a given row
+	// shares one parameter descriptor), so the chosen leg stays correct across reuse.
 	private Control CreateReadOnlyTextBlock(ReadOnlyCellViewModel cell)
 	{
-		var gridStyle = surface.GridStyle;
-		var textBlock = new TextBlock
-		{
-			VerticalAlignment = VerticalAlignment.Center,
-			Padding = new Thickness(
-				gridStyle.CellPaddingLeft,
-				gridStyle.CellPaddingTop,
-				gridStyle.CellPaddingRight,
-				gridStyle.CellPaddingBottom),
-			TextAlignment = TextAlignment.Center,
-		};
-		GridFontApplier.ApplyCellFont(textBlock, gridStyle);
+		var textBlock = CreateDisplayTextBlock(stretch: false);
 
 		// Step start time arrives pre-formatted (HH:MM:SS + units) from the surface refresh tail,
 		// so it binds directly; other read-only cells format through the shared display converter.
@@ -352,7 +430,7 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 		return new Binding(nameof(TransposedRecipeGridSurface.IsReadOnly))
 		{
 			Source = surface,
-			Converter = _negateConverter,
+			Converter = NegateConverter,
 		};
 	}
 
@@ -361,6 +439,6 @@ internal sealed class TransposedCellTemplateFactory(TransposedRecipeGridSurface 
 		var descriptorReadOnlyPath =
 			$"{nameof(ParameterCellViewModel.Descriptor)}.{nameof(ParameterDescriptor.IsReadOnlyParameter)}";
 
-		return new Binding(descriptorReadOnlyPath) { Converter = _negateConverter };
+		return new Binding(descriptorReadOnlyPath) { Converter = NegateConverter };
 	}
 }

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsHost.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsHost.cs
@@ -1,0 +1,73 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.VisualTree;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Lightweight seam between the recycled ListBox container and a pooled column-cells presenter. It sits
+// in the ItemTemplate (so it IS rebuilt on every recycle, but it carries no cell subtree of its own), and
+// on realize it borrows a presenter from the view's pool, binds it to the column, and hosts it; on
+// recycle-out it commits any active edit and returns the presenter. This keeps the heavy cell subtrees
+// out of the rebuilt-on-recycle content while the ListBox still virtualizes the columns.
+internal sealed class TransposedColumnCellsHost : Decorator
+{
+	private TransposedRecipeGridView? _view;
+	private TransposedColumnCellsPool? _acquiredPool;
+	private TransposedColumnCellsPresenter? _presenter;
+
+	protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+	{
+		base.OnAttachedToVisualTree(e);
+		_view ??= this.FindAncestorOfType<TransposedRecipeGridView>();
+		AcquireAndBind();
+	}
+
+	protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+	{
+		ReleasePresenter();
+		base.OnDetachedFromVisualTree(e);
+	}
+
+	protected override void OnDataContextChanged(EventArgs e)
+	{
+		base.OnDataContextChanged(e);
+		AcquireAndBind();
+	}
+
+	private void AcquireAndBind()
+	{
+		// The surface (and its pool) can change under the singleton view on a config swap; always take
+		// the current pool and remember which one lent the presenter so it is returned to its origin.
+		if (_view?.ColumnCellsPool is not { } pool || DataContext is not StepColumnViewModel column)
+		{
+			return;
+		}
+
+		if (_presenter is null)
+		{
+			_presenter = pool.Acquire();
+			_acquiredPool = pool;
+		}
+
+		_presenter.BindColumn(column);
+
+		if (!ReferenceEquals(Child, _presenter))
+		{
+			Child = _presenter;
+		}
+	}
+
+	private void ReleasePresenter()
+	{
+		if (_presenter is null)
+		{
+			return;
+		}
+
+		_presenter.CommitActiveEditor();
+		Child = null;
+		_acquiredPool?.Return(_presenter);
+		_presenter = null;
+		_acquiredPool = null;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPool.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPool.cs
@@ -1,0 +1,29 @@
+﻿using SemiStep.Core.Recipes;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// A small view-owned pool of reusable column-cells presenters. The transposed ListBox recycles its
+// containers by detaching and rebuilding their ItemTemplate content, so a presenter placed inside that
+// content would be rebuilt on every scroll. The pool holds presenters OUTSIDE that recycled content and
+// hands one to each realized column (via TransposedColumnCellsHost), so the built cell subtrees are
+// reused across recycling instead of rebuilt. The pool only ever grows to the realized-container count
+// (a viewport of columns), so never-scrolled columns cost nothing.
+internal sealed class TransposedColumnCellsPool(
+	IReadOnlyList<ParameterDescriptor> descriptors,
+	TransposedCellTemplateFactory cellFactory,
+	double cellHeight)
+{
+	private readonly Stack<TransposedColumnCellsPresenter> _idle = new();
+
+	public TransposedColumnCellsPresenter Acquire()
+	{
+		return _idle.Count > 0
+			? _idle.Pop()
+			: new TransposedColumnCellsPresenter(descriptors, cellFactory, cellHeight);
+	}
+
+	public void Return(TransposedColumnCellsPresenter presenter)
+	{
+		_idle.Push(presenter);
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPresenter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPresenter.cs
@@ -1,0 +1,140 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.VisualTree;
+
+using SemiStep.Core.Recipes;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// One reusable presenter for a step column's cells. Built ONCE with a fixed slot per ParameterDescriptor
+// (cell count and row order are constant across columns), each slot a cell Border whose child is a plain
+// editor control - NOT a ContentControl - so it survives the detach/reattach a recycled ListBox container
+// forces and only rebinds on a DataContext change instead of being rebuilt. Presenters are pooled across
+// containers (see TransposedColumnCellsPool): rebinding a column is a single DataContext assignment that
+// re-resolves every slot's Cells[i], turning a viewport jump from N column rebuilds into N rebinds.
+internal sealed class TransposedColumnCellsPresenter : StackPanel
+{
+	private readonly IReadOnlyList<ParameterDescriptor> _descriptors;
+	private readonly TransposedCellTemplateFactory _cellFactory;
+	private readonly double _cellHeight;
+	private bool _slotsBuilt;
+
+	public TransposedColumnCellsPresenter(
+		IReadOnlyList<ParameterDescriptor> descriptors,
+		TransposedCellTemplateFactory cellFactory,
+		double cellHeight)
+	{
+		_descriptors = descriptors;
+		_cellFactory = cellFactory;
+		_cellHeight = cellHeight;
+		Orientation = Orientation.Vertical;
+	}
+
+	// Binds the presenter to a column: builds the slots on first use (from the config-constant
+	// descriptor count, touching Cells only for this actually-realized column so the never-realized
+	// column's Lazy stays untouched), then rebinds every slot by assigning the column DataContext.
+	public void BindColumn(StepColumnViewModel column)
+	{
+		EnsureSlotsBuilt(column);
+		DataContext = column;
+	}
+
+	// Commits/closes any editing slot (text or combo) inside this presenter before it is released or
+	// rebound, so pending text is never lost to the rebind's OneWay display binding and a combo drops back
+	// to its display. Walks the slot subtree directly (not via focus) so it works even while the presenter
+	// is already detached from its top level during a recycle.
+	public void CommitActiveEditor()
+	{
+		foreach (var slot in this.GetVisualDescendants().OfType<TransposedLazyCellPresenter>())
+		{
+			slot.CommitEdit();
+		}
+	}
+
+	// Backstop for the rare in-place DataContext swap: Avalonia raises this top-down and stops at the
+	// slot Borders (their DataContext is locally bound), so it fires while the editor still shows the
+	// old cell, before any slot rebinds.
+	protected override void OnDataContextBeginUpdate()
+	{
+		CommitActiveEditor();
+		base.OnDataContextBeginUpdate();
+	}
+
+	private void EnsureSlotsBuilt(StepColumnViewModel column)
+	{
+		if (_slotsBuilt)
+		{
+			return;
+		}
+
+		// Slot count is descriptor-driven and constant across columns (one cell per ParameterDescriptor);
+		// derive it from the descriptors, not this column's Cells, so the count is orientation-invariant.
+		var cells = column.Cells;
+		for (var slotIndex = 0; slotIndex < _descriptors.Count; slotIndex++)
+		{
+			var slot = BuildCellSlot(_cellFactory.CreateEditor(cells[slotIndex]));
+			slot.Bind(DataContextProperty, new Binding(nameof(StepColumnViewModel.Cells))
+			{
+				Converter = CellSlotConverter.Instance,
+				ConverterParameter = slotIndex,
+			});
+
+			Children.Add(slot);
+		}
+
+		_slotsBuilt = true;
+	}
+
+	// Rebuilds the cell Border in code (the XAML equivalent lived in the inner ItemsControl item
+	// template): the transposed-cell chrome classes, the flattened background-state MultiBinding, and a
+	// fixed row height. The editor is the Border's direct child.
+	private Border BuildCellSlot(Control editor)
+	{
+		var border = new Border
+		{
+			Height = _cellHeight,
+			Child = editor,
+		};
+
+		border.Classes.Add("transposed-cell");
+
+		var readOnlyParameterPath =
+			$"{nameof(ParameterCellViewModel.Descriptor)}.{nameof(ParameterDescriptor.IsReadOnlyParameter)}";
+
+		border.BindClass("read-only-cell", new Binding(readOnlyParameterPath), border);
+		border.BindClass(
+			"inapplicable",
+			new Binding(nameof(ParameterCellViewModel.IsApplicable))
+			{
+				Converter = TransposedCellTemplateFactory.NegateConverter,
+			},
+			border);
+		border.BindClass("changed", new Binding(nameof(ParameterCellViewModel.IsChanged)), border);
+
+		border.Bind(Border.BackgroundProperty, new MultiBinding
+		{
+			Converter = TransposedCellBackgroundConverter.Instance,
+			Bindings =
+			{
+				new Binding { RelativeSource = new RelativeSource(RelativeSourceMode.Self) },
+				new Binding($"{nameof(ParameterCellViewModel.Row)}.{nameof(RecipeRowViewModel.ForDepth)}"),
+				new Binding($"{nameof(ParameterCellViewModel.Row)}.{nameof(RecipeRowViewModel.IsPastStep)}"),
+				new Binding(readOnlyParameterPath),
+				new Binding(nameof(ParameterCellViewModel.IsApplicable)),
+				new Binding(nameof(ParameterCellViewModel.IsChanged)),
+				new Binding(nameof(ListBoxItem.IsSelected))
+				{
+					RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
+					{
+						AncestorType = typeof(ListBoxItem),
+					},
+				},
+			},
+		});
+
+		return border;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedComboCellPresenter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedComboCellPresenter.cs
@@ -1,0 +1,50 @@
+﻿using Avalonia.Controls;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Lazy display/editor slot for a ComboBox cell. Renders a lightweight display TextBlock showing the
+// selected item's text by default and builds the full ComboBox only when the edit coordinator enters
+// edit here, opening the dropdown so the second press behaves like clicking a live combo. The ComboBox is
+// the heaviest single cell control, so keeping it out of the resident tree until edit removes the bulk of
+// the realized-column cost (a not-in-edit column now instantiates zero ComboBoxes). Writeback stays owned
+// by the ComboBox's SelectionChanged, so there is no deferred content to flush on commit/recycle.
+internal sealed class TransposedComboCellPresenter : TransposedLazyCellPresenter
+{
+	public TransposedComboCellPresenter(
+		TransposedTextEditCoordinator coordinator,
+		Control display,
+		Func<Control> editorBuilder)
+		: base(coordinator, display, editorBuilder)
+	{
+	}
+
+	// The combo carries no seeded text; opening the dropdown on entry matches the click-to-open affordance
+	// of a live combo (the second press / F2 gesture reads as "open this combo").
+	protected override void OnEnteredEdit(Control editor, string? initialText)
+	{
+		if (editor is ComboBox comboBox)
+		{
+			comboBox.IsDropDownOpen = true;
+		}
+	}
+
+	// SelectionChanged already wrote the selection back as the user picked, so there is nothing to flush.
+	// The commit-before-rebind / recycle path swaps the ComboBox out for the display without a blur, so the
+	// dropdown would stay open on the pooled ComboBox: close it here (mirroring CloseActiveEditor) so a
+	// detached popup cannot orphan and a later re-edit's IsDropDownOpen=true actually reopens it.
+	protected override void CommitEditorContent(Control editor)
+	{
+		if (editor is ComboBox comboBox)
+		{
+			comboBox.IsDropDownOpen = false;
+		}
+	}
+
+	// The dropdown popup lives in its own visual root; opening it blurs the ComboBox. Keep editing while
+	// the dropdown is open so the popup interaction is not torn down, and revert to the display only when
+	// focus leaves the closed combo.
+	protected override bool ShouldExitOnEditorLostFocus(Control editor)
+	{
+		return editor is not ComboBox { IsDropDownOpen: true };
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridNavigator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridNavigator.cs
@@ -125,7 +125,7 @@ internal sealed class TransposedGridNavigator(ListBox stepListBox)
 		stepListBox.ScrollIntoView(targetColumnIndex);
 		stepListBox.UpdateLayout();
 
-		var focusTarget = FindFocusableEditor(surface, targetColumnIndex, position.ParameterIndex)
+		var focusTarget = FindFocusableCellPresenter(surface, targetColumnIndex, position.ParameterIndex)
 			?? stepListBox.ContainerFromIndex(targetColumnIndex);
 		focusTarget?.Focus();
 	}
@@ -141,15 +141,21 @@ internal sealed class TransposedGridNavigator(ListBox stepListBox)
 			parameterIndex >= 0 && parameterIndex < cellCount;
 			parameterIndex += direction)
 		{
-			if (FindFocusableEditor(surface, position.ColumnIndex, parameterIndex) is { } editor)
+			if (FindFocusableCellPresenter(surface, position.ColumnIndex, parameterIndex) is { } presenter)
 			{
-				editor.Focus();
+				presenter.Focus();
 				return;
 			}
 		}
 	}
 
-	private Control? FindFocusableEditor(TransposedRecipeGridSurface surface, int columnIndex, int parameterIndex)
+	// Arrow navigation traverses cells by focusing the lazy display presenters (property-text and combo
+	// alike): the heavy editor is built only on edit entry, so navigation targets the display visual and a
+	// focused display then enters edit on F2 (text also on a printable keystroke).
+	private Control? FindFocusableCellPresenter(
+		TransposedRecipeGridSurface surface,
+		int columnIndex,
+		int parameterIndex)
 	{
 		if (stepListBox.ContainerFromIndex(columnIndex) is not ListBoxItem container)
 		{
@@ -159,10 +165,9 @@ internal sealed class TransposedGridNavigator(ListBox stepListBox)
 		var cell = surface.StepColumns[columnIndex].Cells[parameterIndex];
 
 		return container.GetVisualDescendants()
-			.OfType<Control>()
-			.FirstOrDefault(control => control is TextBox or ComboBox
-				&& ReferenceEquals(control.DataContext, cell)
-				&& control.Focusable
-				&& control.IsEffectivelyEnabled);
+			.OfType<TransposedLazyCellPresenter>()
+			.FirstOrDefault(presenter => ReferenceEquals(presenter.DataContext, cell)
+				&& presenter.Focusable
+				&& presenter.IsEffectivelyEnabled);
 	}
 }

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridSelectionController.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridSelectionController.cs
@@ -6,24 +6,27 @@ namespace SemiStep.UI.RecipeGrid.Transposed;
 // Cell presses drive the canonical select-then-edit model. A plain press on a not-yet
 // selected column selects it WITHOUT focusing the editor (focus goes to the container, so
 // Delete/Ctrl+C stay live); a second plain press on the already selected column falls
-// through to the always-live editor. Ctrl/Shift presses toggle/extend the multi-selection
+// through to the editor (a live ComboBox, or edit entry for a lazy text cell — the caller
+// decides on the reported fall-through). Ctrl/Shift presses toggle/extend the multi-selection
 // (the editor would otherwise swallow them — spike finding) and never enter an editor.
 internal sealed class TransposedGridSelectionController(ListBox stepListBox)
 {
-	public void HandleCellSelectionPress(
+	// Returns true when the press was NOT consumed for selection — a second press on the already
+	// single-selected column — so the caller can route it to edit entry (or leave it to a live editor).
+	public bool HandleCellSelectionPress(
 		TransposedRecipeGridSurface? surface,
 		ParameterCellViewModel pressedCell,
 		PointerPressedEventArgs e)
 	{
 		if (surface is null)
 		{
-			return;
+			return false;
 		}
 
 		var index = TransposedGridCellLocator.IndexOfColumn(surface, pressedCell.Row);
 		if (index < 0)
 		{
-			return;
+			return false;
 		}
 
 		if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
@@ -36,7 +39,7 @@ internal sealed class TransposedGridSelectionController(ListBox stepListBox)
 		}
 		else if (IsSingleSelectedColumn(index))
 		{
-			return;
+			return true;
 		}
 		else
 		{
@@ -47,6 +50,8 @@ internal sealed class TransposedGridSelectionController(ListBox stepListBox)
 		// pressed container so the previous editor's LostFocus fires.
 		(stepListBox.ContainerFromIndex(index) as Control)?.Focus();
 		e.Handled = true;
+
+		return false;
 	}
 
 	private bool IsSingleSelectedColumn(int index)

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedLazyCellPresenter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedLazyCellPresenter.cs
@@ -1,0 +1,200 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Shared lazy display/editor slot for a transposed cell. Renders a lightweight display control by default
+// and builds the heavy editor (TextBox / ComboBox) only when the edit coordinator enters edit here,
+// releasing it back to the display on blur/commit/recycle. This removes the always-live editor weight
+// from the fresh-container build and the resident visual tree while preserving the select-then-edit
+// gesture, click-and-type, and keyboard-driven edit entry. A transparent background makes the whole cell
+// hit-testable so a press anywhere in it enters edit; Focusable makes it an arrow-navigation target from
+// which F2 opens the editor. Subclasses supply the per-kind editor build/commit and edit-entry specifics.
+internal abstract class TransposedLazyCellPresenter : Border
+{
+	private readonly TransposedTextEditCoordinator _coordinator;
+	private readonly Control _display;
+	private readonly Func<Control> _editorBuilder;
+	private Control? _editor;
+
+	protected TransposedLazyCellPresenter(
+		TransposedTextEditCoordinator coordinator,
+		Control display,
+		Func<Control> editorBuilder)
+	{
+		_coordinator = coordinator;
+		_display = display;
+		_editorBuilder = editorBuilder;
+		Background = Brushes.Transparent;
+		Focusable = true;
+		Child = _display;
+
+		AddHandler(KeyDownEvent, OnDisplayKeyDown, RoutingStrategies.Bubble);
+		AddHandler(TextInputEvent, OnDisplayTextInput, RoutingStrategies.Bubble);
+	}
+
+	public bool IsEditing { get; private set; }
+
+	public Control? Editor => _editor;
+
+	// Applicability + surface read-only fold into the presenter's bound IsEnabled, so a disabled presenter
+	// is non-focusable and blocks edit entry (read-only / inapplicable / read-only-surface all gate here).
+	public bool CanEnterEdit => IsEffectivelyEnabled;
+
+	// Swaps the display for the editor, focuses it, and hands off to the subclass for the just-entered
+	// state (seed text / open dropdown). Synchronous so the paired TextInput of a printable keystroke
+	// lands on the now-focused editor.
+	public void EnterEdit(string? initialText)
+	{
+		if (!IsEffectivelyEnabled)
+		{
+			return;
+		}
+
+		EnsureEditorBuilt();
+		Child = _editor;
+		IsEditing = true;
+		_editor!.Focus();
+		OnEnteredEdit(_editor, initialText);
+	}
+
+	public void FocusEditor()
+	{
+		_editor?.Focus();
+	}
+
+	// Commit-before-rebind: flush the editor's content to its captured cell (text parses/writes; combo is
+	// a no-op) and drop back to the display without moving focus. Called when a pooled presenter is
+	// recycled out or rebound to a new column so the edit lands on the cell the user was editing before the
+	// display binding rebinds. Idempotent: a second call after ShowDisplay is a no-op.
+	public void CommitEdit()
+	{
+		if (!IsEditing || _editor is null)
+		{
+			return;
+		}
+
+		CommitEditorContent(_editor);
+		ShowDisplay();
+		_coordinator.NotifyEditEnded(this);
+	}
+
+	protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+	{
+		// A recycle detaches this slot while it may still be editing. Commit/close the editor before the
+		// pooled presenter is reused, so a rebind can never silently overwrite pending state.
+		CommitEdit();
+
+		base.OnDetachedFromVisualTree(e);
+	}
+
+	// Applies the just-entered edit state after the editor is built, swapped in, and focused.
+	protected abstract void OnEnteredEdit(Control editor, string? initialText);
+
+	// Pushes the editor's pending content to the model on commit-before-rebind.
+	protected abstract void CommitEditorContent(Control editor);
+
+	// A printable KeyDown reached a focused display. Subclasses that accept typed entry override to enter
+	// edit (text seeds with replace semantics); the combo ignores typing (F2 / pointer are its gestures), so
+	// the base no-op leaves it alone.
+	protected virtual void OnPrintableKeyDown(KeyEventArgs e)
+	{
+	}
+
+	// A TextInput reached a focused display without a preceding printable KeyDown (the pure TextInput /
+	// IME route). Subclasses that accept typed entry override to seed the editor with the carried character.
+	protected virtual void OnDisplayTextInputCore(TextInputEventArgs e)
+	{
+	}
+
+	// Whether an editor LostFocus ends the edit. Text always exits; a combo whose dropdown is open keeps
+	// editing (focus moved into the popup's own visual root, not away from the cell).
+	protected virtual bool ShouldExitOnEditorLostFocus(Control editor)
+	{
+		return true;
+	}
+
+	protected void BeginEdit(string? initialText)
+	{
+		_coordinator.BeginEdit(this, initialText);
+	}
+
+	protected static bool IsPrintable(string? text, KeyModifiers modifiers)
+	{
+		if (string.IsNullOrEmpty(text))
+		{
+			return false;
+		}
+
+		if ((modifiers & (KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Meta)) != 0)
+		{
+			return false;
+		}
+
+		return !char.IsControl(text[0]);
+	}
+
+	private void EnsureEditorBuilt()
+	{
+		if (_editor is not null)
+		{
+			return;
+		}
+
+		_editor = _editorBuilder();
+		_editor.AddHandler(LostFocusEvent, OnEditorLostFocus, RoutingStrategies.Bubble);
+	}
+
+	// The editor blurs on commit (Enter / click-away), on recycle (Avalonia detaches the container), when
+	// focus moves into another cell's editor, and (for a combo) when its dropdown opens. Swap back to the
+	// display and tell the coordinator the edit ended, unless the subclass keeps editing across this blur.
+	private void OnEditorLostFocus(object? sender, RoutedEventArgs e)
+	{
+		if (_editor is null || !ShouldExitOnEditorLostFocus(_editor))
+		{
+			return;
+		}
+
+		ShowDisplay();
+		_coordinator.NotifyEditEnded(this);
+	}
+
+	private void ShowDisplay()
+	{
+		IsEditing = false;
+		if (!ReferenceEquals(Child, _display))
+		{
+			Child = _display;
+		}
+	}
+
+	private void OnDisplayKeyDown(object? sender, KeyEventArgs e)
+	{
+		if (IsEditing || !IsEffectivelyEnabled)
+		{
+			return;
+		}
+
+		if (e.Key == Key.F2 && e.KeyModifiers == KeyModifiers.None)
+		{
+			BeginEdit(initialText: null);
+			e.Handled = true;
+			return;
+		}
+
+		OnPrintableKeyDown(e);
+	}
+
+	private void OnDisplayTextInput(object? sender, TextInputEventArgs e)
+	{
+		if (IsEditing || !IsEffectivelyEnabled)
+		{
+			return;
+		}
+
+		OnDisplayTextInputCore(e);
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml
@@ -71,39 +71,11 @@
                                             Background="{DynamicResource CurrentStepMarkerBrush}"
                                             IsVisible="{Binding Row.IsCurrentStep}" />
                                 </Border>
-                                <ItemsControl ItemsSource="{Binding Cells}">
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate x:DataType="transposed:ParameterCellViewModel">
-                                            <Border Classes="transposed-cell"
-                                                    Classes.read-only-cell="{Binding Descriptor.IsReadOnlyParameter}"
-                                                    Classes.inapplicable="{Binding !IsApplicable}"
-                                                    Classes.changed="{Binding IsChanged}"
-                                                    Height="{DynamicResource TransposedCellHeight}">
-                                                <!-- Full cell-background state matrix (depth / past /
-                                                     read-only / inapplicable / changed / selection)
-                                                     resolved in one converter; a local Background value
-                                                     that outranks any style setter. -->
-                                                <Border.Background>
-                                                    <MultiBinding Converter="{x:Static transposed:TransposedCellBackgroundConverter.Instance}">
-                                                        <Binding RelativeSource="{RelativeSource Self}" />
-                                                        <Binding Path="Row.ForDepth" />
-                                                        <Binding Path="Row.IsPastStep" />
-                                                        <Binding Path="Descriptor.IsReadOnlyParameter" />
-                                                        <Binding Path="IsApplicable" />
-                                                        <Binding Path="IsChanged" />
-                                                        <Binding Path="IsSelected"
-                                                                 RelativeSource="{RelativeSource AncestorType=ListBoxItem}" />
-                                                    </MultiBinding>
-                                                </Border.Background>
-                                                <!-- Editor template resolved from the view's DataTemplates
-                                                     (TransposedCellTemplateFactory) by cell-VM kind. -->
-                                                <ContentControl Content="{Binding}"
-                                                                HorizontalContentAlignment="Stretch"
-                                                                VerticalContentAlignment="Center" />
-                                            </Border>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
+                                <!-- Hosts a pooled cell presenter (built once, rebound on recycle) so a
+                                     recycled column reuses its cell subtrees instead of rebuilding them.
+                                     The heavy cells live in the view-owned pool, outside this
+                                     rebuilt-on-recycle content (see TransposedColumnCellsHost). -->
+                                <transposed:TransposedColumnCellsHost />
                             </StackPanel>
                         </DataTemplate>
                     </ListBox.ItemTemplate>

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml.cs
@@ -5,7 +5,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 
 using ReactiveUI;
@@ -26,6 +25,7 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 	private const double FontSizeToColumnWidthFactor = 8;
 
 	private readonly TransposedStepColumnClassBinder _stepColumnClassBinder = new();
+	private readonly TransposedTextEditCoordinator _editCoordinator = new();
 	private readonly TransposedGridNavigator _gridNavigator;
 	private readonly TransposedGridSelectionController _gridSelectionController;
 	private (RecipeRowViewModel Row, string ColumnKey)? _pendingChangedCell;
@@ -37,18 +37,19 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 		_gridNavigator = new TransposedGridNavigator(StepListBox);
 		_gridSelectionController = new TransposedGridSelectionController(StepListBox);
 
-		// Cell templates and style resources must be in place before the first layout pass
-		// realizes containers, and WhenActivated only fires on Loaded (after that pass) — so
-		// this subscription lives on the constructor, keyed off the DataContext-driven
-		// ViewModel property.
+		// The cell-presenter pool and style resources must be in place before the first layout pass
+		// realizes containers (each container's host borrows a presenter from the pool), and
+		// WhenActivated only fires on Loaded (after that pass) — so this subscription lives on the
+		// constructor, keyed off the DataContext-driven ViewModel property.
 		this.WhenAnyValue(x => x.ViewModel)
 			.Subscribe(surface =>
 			{
-				InstallCellTemplates(surface);
 				if (surface is not null)
 				{
 					ApplyGridStyle(surface.GridStyle);
 				}
+
+				BuildColumnCellsPool(surface);
 			});
 
 		this.WhenActivated(disposables =>
@@ -108,6 +109,8 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 	}
 
 	public bool IsEditing => GetActiveEditor() is not null;
+
+	internal TransposedColumnCellsPool? ColumnCellsPool { get; private set; }
 
 	private void OnContainerPrepared(object? sender, ContainerPreparedEventArgs e)
 	{
@@ -220,10 +223,49 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 		// canonical's CellPointerPressed.
 		if (e.GetCurrentPoint(StepListBox).Properties.IsLeftButtonPressed)
 		{
-			_gridSelectionController.HandleCellSelectionPress(ViewModel, pressedCell, e);
+			if (_gridSelectionController.HandleCellSelectionPress(ViewModel, pressedCell, e))
+			{
+				TryEnterEditFromPointer(source, pressedCell, e);
+			}
+		}
+		else
+		{
+			// A right/middle press over a cell must not reach the ListBoxItem's native selection (which
+			// would collapse a multi-selection). The lazy display TextBlock does not swallow it the way the
+			// always-live editor once did, so consume it here. The context menu opens off ContextRequested,
+			// which is independent of the handled state of this press.
+			e.Handled = true;
 		}
 
 		ResolveChangedCellClickAway(pressedCell);
+	}
+
+	// Select-then-edit under the lazy display: the selection controller reports a fall-through only on a
+	// second press of the already-single-selected column. That press builds and focuses the cell's editor
+	// (a TextBox for property-text, a ComboBox with its dropdown opened for a combo). A read-only /
+	// inapplicable cell's display is non-hit-testable, so the press never resolves to its presenter and
+	// falls through to plain column selection.
+	private void TryEnterEditFromPointer(
+		Visual source,
+		ParameterCellViewModel pressedCell,
+		PointerPressedEventArgs e)
+	{
+		if (source.FindAncestorOfType<TransposedLazyCellPresenter>(includeSelf: true) is not { } presenter
+			|| !ReferenceEquals(presenter.DataContext, pressedCell))
+		{
+			return;
+		}
+
+		// A press inside the already-open editor must reach the live TextBox to reposition the caret, so
+		// leave it unhandled: only the entry press (a display not yet editing) is consumed. This is the
+		// tunnel phase, so a handled press never reaches the editor.
+		if (presenter.IsEditing)
+		{
+			return;
+		}
+
+		_editCoordinator.BeginEdit(presenter, initialText: null);
+		e.Handled = true;
 	}
 
 	// Click-away rule: a changed (orange) cell clears the moment any OTHER cell is pressed. This
@@ -265,41 +307,30 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 		TransposedCellTemplateFactory.CommitByDefocusing(editor);
 	}
 
-	// An always-live editor holding keyboard focus counts as editing (there is no DataGrid edit
-	// lifecycle). ComboBox is resolved through the logical tree so an open dropdown (focus inside
-	// the popup's own visual root) still counts.
+	// Editing is defined off the coordinator, which owns the one active lazy edit for both cell kinds (the
+	// heavy editor exists only while editing). A focused display visual is NOT editing, so arrow-navigating
+	// onto a cell leaves IsEditing false and the step-level hotkeys stay live. A combo whose dropdown is
+	// open still counts (the coordinator holds it as editing until the dropdown closes and focus leaves).
 	private Control? GetActiveEditor()
 	{
-		if (TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement() is not Control focused)
-		{
-			return null;
-		}
-
-		var editor = focused.FindAncestorOfType<TextBox>(includeSelf: true) as Control
-			?? focused.FindLogicalAncestorOfType<ComboBox>(includeSelf: true);
-		if (editor is null)
-		{
-			return null;
-		}
-
-		return ReferenceEquals(editor.FindLogicalAncestorOfType<TransposedRecipeGridView>(), this)
-			? editor
-			: null;
+		return _editCoordinator.ActiveEditor;
 	}
 
-	private void InstallCellTemplates(TransposedRecipeGridSurface? surface)
+	// A fresh pool per surface: the singleton view is rebound to a new surface on a config swap, whose
+	// descriptor set (and thus the built cell subtrees) differ, so presenters must not carry across.
+	// Hosts return their borrowed presenter to the pool that lent it, so the stale pool drains to GC.
+	private void BuildColumnCellsPool(TransposedRecipeGridSurface? surface)
 	{
-		DataTemplates.Clear();
+		// The prior surface's pooled presenters (and their editors) are discarded with the pool, so the
+		// coordinator must forget any edit it was tracking before the new pool's slots come alive.
+		_editCoordinator.Reset();
 
-		if (surface is null)
-		{
-			return;
-		}
-
-		foreach (var template in new TransposedCellTemplateFactory(surface).CreateTemplates())
-		{
-			DataTemplates.Add(template);
-		}
+		ColumnCellsPool = surface is null
+			? null
+			: new TransposedColumnCellsPool(
+				surface.ParameterDescriptors,
+				new TransposedCellTemplateFactory(surface, _editCoordinator),
+				surface.GridStyle.RowHeight);
 	}
 
 	// The step-number header cell is the transposed analog of canonical's step-number cells (cell

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedTextCellPresenter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedTextCellPresenter.cs
@@ -1,0 +1,73 @@
+﻿using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Lazy display/editor slot for a property-text cell. Renders a lightweight display TextBlock by default
+// and builds the full TextBox editor only when the edit coordinator enters edit here, releasing it back
+// to the display on blur/commit/recycle. This removes the always-live TextBox weight (~34 per wide
+// column) from the fresh-container build and the resident visual tree while preserving click-and-type and
+// keyboard-driven edit entry. See TransposedLazyCellPresenter for the shared machinery.
+internal sealed class TransposedTextCellPresenter : TransposedLazyCellPresenter
+{
+	public TransposedTextCellPresenter(
+		TransposedTextEditCoordinator coordinator,
+		Control display,
+		Func<Control> editorBuilder)
+		: base(coordinator, display, editorBuilder)
+	{
+	}
+
+	// Applies the initial text (see the coordinator's BeginEdit for the null / "" / seed contract): null
+	// selects the whole value (F2 / pointer entry) so typing replaces it; "" clears it so the paired
+	// TextInput of a printable keystroke types fresh; a non-empty value seeds it directly.
+	protected override void OnEnteredEdit(Control editor, string? initialText)
+	{
+		if (editor is not TextBox textBox)
+		{
+			return;
+		}
+
+		if (initialText is null)
+		{
+			textBox.SelectAll();
+			return;
+		}
+
+		textBox.Text = initialText;
+		textBox.CaretIndex = initialText.Length;
+	}
+
+	protected override void CommitEditorContent(Control editor)
+	{
+		if (editor is TextBox textBox)
+		{
+			TransposedCellTemplateFactory.CommitEditor(textBox);
+		}
+	}
+
+	// Enter edit and clear the cell so the character delivered by the paired TextInput (a separate raw
+	// event that lands on the now-focused editor) types fresh — replace semantics, matching the canonical
+	// grid. No seed here, so the char is neither dropped nor doubled.
+	protected override void OnPrintableKeyDown(KeyEventArgs e)
+	{
+		if (IsPrintable(e.KeySymbol, e.KeyModifiers))
+		{
+			BeginEdit(initialText: string.Empty);
+			e.Handled = true;
+		}
+	}
+
+	// A TextInput that reaches the display without a preceding printable KeyDown carries the only copy of
+	// the character, so seed the editor with it directly.
+	protected override void OnDisplayTextInputCore(TextInputEventArgs e)
+	{
+		if (!IsPrintable(e.Text, KeyModifiers.None))
+		{
+			return;
+		}
+
+		BeginEdit(initialText: e.Text);
+		e.Handled = true;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedTextEditCoordinator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedTextEditCoordinator.cs
@@ -1,0 +1,55 @@
+﻿using Avalonia.Controls;
+
+namespace SemiStep.UI.RecipeGrid.Transposed;
+
+// Owns THE ONE active lazy edit for the transposed surface across both cell kinds. Property-text and
+// ComboBox cells render a lightweight display by default (TransposedLazyCellPresenter subclasses); the
+// heavy TextBox / ComboBox editor is built only when this coordinator enters edit on a cell, and released
+// back to the display on exit. A single active edit gives one place to reset on cell change, on blur, and
+// before a pooled presenter is recycled, and one definition of "editing" for the view's exit gating.
+internal sealed class TransposedTextEditCoordinator
+{
+	private TransposedLazyCellPresenter? _active;
+
+	// The live editor of the current edit (a TextBox or a ComboBox), or null when no cell is being edited.
+	// A focused display visual is NOT editing; only a built-and-editing presenter counts.
+	public Control? ActiveEditor => _active is { IsEditing: true } presenter ? presenter.Editor : null;
+
+	// Enters edit on a cell: swaps its display for the editor, focuses it, and applies the entry state
+	// (see the subclass OnEnteredEdit). initialText is meaningful only to the text cell; the combo ignores
+	// it. Focusing the new editor blurs any previous one, which self-exits.
+	public void BeginEdit(TransposedLazyCellPresenter presenter, string? initialText)
+	{
+		if (!presenter.CanEnterEdit)
+		{
+			return;
+		}
+
+		if (ReferenceEquals(_active, presenter) && presenter.IsEditing)
+		{
+			presenter.FocusEditor();
+			return;
+		}
+
+		_active = presenter;
+		presenter.EnterEdit(initialText);
+	}
+
+	// Called by a presenter whose editor lost focus (blur / commit / recycle). Clears the active slot only
+	// when it is still the one that ended, so a focus MOVE into a new edit (which blurs the old one after
+	// _active has already advanced) does not wipe the newly active edit.
+	public void NotifyEditEnded(TransposedLazyCellPresenter presenter)
+	{
+		if (ReferenceEquals(_active, presenter))
+		{
+			_active = null;
+		}
+	}
+
+	// Drops the active edit reference without touching visuals; used when the view is rebound to a new
+	// surface and the pooled presenters (and their editors) are discarded.
+	public void Reset()
+	{
+		_active = null;
+	}
+}


### PR DESCRIPTION
Round 2 of the transposed grid perf work: reuse column cell subtrees on recycle.

- Rebind rather than rebuild transposed column cells when a virtualized container is recycled (`_slotsBuilt` guard makes the pool effective)
- Lazy display/editor swap for text and combo cells so idle cells render as lightweight TextBlocks
- Allocation probe extended with a wide-config viewport-jump scenario

Keeps per-realized-column allocation bounded. Stacked on top of the allocation-reduction PR — **base is `transposed-grid-allocation-reduction`**; merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
