### PR TITLE
fix: source transposed cell selection from the presenter, forward Avalonia diagnostics to Serilog

### DIFF
--- a/Docs/architecture/recipe-grid-surface.md
+++ b/Docs/architecture/recipe-grid-surface.md
@@ -266,7 +266,15 @@ same recipe and churned gen0 on every mutation. The reductions land in three pla
   This replaces the descendant-selector background rules in `TransposedGridStyles.axaml`, avoiding
   the per-cell style-activator / dynamic-resource machinery those rules multiplied. The
   `TextElement.Foreground` setters stay as style setters (background stripped out), so foreground
-  precedence is unchanged.
+  precedence is unchanged. The `IsSelected` leg is sourced from the presenter's own
+  `TransposedColumnCellsPresenter.IsColumnSelected` (a `DirectProperty`, bound `Source = this`),
+  which `TransposedColumnCellsHost` keeps in sync with the container `ListBoxItem.IsSelected`
+  imperatively (one held subscription, resolved on attach, disposed-before-resubscribe on recycle,
+  reset to `false` on release). It is deliberately NOT a `RelativeSource FindAncestor ListBoxItem`
+  lookup: a pooled presenter is transiently off-tree (detached from any `ListBoxItem`), so that
+  ancestor leg logged ~1155 "Ancestor not found" binding errors on a short scroll. The presenter
+  re-announces the leg in `OnAttachedToVisualTree` so the background converter re-evaluates once the
+  slot `Border` can reach the palette resources.
 - **Lighter cell VMs.** Transposed cell view models are plain `INotifyPropertyChanged`, not
   `ReactiveObject` (nothing observes a cell VM reactively); `StepColumnViewModel.Cells` materialize
   lazily, so a column never scrolled to or keyboard-traversed never builds its cell VMs; and the
@@ -336,3 +344,26 @@ The grid's context menu lives on the `Panel` wrapping `RecipeGridHost` in `MainW
 because its commands bind to `MainWindowViewModel`. Right-clicks over grid rows bubble
 `ContextRequested` out of the DataGrid unhandled; a headless test in `RecipeGridHostTests`
 pins this.
+
+## Framework diagnostics logging
+
+Avalonia framework diagnostics (binding errors, layout warnings, and the rest) are forwarded into
+the app's Serilog pipeline by a custom `Avalonia.Logging.ILogSink`, `AvaloniaSerilogSink`, installed
+via `LogToSerilog()` in `BuildAvaloniaApp` (`App.axaml.cs`) in place of `LogToTrace`. `LogToTrace`
+routed diagnostics to `System.Diagnostics.Trace`, where under a debugger each write is a synchronous
+`OutputDebugString`; a binding-error storm on the UI thread then froze the grid under F5 while
+Release stayed smooth. The Serilog sink neutralizes that freeze mechanism and unifies the two log
+channels.
+
+The sink runs at minimum `Warning`, across all `LogArea`s, with a per-`(area + template)` throttle
+(first 20 in full, then every 500th carrying the running count) so a repeating template cannot flood
+the file. It forwards the template and args structured (not pre-formatted) under a
+`SourceContext` of `"Avalonia.<area>"`, mapping the Avalonia log level to the Serilog level by an
+explicit switch.
+
+A healthy build logs zero binding errors. That invariant is enforced in headless tests by
+`BindingErrorGuard` (`SemiStep.Tests/UI/Helpers/BindingErrorGuard.cs`), an `IDisposable` that
+installs a collecting `ILogSink` for the duration of a test, records `LogArea.Binding` events, and
+restores the previous sink on dispose. `TransposedSelectionBindingTests.ScrollSweepAndSelect_LogsZeroBindingErrors`
+wraps a transposed scroll start→end→start plus a column select in the guard and asserts zero binding
+errors (down from ~1155 before the presenter-sourced selection fix above).

--- a/Docs/plans/completed/20260715-transposed-binding-fix-and-logging.md
+++ b/Docs/plans/completed/20260715-transposed-binding-fix-and-logging.md
@@ -1,0 +1,304 @@
+# Transposed Grid Binding Fix, Serilog Logging, and Comment Cleanup
+
+## Overview
+
+Four related changes, driven by a fully-diagnosed defect. During development the transposed recipe grid
+"froze" only under the debugger (F5); Release and Debug-without-debugger (Ctrl+F5) are both smooth. The
+cause is a fragile binding that logs ~1155 errors on a short scroll, routed through Avalonia's
+`.LogToTrace()` to `System.Diagnostics.Trace`. In production (no trace listener) those go nowhere and cost
+nothing — hence no user-facing problem. Under the debugger each write is a synchronous `OutputDebugString`
+to Debug Output (~1 ms), so the storm freezes the UI thread. This is **not** a production performance fix;
+it fixes a real latent binding bug, unifies the logging channel, adds a CI guard against this whole bug
+class, and clears accumulated comment noise.
+
+Root cause (verified): the transposed cell-background `MultiBinding` reads `ListBoxItem.IsSelected` via
+`RelativeSource FindAncestor ListBoxItem` (`TransposedColumnCellsPresenter.cs`, the 7th leg in
+`BuildCellSlot`). Under virtualization/pool recycling the cell `Border` is transiently not under a
+`ListBoxItem` (pooled/detached), so Avalonia logs `[Binding] '(unknown)' to
+'$visualParent[ListBoxItem].IsSelected' : 'Ancestor not found.'`. Long-standing (present since the first
+build; the round-3 pool amplified the frequency — it is not a round-3 regression).
+
+The four parts (numbered in task/execution order):
+1. **Serilog logging sink** — replace `.LogToTrace()` with a custom `Avalonia.Logging.ILogSink` that
+   forwards to Serilog (structured, Warning, all areas, per-template throttle). Neutralizes the
+   debugger-freeze mechanism for any future binding storm and unifies the two log channels.
+2. **CI guard** — a headless test helper that fails on `LogArea.Binding` events, plus a transposed
+   scroll+select test asserting zero binding errors. Proves the fix and blocks regressions of this class.
+3. **Fix the binding** — source the selection state from the presenter itself (which builds the cell
+   slot), bound directly with `Source = this`, and keep it in sync with the container `ListBoxItem`
+   imperatively from the host. Zero "ancestor not found", and no tree traversal at all.
+4. **Comment cleanup** — apply the `dev:comment-hater` audit (41 DELETE, 19 SHORTEN, 2 stale-wording
+   fixes, 37 KEEP) across the transposed grid; the design rationale already lives in
+   `Docs/architecture/recipe-grid-surface.md`, so essays are deleted, not relocated.
+
+## Context (from discovery)
+
+- Files/components involved:
+  - `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPresenter.cs` — `BuildCellSlot`
+    builds the cell `Border` + background `MultiBinding`; the fragile `IsSelected` leg is here (~line
+    117-136). Presenters are pooled (`TransposedColumnCellsPool`) and hosted by
+    `TransposedColumnCellsHost`; cells are always children of the presenter, even when the presenter is
+    detached from the top level.
+  - `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsHost.cs` — the seam inside the
+    `ListBoxItem`: `OnAttachedToVisualTree` / `OnDetachedFromVisualTree` / `AcquireAndBind` /
+    `ReleasePresenter`. Knows how to resolve the container `ListBoxItem`.
+  - `SemiStep/SemiStep.UI/App.axaml.cs:73` — `.LogToTrace()` in `BuildAvaloniaApp()`.
+  - `SemiStep/SemiStep.UI/Program.cs` — Serilog bootstrap; `Log.Logger` is set before `App.Run`, so the
+    Avalonia sink can read the static `Serilog.Log` lazily and startup ordering is safe.
+  - Test harness: `SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs`, `TransposedVirtualizationTests.cs`,
+    selection-controller tests.
+  - `Docs/architecture/recipe-grid-surface.md` — already documents the pool, lazy swap,
+    commit-before-rebind, select-then-edit, arrow semantics, stale-guard, background converter.
+- Verified facts: Release and Debug-no-debugger are smooth; Avalonia binding errors are LOGGED, not
+  thrown (exception breakpoints never fire); `.LogToTrace()` -> Trace is the routing; ~1155 errors per
+  short scroll from the single fragile leg.
+- Swept: this `RelativeSource FindAncestor ListBoxItem` leg is the ONLY declarative ancestor binding in
+  the whole UI project (zero `RelativeSource` usages in any `.axaml`); the imperative `FindAncestorOfType`
+  lookups (`TransposedGridNavigator.cs:64`, `TransposedRecipeGridView.axaml.cs:253`,
+  `TransposedCellTemplateFactory.cs:158`, `TransposedColumnCellsHost.cs:21`) are one-shot and do not log.
+  No wider sweep needed.
+- Dependencies: Avalonia 12 `Avalonia.Logging` (`ILogSink`, `Logger.Sink`, `LogArea`,
+  `LogEventLevel`); Serilog + Microsoft.Extensions.Logging; `[AvaloniaFact]` headless tests.
+
+## Development Approach
+
+- **testing approach**: Regular (code-first), mandatory tests per task. The binding-error guard is itself
+  the key regression test for this whole effort.
+- complete each task fully before the next; small focused changes; keep the full suite green throughout.
+- **CRITICAL: every task adds/updates tests and they must pass before the next task.**
+- **CRITICAL: keep every task green** — the guard helper (Task 2) ships WITHOUT a failing assertion; the
+  zero-binding-errors assertion test lands WITH the fix (Task 3) so it is green when committed.
+- **CRITICAL: update this plan file when scope changes.**
+- Comments-only cleanup (Task 4) must not change behavior; run last so line numbers have settled.
+
+## Testing Strategy
+
+- **unit tests**: the Serilog sink (throttle full-then-sample, level mapping, structured template
+  forwarding) via a captured Serilog test sink.
+- **headless [AvaloniaFact] tests**: selection background still paints after the binding fix; recycled
+  column shows correct selection; transposed scroll-sweep + select logs ZERO `LogArea.Binding` events
+  (the guard). Keep `TransposedVirtualizationTests` / selection tests green.
+- **guard infrastructure**: a `BindingErrorGuard` that installs a collecting `ILogSink` for the duration
+  of a test and restores the prior sink; handle static-`Logger.Sink` scoping and test parallelization
+  (serialize or scope so concurrent tests do not race the global sink).
+- **measurement gate (not CI)**: none new; this is a correctness + hygiene change, not a perf change.
+
+## Progress Tracking
+
+- mark completed items `[x]` immediately; add discovered work with `➕`, blockers with `⚠️`.
+- record the guard's before/after binding-error count (should go from ~1155 on a scroll to 0 after Task 3).
+- **Task 3 binding-error count:** before ~1155 (`Ancestor not found` on a short transposed scroll, from the
+  `RelativeSource FindAncestor ListBoxItem` leg) -> after **0**. `TransposedSelectionBindingTests.ScrollSweepAndSelect_LogsZeroBindingErrors`
+  wraps a scroll start->end->start plus a column select in `BindingErrorGuard` and asserts zero `LogArea.Binding` events.
+
+## Solution Overview
+
+- **Selection sourced from the presenter (Task 3)**: add `IsColumnSelected` (an Avalonia
+  `StyledProperty<bool>` or `DirectProperty<TransposedColumnCellsPresenter,bool>`) to the presenter.
+  `BuildCellSlot` is an instance method on the presenter, so the cell's selection leg binds DIRECTLY to
+  it: `new Binding(nameof(IsColumnSelected)) { Source = this }` — no `RelativeSource`, no tree traversal,
+  cannot fail off-tree by construction. The host keeps `presenter.IsColumnSelected` in sync with the
+  container `ListBoxItem.IsSelected` imperatively: one held `IDisposable` subscription, resolved when the
+  container is available, disposed-before-resubscribe across recycle, tolerant of a null container
+  pre-attach (re-resolve on attach), and reset to `false` in `ReleasePresenter` so a pooled presenter
+  never carries stale selection into its next column. Selection source of truth stays the `ListBoxItem`
+  (no divergence, no VM/surface changes).
+- **Serilog sink (Task 1)**: `AvaloniaSerilogSink : ILogSink` forwards `(level, area, source, template,
+  args)` to `Serilog.Log.ForContext("SourceContext","Avalonia."+area).Write(mapped, template, args)` —
+  structured, not pre-formatted. Cheap on the hot path: `IsEnabled = level >= min` gate first, throttle
+  before any Serilog call (the throttle key concat + `ConcurrentDictionary` update do allocate — do not
+  claim "allocation-free"). Per-(area+template) throttle via `ConcurrentDictionary<string,int>`: first 20
+  in full, then every 500th with the running count. Note Avalonia funnels most binding errors through one
+  shared template, so this throttle merges distinct binding failures under one counter — the
+  `BindingErrorGuard` CI test, not the log, is the regression net (which is why min-Warning/all-areas is
+  acceptable). `LogToSerilog(this AppBuilder, level=Warning)` sets `Logger.Sink` and replaces `LogToTrace`.
+- **Guard (Task 2)**: `BindingErrorGuard` installs a collecting `ILogSink` (records `LogArea.Binding`
+  events, restores the previous sink on dispose) for use inside headless tests.
+- **Comment cleanup (Task 4)**: re-run `dev:comment-hater` on the transposed scope (line numbers shift
+  after Tasks 1-3), apply DELETE/SHORTEN, fix the 2 stale comments, keep the load-bearing set.
+
+## Technical Details
+
+- The two `LogEventLevel` enums (Avalonia vs Serilog) collide by name — alias both and map with an
+  explicit `switch`, never a cast.
+- Avalonia logs on the thread that hit the issue (usually the UI thread); the sink must stay cheap on the
+  hot path (`IsEnabled` gate first, throttle before any Serilog call).
+- `Logger.Sink` is a single global slot (last assignment wins) — set it once in `BuildAvaloniaApp`; in
+  tests set/restore it around the guarded interaction.
+- Do NOT add `Serilog.Sinks.Async` or any package; the throttle plus the buffered file sink are enough.
+- Selection behavior must be pixel-identical: the selected column's cells paint the selected background
+  exactly as before; read-only/inapplicable/changed/execution states unaffected.
+- No new binding may reintroduce a visual-ancestor lookup that can fail off-tree.
+
+## What Goes Where
+
+- **Implementation Steps** (checkboxes): sink, guard, binding fix, comment cleanup, verify, docs — all in
+  this repo.
+- **Post-Completion** (no checkboxes): manual confirmation that F5 debugging no longer freezes on a
+  transposed scroll at ~200-1000 steps; decision to keep or push the branch.
+
+## Implementation Steps
+
+### Task 1: Forward Avalonia diagnostics to Serilog (replace LogToTrace)
+
+**Files:**
+- Create: `SemiStep/SemiStep.UI/Logging/AvaloniaSerilogSink.cs`
+- Create: `SemiStep/SemiStep.UI/Logging/SerilogLoggingExtensions.cs`
+- Modify: `SemiStep/SemiStep.UI/App.axaml.cs`
+- Create: `SemiStep/SemiStep.Tests/UI/Logging/AvaloniaSerilogSinkTests.cs`
+
+- [x] Implement `AvaloniaSerilogSink : Avalonia.Logging.ILogSink` (ctor takes minimum
+      `Avalonia.Logging.LogEventLevel`): `IsEnabled` = level >= min; both `Log` overloads forward the
+      template + args structured to `Serilog.Log.ForContext("SourceContext","Avalonia."+area)`, level
+      mapped by explicit switch (alias the two `LogEventLevel` enums).
+- [x] Add the per-(area+template) throttle: `ConcurrentDictionary<string,int>` counter, first 20 in full,
+      then every 500th carrying the running `Occurrence` count; below-threshold repeats are dropped.
+- [x] Add `SerilogLoggingExtensions.LogToSerilog(this AppBuilder, LogEventLevel level = Warning)` that
+      sets `Avalonia.Logging.Logger.Sink = new AvaloniaSerilogSink(level)`; replace `.LogToTrace()` at
+      `App.axaml.cs:73` with `.LogToSerilog()`. Policy: min Warning, all areas, no `#if`.
+- [x] Write tests: feeding N identical (area,template) events yields full-then-sampled output with a
+      correct running count; distinct templates are throttled independently; each Avalonia level maps to
+      the expected Serilog level; template+args reach Serilog structured (assert via a captured Serilog
+      sink / test logger, not string matching).
+- [x] Build + run tests - must pass before Task 2.
+
+### Task 2: Binding-error test guard (collecting ILogSink)
+
+**Files:**
+- Create: `SemiStep/SemiStep.Tests/UI/Helpers/BindingErrorGuard.cs`
+- Create: `SemiStep/SemiStep.Tests/UI/Helpers/BindingErrorGuardTests.cs`
+
+- [x] Implement `BindingErrorGuard` (IDisposable): on construction install a collecting
+      `Avalonia.Logging.ILogSink` that records events (filterable to `LogArea.Binding`), remembering and
+      restoring the previous `Logger.Sink` on dispose. Expose the captured binding-error messages/count
+      and an `AssertNoBindingErrors()` helper.
+- [x] Restore safely with try/finally (dispose): test parallelization is ALREADY disabled assembly-wide
+      (`SemiStep.Tests/AssemblyAttributes.cs` has `[assembly: CollectionBehavior(DisableTestParallelization
+      = true)]`) and `TestAppBuilder.cs` installs no sink, so the prior `Logger.Sink` is null in tests —
+      the guard just needs to capture and restore the previous sink (including null) on dispose. Do NOT add
+      an xUnit collection for this; it is not needed.
+- [x] Write tests: the guard captures a deliberately-induced binding error (e.g. a throwaway control with
+      a binding to a missing ancestor) and reports it; reports zero + restores the previous sink when no
+      error occurs.
+- [x] Build + run tests - must pass before Task 3.
+
+### Task 3: Fix the selection binding (source it from the presenter)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPresenter.cs`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsHost.cs`
+- Create/Modify: a transposed selection + binding-error test (e.g.
+  `SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedSelectionBindingTests.cs`)
+
+- [x] Add `IsColumnSelected` (Avalonia `StyledProperty<bool>` or `DirectProperty`) to
+      `TransposedColumnCellsPresenter`. Used a `DirectProperty<TransposedColumnCellsPresenter, bool>`.
+- [x] Change the selection leg in `BuildCellSlot` from `Binding(IsSelected){RelativeSource FindAncestor
+      ListBoxItem}` to `new Binding(nameof(IsColumnSelected)) { Source = this }` (direct source, no
+      `RelativeSource`, no ancestor lookup); keep the other 6 legs and the converter unchanged.
+- [x] In `TransposedColumnCellsHost`, keep `presenter.IsColumnSelected` in sync with the container
+      `ListBoxItem.IsSelected`: hold ONE `IDisposable` subscription; resolve the `ListBoxItem` when
+      available (tolerate a null container pre-attach and re-resolve on attach); dispose-before-resubscribe
+      across recycle so no double-subscription; push the current value on bind; and reset
+      `presenter.IsColumnSelected = false` in `ReleasePresenter` so a released presenter carries no stale
+      selection into its next acquisition. `AcquireAndBind` runs from `OnAttachedToVisualTree`,
+      `OnDataContextChanged`, and in-place recycle — the subscription logic must be idempotent across all
+      three.
+- [x] Write tests: selecting a column paints its cells' selected background; DESELECTING reverts it
+      (proves the imperative sync propagates change notifications, not just the initial push); a presenter
+      recycled out of a selected column into an unselected one paints unselected; using `BindingErrorGuard`,
+      a transposed scroll start->end->start plus a column select logs ZERO `LogArea.Binding` events (record
+      the before number ~1155 in the plan for contrast). The parity oracle is
+      `TransposedCellStyleRenderTests` (it already asserts `Border.Background` same-instance vs
+      `CellPaletteInstaller.SelectionBackgroundBrushKey` / the changed+selected brush) — those cases must
+      stay green unmodified. New file: `TransposedSelectionBindingTests.cs` (4 `[AvaloniaFact]`).
+- [x] Keep `TransposedVirtualizationTests` and selection-controller tests green. Build + run full suite -
+      must pass before Task 4. Full suite: 1370 passed / 2 skipped / 0 failed (baseline 1366 + 4 new).
+
+➕ **Discovered subtlety (`OnAttachedToVisualTree` re-announce):** the old `RelativeSource FindAncestor`
+leg did double duty — it re-emitted when its `ListBoxItem` ancestor was found on attach, which re-ran the
+background converter *after* the slot `Border` could reach the palette resources. A pooled presenter's
+legs otherwise settle while detached, so the converter runs once against an unreachable resource host and
+yields no brush (idle cells rendered `null`, breaking the parity oracle). Fix: `TransposedColumnCellsPresenter.OnAttachedToVisualTree`
+re-announces the `IsColumnSelected` leg (`RaisePropertyChanged(IsColumnSelectedProperty, !_isColumnSelected, _isColumnSelected)`)
+so the converter re-evaluates once the `Border` is attached. Isolated probe confirmed the `Source = this`
+leg does emit its initial value; the failure was purely resource-host reachability at first evaluation.
+
+### Task 4: Apply the comment-hater cleanup across the transposed grid
+
+**Files:**
+- Modify: all `.cs` under `SemiStep/SemiStep.UI/RecipeGrid/Transposed/`
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs`,
+  `SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs`
+
+- [x] Re-run `dev:comment-hater` on the scope above (line numbers have shifted after Tasks 1-3) to get a
+      current ranked kill-list.
+- [x] DELETE the class-header design essays and next-line restatements whose content is already in
+      `Docs/architecture/recipe-grid-surface.md` (do not relocate — it would duplicate the doc).
+- [x] SHORTEN the verbose-but-real comments to their one-line load-bearing "why"; KEEP the load-bearing
+      set (Avalonia gotchas, stale-guard decode, ordering constraints, tri-state decodes, recycle hazards)
+      untouched.
+- [x] Fix the 2 stale-wording comments that no longer match the lazy-editor code: "always-live editors"
+      (`TransposedRecipeGridView.axaml.cs`, ~lines 64 and 236) and "FontSize explicit"
+      (`TransposedCellTemplateFactory.cs`, ~line 166 — code calls `ApplyCellFont`, no explicit FontSize).
+- [x] Comments-only, no behavior change: build + run full suite (must stay green) and
+      `dotnet format --verify-no-changes` clean before Task 5.
+
+### Task 5: Verify acceptance criteria
+
+- [x] Confirm the guard test reports zero `LogArea.Binding` events on the transposed scroll+select
+      (the core acceptance signal); record the before (~1155) / after (0) in Progress Tracking.
+      Verified: `TransposedSelectionBindingTests` 4/4 passed (incl. `ScrollSweepAndSelect_LogsZeroBindingErrors`);
+      before ~1155 / after 0 already recorded in Progress Tracking above.
+- [x] Confirm selection-background parity: `TransposedCellStyleRenderTests` (the selected-column and
+      changed+selected `Border.Background` same-instance cases) stays green unmodified; no regression in
+      `TransposedVirtualizationTests`, selection, editing, navigation tests.
+      Verified: `TransposedCellStyleRenderTests` 7/7 passed unmodified; `Area=RecipeGrid` 361 passed / 1 skipped / 0 failed.
+- [x] Confirm the Serilog sink is wired (`.LogToSerilog()` replaces `.LogToTrace()`), min Warning, all
+      areas; the throttle is exercised by the sink unit test.
+      Verified: `App.axaml.cs:74` calls `.LogToSerilog()` (default `LogEventLevel.Warning`, no area filter in `IsEnabled`);
+      no `.LogToTrace()` remains in code (only plan-doc prose); `AvaloniaSerilogSinkTests` 9/9 passed.
+- [x] Run the full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`.
+      Verified: 1370 passed / 2 skipped / 0 failed (matches the Task 4 baseline).
+- [x] Run `dotnet format SemiStep/SemiStep.slnx` (pre-commit hook enforces it).
+      Verified: `dotnet format "SemiStep\SemiStep.slnx" --verify-no-changes` exits 0 with no output (clean).
+- [x] Decide the fate of the uncommitted investigation artifact
+      `SemiStep/SemiStep.Tests/Performance/TransposedViewLatencyProbe.cs`: recommend REMOVE (it measures a
+      forced synchronous worst-case that did not reflect production and misled; the allocation probe
+      stays). Delete it (or, if kept, relabel clearly as a manual latency probe) and note the choice.
+      Verified REMOVED: file absent on disk and not in `git ls-files` (only `CoreAllocationProbe.cs` and
+      `TransposedViewAllocationProbe.cs` remain tracked under `Performance/`).
+
+### Task 6: Update documentation
+
+- [x] Update `Docs/architecture/recipe-grid-surface.md`: note the logging channel (Avalonia diagnostics
+      forwarded to Serilog via `AvaloniaSerilogSink`, replacing `LogToTrace`) and that the cell selection
+      state is sourced from `TransposedColumnCellsPresenter.IsColumnSelected` (fed from the container
+      `ListBoxItem`) rather than a `RelativeSource` ancestor lookup.
+      Done: added a "Framework diagnostics logging" section (sink, throttle, `BindingErrorGuard`, zero
+      binding errors invariant) and expanded the "Cell background via a converter" bullet with the
+      presenter-sourced `IsColumnSelected` leg.
+- [x] Update `CLAUDE.md` only if a durable convention emerged (e.g. "Avalonia diagnostics go through the
+      Serilog sink; a healthy build logs zero binding errors, enforced by BindingErrorGuard"). Keep it to
+      a short line; skip if it does not rise to a durable cross-cutting rule.
+      No new durable convention added to CLAUDE.md; it is the project overview file ("do not add specifics
+      here"), so this grid/logging fact was routed to recipe-grid-surface.md instead.
+- [x] Move this plan to `Docs/plans/completed/`.
+      [x] harness moves the plan after finalize (not moved here).
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems - no checkboxes, informational only*
+
+**Manual verification**:
+- Run the app under the debugger (F5), RIE / transposed, at ~200-1000 steps, and confirm scrolling no
+  longer freezes and the Debug Output no longer floods with `[Binding] ... Ancestor not found`.
+- Confirm the app's Serilog file now carries any Avalonia Warning-level diagnostics (throttled), and that
+  a normal session logs zero binding errors.
+
+**Branch / PR shape**:
+- This runs on `transposed-grid-realize-cost-reduction` (round-3, unpushed) or a fresh branch off it —
+  decide at exec time. Round-3 and this change are both unpushed.
+- Commit per task (clean per-task commits). Intended PR split is three logical changes: (a) the logging
+  sink + binding-error guard, (b) the binding fix, (c) the comment cleanup — either as one PR with clean
+  per-task commits or three stacked PRs, named explicitly so the large comment-churn diff does not obscure
+  the fix review. Comment cleanup (Task 4) stays last regardless.

--- a/SemiStep/SemiStep.Tests/UI/Helpers/BindingErrorGuard.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/BindingErrorGuard.cs
@@ -1,0 +1,115 @@
+﻿using System.Text;
+
+using Avalonia.Logging;
+
+using Xunit.Sdk;
+
+namespace SemiStep.Tests.UI.Helpers;
+
+// Installs a collecting Avalonia log sink for the lifetime of the scope and restores the previous
+// Logger.Sink (including null) on dispose, so a headless test can assert it produced zero binding
+// errors. Logger.Sink is a single global slot; assembly parallelization is disabled, so capture and
+// restore around the guarded interaction is enough to keep it from leaking between tests.
+public sealed class BindingErrorGuard : IDisposable
+{
+	private readonly ILogSink? _previousSink;
+	private readonly List<CapturedLogEvent> _events = new();
+	private bool _disposed;
+
+	public BindingErrorGuard()
+	{
+		_previousSink = Logger.Sink;
+		Logger.Sink = new CollectingSink(_events);
+	}
+
+	public IReadOnlyList<string> BindingErrors =>
+		_events.Where(static logEvent => logEvent.Area == LogArea.Binding)
+			.Select(static logEvent => logEvent.Message)
+			.ToList();
+
+	public int BindingErrorCount => BindingErrors.Count;
+
+	public void AssertNoBindingErrors()
+	{
+		var bindingErrors = BindingErrors;
+		if (bindingErrors.Count == 0)
+		{
+			return;
+		}
+
+		var details = string.Join(Environment.NewLine, bindingErrors.Select(static message => "  - " + message));
+		throw new XunitException(
+			$"Expected zero Avalonia binding errors, but {bindingErrors.Count} were recorded:{Environment.NewLine}{details}");
+	}
+
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		_disposed = true;
+		Logger.Sink = _previousSink;
+	}
+
+	private static string RenderMessage(string messageTemplate, object?[] propertyValues)
+	{
+		if (propertyValues.Length == 0)
+		{
+			return messageTemplate;
+		}
+
+		var builder = new StringBuilder(messageTemplate.Length);
+		var valueIndex = 0;
+		var position = 0;
+		while (position < messageTemplate.Length)
+		{
+			var character = messageTemplate[position];
+			if (character == '{')
+			{
+				var closing = messageTemplate.IndexOf('}', position);
+				if (closing > position)
+				{
+					var value = valueIndex < propertyValues.Length ? propertyValues[valueIndex] : null;
+					builder.Append(value?.ToString() ?? "null");
+					valueIndex++;
+					position = closing + 1;
+					continue;
+				}
+			}
+
+			builder.Append(character);
+			position++;
+		}
+
+		return builder.ToString();
+	}
+
+	public sealed record CapturedLogEvent(string Area, string Message);
+
+	private sealed class CollectingSink : ILogSink
+	{
+		private readonly List<CapturedLogEvent> _events;
+
+		public CollectingSink(List<CapturedLogEvent> events)
+		{
+			_events = events;
+		}
+
+		public bool IsEnabled(LogEventLevel level, string area)
+		{
+			return true;
+		}
+
+		public void Log(LogEventLevel level, string area, object? source, string messageTemplate)
+		{
+			Log(level, area, source, messageTemplate, Array.Empty<object?>());
+		}
+
+		public void Log(LogEventLevel level, string area, object? source, string messageTemplate, params object?[] propertyValues)
+		{
+			_events.Add(new CapturedLogEvent(area, RenderMessage(messageTemplate, propertyValues)));
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Helpers/BindingErrorGuardTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/BindingErrorGuardTests.cs
@@ -1,0 +1,100 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Logging;
+using Avalonia.Threading;
+
+using FluentAssertions;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace SemiStep.Tests.UI.Helpers;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Logging")]
+[Trait("Category", "Integration")]
+public sealed class BindingErrorGuardTests
+{
+	[AvaloniaFact]
+	public void CapturesBindingError_WhenAncestorLookupFails()
+	{
+		using var guard = new BindingErrorGuard();
+
+		var window = ShowControlWithMissingAncestorBinding();
+		try
+		{
+			guard.BindingErrorCount.Should().BeGreaterThanOrEqualTo(1);
+			guard.BindingErrors.Should().Contain(message => message.Contains("Ancestor not found"));
+
+			var assert = () => guard.AssertNoBindingErrors();
+			assert.Should().Throw<XunitException>();
+		}
+		finally
+		{
+			window.Close();
+		}
+	}
+
+	[AvaloniaFact]
+	public void CapturesZeroAndRestoresPreviousSink_WhenNoBindingFails()
+	{
+		var previousSink = Logger.Sink;
+
+		using (var guard = new BindingErrorGuard())
+		{
+			var window = ShowControlWithoutFailingBinding();
+			try
+			{
+				guard.BindingErrorCount.Should().Be(0);
+
+				var assert = () => guard.AssertNoBindingErrors();
+				assert.Should().NotThrow();
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		Logger.Sink.Should().BeSameAs(previousSink);
+	}
+
+	private static Window ShowControlWithMissingAncestorBinding()
+	{
+		var textBlock = new TextBlock();
+		textBlock.Bind(
+			TextBlock.TextProperty,
+			new Binding(nameof(ListBoxItem.IsSelected))
+			{
+				RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
+				{
+					AncestorType = typeof(ListBoxItem),
+				},
+			});
+
+		return ShowInWindow(new Border { Child = textBlock });
+	}
+
+	private static Window ShowControlWithoutFailingBinding()
+	{
+		var textBlock = new TextBlock { Text = "static" };
+		return ShowInWindow(new Border { Child = textBlock });
+	}
+
+	private static Window ShowInWindow(Control content)
+	{
+		var window = new Window
+		{
+			Width = 200,
+			Height = 200,
+			Content = content,
+		};
+
+		window.Show();
+		Dispatcher.UIThread.RunJobs();
+
+		return window;
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Logging/AvaloniaSerilogSinkTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Logging/AvaloniaSerilogSinkTests.cs
@@ -1,0 +1,138 @@
+﻿using FluentAssertions;
+
+using SemiStep.UI.Logging;
+
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+using Xunit;
+
+using AvaloniaLevel = Avalonia.Logging.LogEventLevel;
+
+namespace SemiStep.Tests.UI.Logging;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Logging")]
+[Trait("Category", "Unit")]
+public sealed class AvaloniaSerilogSinkTests
+{
+	[Fact]
+	public void IdenticalEvents_LogFullThenSampled_CarryingRunningCount()
+	{
+		var events = Capture(sink =>
+		{
+			for (var i = 0; i < 1000; i++)
+			{
+				sink.Log(AvaloniaLevel.Warning, "Binding", null, "Ancestor not found {Path}", "P");
+			}
+		});
+
+		// First 20 in full, then every 500th (occurrence 500 and 1000).
+		events.Should().HaveCount(22);
+		events.Take(20).Should().OnlyContain(e => !e.Properties.ContainsKey("Occurrence"));
+		OccurrenceOf(events[20]).Should().Be(500);
+		OccurrenceOf(events[21]).Should().Be(1000);
+	}
+
+	[Fact]
+	public void DistinctKeys_AreThrottledIndependently()
+	{
+		var events = Capture(sink =>
+		{
+			for (var i = 0; i < 21; i++)
+			{
+				sink.Log(AvaloniaLevel.Warning, "AreaA", null, "Same template {X}", i);
+				sink.Log(AvaloniaLevel.Warning, "AreaB", null, "Same template {X}", i);
+			}
+		});
+
+		// Each (area+template) key emits its own first 20; the 21st of each is dropped.
+		events.Should().HaveCount(40);
+		events.Count(e => Rendered(e, "SourceContext") == "Avalonia.AreaA").Should().Be(20);
+		events.Count(e => Rendered(e, "SourceContext") == "Avalonia.AreaB").Should().Be(20);
+	}
+
+	[Theory]
+	[InlineData(AvaloniaLevel.Verbose, LogEventLevel.Verbose)]
+	[InlineData(AvaloniaLevel.Debug, LogEventLevel.Debug)]
+	[InlineData(AvaloniaLevel.Information, LogEventLevel.Information)]
+	[InlineData(AvaloniaLevel.Warning, LogEventLevel.Warning)]
+	[InlineData(AvaloniaLevel.Error, LogEventLevel.Error)]
+	[InlineData(AvaloniaLevel.Fatal, LogEventLevel.Fatal)]
+	public void EachLevel_MapsToExpectedSerilogLevel(AvaloniaLevel avaloniaLevel, LogEventLevel expected)
+	{
+		var events = Capture(
+			sink => sink.Log(avaloniaLevel, "Layout", null, "message"),
+			minimumLevel: AvaloniaLevel.Verbose);
+
+		events.Should().ContainSingle();
+		events[0].Level.Should().Be(expected);
+	}
+
+	[Fact]
+	public void TemplateAndArgs_ReachSerilogStructured()
+	{
+		var events = Capture(sink =>
+			sink.Log(AvaloniaLevel.Warning, "Binding", null, "Value {Count} at {Name}", 42, "foo"));
+
+		events.Should().ContainSingle();
+		var logEvent = events[0];
+		logEvent.MessageTemplate.Text.Should().Be("Value {Count} at {Name}");
+		ScalarValueOf(logEvent, "Count").Should().Be(42);
+		ScalarValueOf(logEvent, "Name").Should().Be("foo");
+		ScalarValueOf(logEvent, "SourceContext").Should().Be("Avalonia.Binding");
+	}
+
+	private static IReadOnlyList<LogEvent> Capture(
+		Action<AvaloniaSerilogSink> feed,
+		AvaloniaLevel minimumLevel = AvaloniaLevel.Warning)
+	{
+		var capturingSink = new CapturingSink();
+		var logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(capturingSink)
+			.CreateLogger();
+
+		var previous = Log.Logger;
+		Log.Logger = logger;
+		try
+		{
+			feed(new AvaloniaSerilogSink(minimumLevel));
+		}
+		finally
+		{
+			Log.Logger = previous;
+			logger.Dispose();
+		}
+
+		return capturingSink.Events;
+	}
+
+	private static int OccurrenceOf(LogEvent logEvent)
+	{
+		return (int)((ScalarValue)logEvent.Properties["Occurrence"]).Value!;
+	}
+
+	private static object? ScalarValueOf(LogEvent logEvent, string property)
+	{
+		return ((ScalarValue)logEvent.Properties[property]).Value;
+	}
+
+	private static string? Rendered(LogEvent logEvent, string property)
+	{
+		return ScalarValueOf(logEvent, property) as string;
+	}
+
+	private sealed class CapturingSink : ILogEventSink
+	{
+		private readonly List<LogEvent> _events = new();
+
+		public IReadOnlyList<LogEvent> Events => _events;
+
+		public void Emit(LogEvent logEvent)
+		{
+			_events.Add(logEvent);
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedSelectionBindingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedSelectionBindingTests.cs
@@ -1,0 +1,252 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+using FluentAssertions;
+
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.RecipeGrid.Transposed;
+using SemiStep.UI.Styles;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid.Transposed;
+
+// Confirms the cell selection background is sourced from TransposedColumnCellsPresenter.IsColumnSelected
+// (fed imperatively from the container ListBoxItem) and no longer from a RelativeSource ancestor lookup:
+// selecting paints, deselecting reverts, a presenter recycled out of a selected column paints unselected,
+// and a scroll-sweep plus a select logs zero Avalonia binding errors (the ancestor-not-found storm is gone).
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public sealed class TransposedSelectionBindingTests : IAsyncLifetime
+{
+	private const int SeededStepCount = 40;
+	private const string CellClass = "transposed-cell";
+
+	private readonly UIFixture _fixture = new();
+	private TransposedRecipeGridSurface _surface = null!;
+	private Window? _window;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_fixture.SeedRecipe(SeededStepCount);
+
+		_surface = _fixture.CreateTransposedSurface();
+		_surface.Initialize();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		_window?.Close();
+		_surface.Dispose();
+		await _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void SelectedColumn_EditableCell_PaintsSelectionBackground()
+	{
+		var stepListBox = ShowView(1200);
+		var index = EditableApplicableIndex();
+
+		_surface.RequestSelection(0);
+		Dispatcher.UIThread.RunJobs();
+
+		var cells = FindCellBorders(stepListBox, 0);
+		cells[index].Background.Should().BeSameAs(Resource(CellPaletteInstaller.SelectionBackgroundBrushKey));
+	}
+
+	[AvaloniaFact]
+	public void DeselectingColumn_RevertsEditableCellBackground()
+	{
+		var stepListBox = ShowView(1200);
+		var index = EditableApplicableIndex();
+
+		_surface.RequestSelection(0);
+		Dispatcher.UIThread.RunJobs();
+
+		var cells = FindCellBorders(stepListBox, 0);
+		cells[index].Background.Should().BeSameAs(
+			Resource(CellPaletteInstaller.SelectionBackgroundBrushKey), "selecting the column paints its cells");
+
+		_surface.RequestSelection(null);
+		Dispatcher.UIThread.RunJobs();
+
+		cells[index].Background.Should().BeSameAs(
+			Resource(CellPaletteInstaller.GridBackgroundBrushKey),
+			"deselecting must revert the background, proving the imperative sync propagates change notifications");
+	}
+
+	[AvaloniaFact]
+	public void MultipleColumnsSelected_BothPaintSelectionBackground()
+	{
+		var stepListBox = ShowView(1200);
+		var index = EditableApplicableIndex(0, 1);
+		var selectionBrush = Resource(CellPaletteInstaller.SelectionBackgroundBrushKey);
+
+		stepListBox.SelectedItems!.Add(_surface.StepColumns[0]);
+		stepListBox.SelectedItems!.Add(_surface.StepColumns[1]);
+		Dispatcher.UIThread.RunJobs();
+
+		FindCellBorders(stepListBox, 0)[index].Background.Should().BeSameAs(
+			selectionBrush, "the first selected column paints its cells");
+		FindCellBorders(stepListBox, 1)[index].Background.Should().BeSameAs(
+			selectionBrush, "a second column selected simultaneously (SelectionMode=Multiple) paints its cells too");
+	}
+
+	[AvaloniaFact]
+	public void ContainerRecycledOutOfSelectedColumn_PaintsUnselected()
+	{
+		var stepListBox = ShowView(560);
+		var index = EditableApplicableIndex();
+		var selectionBrush = Resource(CellPaletteInstaller.SelectionBackgroundBrushKey);
+
+		_surface.RequestSelection(0);
+		Dispatcher.UIThread.RunJobs();
+
+		FindCellBorders(stepListBox, 0)[index].Background.Should().BeSameAs(
+			selectionBrush, "column 0 is selected before the scroll");
+
+		ScrollToHorizontalEnd(stepListBox);
+
+		// Proves pool recycling actually happened: a non-virtualizing layout would realize all columns and
+		// never reuse the selected column's released presenter, making the stale-carry check below vacuous.
+		RealizedContainerCount(stepListBox).Should().BeLessThan(
+			SeededStepCount / 2, "the far columns must be hosted by recycled containers, not freshly realized ones");
+
+		// The recycled containers now host far, unselected columns; no pooled presenter released from the
+		// selected column may carry its selection into the next column it is bound to.
+		var unselectedFarColumnsChecked = 0;
+		foreach (var container in stepListBox.GetRealizedContainers())
+		{
+			if (container is ListBoxItem { IsSelected: false } item)
+			{
+				FindCellBorders(item)[index].Background.Should().NotBeSameAs(
+					selectionBrush, "an unselected recycled column must not paint the selection brush");
+				unselectedFarColumnsChecked++;
+			}
+		}
+
+		unselectedFarColumnsChecked.Should().BeGreaterThan(
+			0, "the scroll must land on far, unselected columns hosted by reused presenters, else the stale-carry path is untested");
+
+		ScrollToHorizontalStart(stepListBox);
+
+		FindCellBorders(stepListBox, 0)[index].Background.Should().BeSameAs(
+			selectionBrush,
+			"scrolling the still-selected column back in must re-apply selection to its recycled-in presenter");
+	}
+
+	[AvaloniaFact]
+	public void ScrollSweepAndSelect_LogsZeroBindingErrors()
+	{
+		// Install the guard before the first realize so binding errors during initial column realization are also caught.
+		using var guard = new BindingErrorGuard();
+
+		var stepListBox = ShowView(560);
+
+		// The ancestor-not-found storm this test guards is triggered BY pool recycle, so the run must
+		// actually virtualize; a non-recycling layout would pass the guard vacuously.
+		RealizedContainerCount(stepListBox).Should().BeLessThan(
+			SeededStepCount / 2, "the 560px window must realize a viewport of columns, not the whole recipe, so pool recycling is exercised");
+
+		ScrollToHorizontalEnd(stepListBox);
+		ScrollToHorizontalStart(stepListBox);
+		_surface.RequestSelection(0);
+		Dispatcher.UIThread.RunJobs();
+		ScrollToHorizontalEnd(stepListBox);
+		ScrollToHorizontalStart(stepListBox);
+
+		RealizedContainerCount(stepListBox).Should().BeLessThan(
+			SeededStepCount / 2, "containers must be recycled across the scroll sweep, not accumulated");
+
+		guard.AssertNoBindingErrors();
+	}
+
+	// Returns a descriptor index that is editable and applicable in every listed column (defaults to column 0),
+	// so its cell paints the plain selection background rather than the inapplicable variant.
+	private int EditableApplicableIndex(params int[] columnIndices)
+	{
+		var columns = columnIndices.Length == 0 ? new[] { 0 } : columnIndices;
+		var descriptors = _surface.ParameterDescriptors;
+		for (var i = 0; i < descriptors.Count; i++)
+		{
+			if (descriptors[i].IsReadOnlyParameter)
+			{
+				continue;
+			}
+
+			if (columns.All(column => _surface.StepColumns[column].Row.IsApplicable(descriptors[i].ParameterKey)))
+			{
+				return i;
+			}
+		}
+
+		throw new InvalidOperationException("No editable, applicable parameter descriptor found.");
+	}
+
+	private static int RealizedContainerCount(ListBox stepListBox)
+	{
+		return stepListBox.GetRealizedContainers().Count();
+	}
+
+	private IBrush Resource(string key)
+	{
+		_window!.TryFindResource(key, out var value).Should().BeTrue($"resource '{key}' must be installed");
+		return value.Should().BeAssignableTo<IBrush>().Subject;
+	}
+
+	private static List<Border> FindCellBorders(ListBox stepListBox, int columnIndex)
+	{
+		return FindCellBorders((ListBoxItem)stepListBox.ContainerFromIndex(columnIndex)!);
+	}
+
+	private static List<Border> FindCellBorders(ListBoxItem container)
+	{
+		return container.GetVisualDescendants()
+			.OfType<Border>()
+			.Where(border => border.Classes.Contains(CellClass))
+			.ToList();
+	}
+
+	private static void ScrollToHorizontalEnd(ListBox stepListBox)
+	{
+		var scrollViewer = stepListBox.GetVisualDescendants().OfType<ScrollViewer>().First();
+		scrollViewer.Offset = new Vector(scrollViewer.Extent.Width, 0);
+		Dispatcher.UIThread.RunJobs();
+	}
+
+	private static void ScrollToHorizontalStart(ListBox stepListBox)
+	{
+		var scrollViewer = stepListBox.GetVisualDescendants().OfType<ScrollViewer>().First();
+		scrollViewer.Offset = new Vector(0, 0);
+		Dispatcher.UIThread.RunJobs();
+	}
+
+	private ListBox ShowView(double width)
+	{
+		var view = new TransposedRecipeGridView { DataContext = _surface };
+		_window = new Window
+		{
+			Width = width,
+			Height = 800,
+			Content = view,
+		};
+
+		CellPaletteInstaller.Install(_window.Resources, _fixture.AppConfiguration.GridStyle);
+		ExecutionPaletteInstaller.Install(_window.Resources, _fixture.AppConfiguration.GridStyle);
+
+		_window.Show();
+		Dispatcher.UIThread.RunJobs();
+
+		var stepListBox = view.FindControl<ListBox>("StepListBox");
+		stepListBox.Should().NotBeNull();
+
+		return stepListBox!;
+	}
+}

--- a/SemiStep/SemiStep.UI/App.axaml.cs
+++ b/SemiStep/SemiStep.UI/App.axaml.cs
@@ -10,6 +10,7 @@ using SemiStep.Core.Configuration;
 using SemiStep.Core.Recipes;
 using SemiStep.UI.Coordinator;
 using SemiStep.UI.Dialogs;
+using SemiStep.UI.Logging;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.Styles;
@@ -70,7 +71,7 @@ public class App : Application
 			.UseSkia()
 			.UseHarfBuzz()
 			.UseReactiveUI(_ => { })
-			.LogToTrace();
+			.LogToSerilog();
 	}
 
 	public static void Run(IServiceProvider serviceProvider)

--- a/SemiStep/SemiStep.UI/Logging/AvaloniaSerilogSink.cs
+++ b/SemiStep/SemiStep.UI/Logging/AvaloniaSerilogSink.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Concurrent;
+
+using Avalonia.Logging;
+
+using Serilog;
+
+using AvaloniaLevel = Avalonia.Logging.LogEventLevel;
+using SerilogLevel = Serilog.Events.LogEventLevel;
+
+namespace SemiStep.UI.Logging;
+
+public sealed class AvaloniaSerilogSink : ILogSink
+{
+	private const int FullLogCount = 20;
+	private const int SampleInterval = 500;
+
+	private readonly AvaloniaLevel _minimumLevel;
+
+	// The key set is trusted finite: Avalonia log templates are constant strings from a fixed set of
+	// call sites, so this never grows unbounded and needs no eviction.
+	private readonly ConcurrentDictionary<(string Area, string Template), int> _occurrences = new();
+
+	public AvaloniaSerilogSink(AvaloniaLevel minimumLevel)
+	{
+		_minimumLevel = minimumLevel;
+	}
+
+	public bool IsEnabled(AvaloniaLevel level, string area)
+	{
+		return level >= _minimumLevel;
+	}
+
+	public void Log(AvaloniaLevel level, string area, object? source, string messageTemplate)
+	{
+		Log(level, area, source, messageTemplate, Array.Empty<object?>());
+	}
+
+	public void Log(AvaloniaLevel level, string area, object? source, string messageTemplate, params object?[] propertyValues)
+	{
+		if (level < _minimumLevel)
+		{
+			return;
+		}
+
+		var occurrence = _occurrences.AddOrUpdate((area, messageTemplate), 1, static (_, count) => count + 1);
+		if (!ShouldEmit(occurrence))
+		{
+			return;
+		}
+
+		var logger = Serilog.Log.ForContext("SourceContext", "Avalonia." + area);
+		if (occurrence > FullLogCount)
+		{
+			logger = logger.ForContext("Occurrence", occurrence);
+		}
+
+		logger.Write(MapLevel(level), messageTemplate, propertyValues);
+	}
+
+	private static bool ShouldEmit(int occurrence)
+	{
+		if (occurrence <= FullLogCount)
+		{
+			return true;
+		}
+
+		return occurrence % SampleInterval == 0;
+	}
+
+	private static SerilogLevel MapLevel(AvaloniaLevel level)
+	{
+		switch (level)
+		{
+			case AvaloniaLevel.Verbose:
+				return SerilogLevel.Verbose;
+			case AvaloniaLevel.Debug:
+				return SerilogLevel.Debug;
+			case AvaloniaLevel.Information:
+				return SerilogLevel.Information;
+			case AvaloniaLevel.Warning:
+				return SerilogLevel.Warning;
+			case AvaloniaLevel.Error:
+				return SerilogLevel.Error;
+			case AvaloniaLevel.Fatal:
+				return SerilogLevel.Fatal;
+			default:
+				return SerilogLevel.Information;
+		}
+	}
+}

--- a/SemiStep/SemiStep.UI/Logging/SerilogLoggingExtensions.cs
+++ b/SemiStep/SemiStep.UI/Logging/SerilogLoggingExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Avalonia;
+using Avalonia.Logging;
+
+using AvaloniaLevel = Avalonia.Logging.LogEventLevel;
+
+namespace SemiStep.UI.Logging;
+
+public static class SerilogLoggingExtensions
+{
+	public static AppBuilder LogToSerilog(this AppBuilder builder, AvaloniaLevel level = AvaloniaLevel.Warning)
+	{
+		Logger.Sink = new AvaloniaSerilogSink(level);
+		return builder;
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs
@@ -128,9 +128,7 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 	{
 		FullRebuild(_coordinator.CurrentRecipe);
 
-		// FullRebuild installs fresh rows carrying StepStartTime=null and ForDepth=0. Run the tail
-		// once from index 0 to establish the incremental start-time baseline; otherwise the first
-		// post-init mutation would refresh only from its own index and leave earlier rows blank.
+		// Run the start-time tail from 0 to seed the baseline; a later mutation refreshes only from its own index.
 		RefreshStepStartTimes(0);
 		RefreshLoopDepths();
 	}
@@ -146,9 +144,7 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 			signal.GetType().Name,
 			recipe.StepCount);
 
-		// Catching here (not letting the throw escape to RecipeCoordinator.RaiseMutatedSafely)
-		// keeps the multicast Mutated invocation intact: the sibling surface and the other
-		// subscribers still receive the signal, and the failure stays user-visible.
+		// Catch here so the throw doesn't break the multicast Mutated to the sibling surface.
 		try
 		{
 			switch (signal)
@@ -200,12 +196,7 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 		RefreshLoopDepths();
 	}
 
-	// Drives the incremental start-time refresh only. start-time[i] is forward-prefix-determined
-	// (computed from steps 0..i-1), so a mutation at index k cannot change any start-time before k;
-	// refreshing from this index down is behavior-preserving. Loop-depth is a matched-bracket
-	// property that a committed marker mutation can change for rows before k (deleting an EndForLoop
-	// unnests its opening marker above it), so RefreshLoopDepths stays a full 0..Count scan and is
-	// never driven by this index.
+	// start-time[i] depends only on steps 0..i-1, so refreshing from the mutation index is safe; loop-depth can change earlier rows, so it stays a full scan.
 	private static int RefreshStartIndexFor(MutationSignal signal)
 	{
 		var fromIndex = signal switch
@@ -249,10 +240,7 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 		_selectionRequests.OnNext(stepIndex);
 	}
 
-	// A click-away acknowledgement must land on both orientation surfaces (each holds its own
-	// row view model for the step), so the clear round-trips through the shared broadcaster
-	// instead of touching this surface's row directly. Rows no longer in the projection are
-	// skipped (the view arms the pending cell before mutations can replace its row).
+	// Clear round-trips through the shared broadcaster so both orientation surfaces clear.
 	public void ClearChangedByClickAway(RecipeRowViewModel row, string columnKey)
 	{
 		for (var i = 0; i < Items.Count; i++)
@@ -553,11 +541,7 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 			.ToList();
 	}
 
-	// Throws instead of skipping: a skipped step would leave Items.Count < recipe.StepCount and
-	// silently desync every index-based dispatch. Config loading and import validation make the
-	// branch unreachable; if the invariant is ever breached, Initialize() crashes, while
-	// OnMutation catches this specific exception, error-logs it, reports it to the message
-	// panel, and leaves the projection as-is.
+	// Throws rather than skips: a skipped step desyncs Items.Count from StepCount and breaks index-based dispatch.
 	private TItem CreateItemChecked(Step step, int stepNumber)
 	{
 		if (!RecipeMetadataRegistry.TryGetAction(step.ActionKey, out var action))

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeRowViewModel.cs
@@ -18,11 +18,7 @@ public sealed class RecipeRowViewModel(
 {
 	private const string IndexerName = "Item";
 
-	// The Units/FormatKinds/GroupItems dictionaries depend only on (ActionDefinition, registry) and
-	// are immutable once built, so they are cached per action instead of rebuilt for every row. The
-	// registry hands out a stable ActionDefinition instance per action id, so the reference key is
-	// safe; the weak table lets an entry fall away when its action is collected (e.g. a discarded
-	// registry in a test).
+	// Cached per action (stable ActionDefinition instance makes the reference key safe); weak table drops entries when an action is collected.
 	private static readonly ConditionalWeakTable<ActionDefinition, ActionColumnMetadata> _actionMetadataCache = new();
 
 	private readonly ActionColumnMetadata _actionMetadata = GetActionMetadata(action, recipeMetadataRegistry);
@@ -257,12 +253,7 @@ public sealed class RecipeRowViewModel(
 	}
 
 	/// <summary>
-	/// Detects a selector-column edit and computes the columns the new selection deactivates (drop)
-	/// and activates (seed with their default values). A column is a selector when some union column
-	/// carries an <see cref="ActivationCondition"/> keyed on it (the resolver strips per-column
-	/// <c>Targets</c> from the resolved action and records the dependency as activation conditions
-	/// instead). Returns false for ordinary edits, non-selector columns, or values that do not parse
-	/// to a selector id.
+	/// A column is a selector when a union column carries an ActivationCondition keyed on it.
 	/// </summary>
 	private bool TryBuildSelectorEdit(string columnKey, string? value, out SelectorEdit selectorEdit)
 	{
@@ -376,10 +367,7 @@ public sealed class RecipeRowViewModel(
 		ActionDefinition actionDefinition,
 		RecipeMetadataRegistry recipeMetadataRegistry)
 	{
-		// Pre-populate every group-bound column with an empty items list, regardless of whether
-		// the current action defines that property. When a cell is recycled onto a row whose
-		// action lacks the property, the binding still resolves to an empty list instead of
-		// throwing KeyNotFoundException and logging a binding error on every recycle.
+		// Pre-populate group-bound columns with empty lists so a recycle onto an action lacking the property doesn't throw KeyNotFoundException.
 		var result = new Dictionary<string, IReadOnlyList<ComboBoxItemViewModel>>(StringComparer.OrdinalIgnoreCase);
 
 		foreach (var column in recipeMetadataRegistry.GetAllColumns())
@@ -397,10 +385,7 @@ public sealed class RecipeRowViewModel(
 				continue;
 			}
 
-			// Only overlay onto columns that were pre-populated above (group-bound columns).
-			// Cross-reference validation rejects actions that reference non-existent column keys
-			// at startup, but this guard keeps the dictionary's documented invariant explicit
-			// and protects against future config-validator drift.
+			// Validation already rejects unknown keys; this guard confines the overlay to pre-populated columns.
 			if (!result.ContainsKey(actionProperty.Key))
 			{
 				continue;

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/CellSlotConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/CellSlotConverter.cs
@@ -5,10 +5,6 @@ using Avalonia.Data.Converters;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Resolves a fixed column-cell slot to Cells[index] so a recycled container rebinds slot i from the
-// old column's cell to the new column's cell on a single DataContext change, instead of rebuilding.
-// The slot count and order are constant across columns (one cell per ParameterDescriptor), so the
-// index is baked once per slot and passed as the converter parameter.
 internal sealed class CellSlotConverter : IValueConverter
 {
 	public static readonly CellSlotConverter Instance = new();

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/ComboBoxDisplayTextConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/ComboBoxDisplayTextConverter.cs
@@ -6,11 +6,6 @@ using SemiStep.Core.Recipes;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Resolves a combo cell's (Value, Items) to the selected item's display text for the lazy display
-// TextBlock. It delegates the (id, items) -> item lookup to ComboBoxItemMultiSelectionConverter (the same
-// resolver the ComboBox editor's SelectedItem uses) and projects the item's DisplayText, so the display
-// updates on any external Value change (selector edit, action change, recycle rebind) through the same
-// OneWay MultiBinding the editor uses, with the lookup living in exactly one place.
 internal sealed class ComboBoxDisplayTextConverter : IMultiValueConverter
 {
 	public static readonly ComboBoxDisplayTextConverter Instance = new();

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/PropertyTextEditingMultiConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/PropertyTextEditingMultiConverter.cs
@@ -5,10 +5,6 @@ using Avalonia.Data.Converters;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Stateless OneWay display converter for the transposed recyclable text editor: (Value, FormatKind)
-// -> the units-less formatted string the per-cell PropertyTimeEditingConverter used to bake. Binding
-// FormatKind instead of baking it is what lets the TextBox be reused across recycled cells; the edit
-// commit is owned by the editor's LostFocus/KeyDown handlers (Avalonia MultiBinding has no ConvertBack).
 internal sealed class PropertyTextEditingMultiConverter : IMultiValueConverter
 {
 	public static readonly PropertyTextEditingMultiConverter Instance = new();

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellBackgroundConverter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellBackgroundConverter.cs
@@ -9,16 +9,12 @@ using SemiStep.UI.Styles;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Collapses the transposed cell's background state matrix into one binding, replacing the 29
-// background setter rules that previously lived in TransposedGridStyles.axaml. The
-// winning brush reproduces those rules' document-order, last-match-wins precedence exactly:
+// Last-match-wins precedence decoding ResolveBrushKey:
 //   selected            -> changed > inapplicable > read-only > plain selection tint
 //   else changed        -> the changed highlight (beats depth/read-only/inapplicable, loses to selection)
 //   else inapplicable   -> disabled palette, per loop depth + past-step
 //   else read-only      -> read-only palette, per loop depth + past-step
 //   else                -> execution depth/past tint (depth-0 idle is the plain grid background)
-// Brushes resolve through the target Border as a resource host, so the same visual-tree + application
-// lookup {DynamicResource} used still applies (works for both app- and window-scoped palette installs).
 internal sealed class TransposedCellBackgroundConverter : IMultiValueConverter
 {
 	public static readonly TransposedCellBackgroundConverter Instance = new();

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedCellTemplateFactory.cs
@@ -15,18 +15,10 @@ using SemiStep.Core.Recipes;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-/// <summary>
-/// Builds the per-kind cell controls for the transposed grid, dispatched over the cell-VM type. Both
-/// editor kinds are lazy: property-text and ComboBox cells render a lightweight display and build their
-/// heavy editor (TextBox / ComboBox) only on edit entry through the view-level edit coordinator, released
-/// back to the display on exit. Display and parse-back go through the shared time/unit converters; input
-/// is gated on applicability, column-level read-only, and the surface read-only state.
-/// </summary>
 internal sealed class TransposedCellTemplateFactory(
 	TransposedRecipeGridSurface surface,
 	TransposedTextEditCoordinator editCoordinator)
 {
-	// Shared bool negation, reused by the pooled column-cells presenter's class bindings.
 	internal static readonly FuncValueConverter<bool, bool> NegateConverter = new(value => !value);
 	private static readonly FuncValueConverter<int?, int> _maxLengthConverter = new(maxLength => maxLength ?? 0);
 	private static readonly PropertyTimeMultiConverter _displayConverter = new();
@@ -38,10 +30,6 @@ internal sealed class TransposedCellTemplateFactory(
 		AvaloniaProperty.RegisterAttached<TransposedCellTemplateFactory, TextBox, PropertyTextCellViewModel?>(
 			"EditingCell");
 
-	// Builds the per-kind editor control directly (no ContentControl/ContentPresenter wrapper), so a
-	// pooled column presenter can host it as a plain child that survives detach/reattach and only
-	// rebinds on DataContext change. The kind is constant per slot (every column's cell at a given row
-	// shares one descriptor), so the editor built from the first bound cell stays correct across reuse.
 	public Control CreateEditor(ParameterCellViewModel cell)
 	{
 		return cell switch
@@ -52,11 +40,6 @@ internal sealed class TransposedCellTemplateFactory(
 		};
 	}
 
-	// ComboBox cells are lazy: a display TextBlock showing the selected item's text by default, with the
-	// heavy ComboBox editor built only when the coordinator enters edit here. Hit-testable/focusable follow
-	// applicability + column read-only (a read-only or inapplicable combo is non-hit-testable and
-	// non-focusable, so it cannot enter edit and a press falls through to column selection); IsEnabled adds
-	// the surface read-only state.
 	private Control CreateComboCellPresenter()
 	{
 		var presenter = new TransposedComboCellPresenter(
@@ -74,9 +57,6 @@ internal sealed class TransposedCellTemplateFactory(
 	{
 		var textBlock = CreateDisplayTextBlock(stretch: true);
 
-		// The same OneWay (Value, Items) lookup the ComboBox editor's SelectedItem uses, projected to the
-		// item's display text, so a recycled slot rebinds its display to the new cell's selection and an
-		// external value change (selector edit / action change) updates the shown text.
 		textBlock.Bind(TextBlock.TextProperty, new MultiBinding
 		{
 			Mode = BindingMode.OneWay,
@@ -91,10 +71,6 @@ internal sealed class TransposedCellTemplateFactory(
 		return textBlock;
 	}
 
-	// Property-text cells are lazy: a display TextBlock by default, with the TextBox editor built only
-	// when the coordinator enters edit here. The display mirrors the editor's units-less formatting so
-	// entering/leaving edit shows identical text; IsEnabled follows applicability + surface read-only so
-	// inapplicable / read-only-surface cells are non-hit-testable and non-focusable (edit entry blocked).
 	private Control CreateTextCellPresenter()
 	{
 		var presenter = new TransposedTextCellPresenter(
@@ -110,8 +86,6 @@ internal sealed class TransposedCellTemplateFactory(
 	{
 		var textBlock = CreateDisplayTextBlock(stretch: true);
 
-		// The same OneWay (Value, FormatKind) MultiBinding the editor uses, so a recycled slot rebinds
-		// its display to the new cell's value and the display matches what the editor would show.
 		textBlock.Bind(TextBlock.TextProperty, new MultiBinding
 		{
 			Mode = BindingMode.OneWay,
@@ -126,10 +100,6 @@ internal sealed class TransposedCellTemplateFactory(
 		return textBlock;
 	}
 
-	// The display TextBlock shared by all three cell kinds (combo display, text display, read-only): same
-	// vertical centering, cell padding, centered text, and grid font. Callers attach their own Text binding.
-	// The two editor-backed kinds pass stretch: true to fill the cell width; the read-only kind keeps the
-	// default alignment.
 	private TextBlock CreateDisplayTextBlock(bool stretch)
 	{
 		var gridStyle = surface.GridStyle;
@@ -163,10 +133,7 @@ internal sealed class TransposedCellTemplateFactory(
 		TopLevel.GetTopLevel(editor)?.FocusManager?.Focus(null);
 	}
 
-	// The ComboBox editor, built lazily by the combo presenter on edit entry. FontSize explicit: the Semi
-	// ComboBox selection box does not inherit the grid font (parity with the canonical ComboBoxCellFactory).
-	// SelectedItem resolves via a OneWay MultiBinding; writeback is owned by SelectionChanged, which no-ops
-	// when the value is unchanged (so the initial selection on a lazy build is a no-op, not a recipe edit).
+	// Semi ComboBox selection box does not inherit the grid font, so ApplyCellFont is applied explicitly.
 	private ComboBox CreateComboBox()
 	{
 		var itemsPath = nameof(ComboBoxCellViewModel.Items);
@@ -201,6 +168,8 @@ internal sealed class TransposedCellTemplateFactory(
 		return comboBox;
 	}
 
+	// The initial SelectionChanged on a lazy-built combo assigns the value it already holds; Value's setter
+	// ignores an unchanged value (RecipeRowViewModel.SetPropertyValue no-ops), so it does not dirty the recipe.
 	private static void OnComboBoxSelectionChanged(object? sender, SelectionChangedEventArgs e)
 	{
 		if (sender is not ComboBox comboBox
@@ -213,10 +182,6 @@ internal sealed class TransposedCellTemplateFactory(
 		cell.Value = selected.Id.ToString(CultureInfo.InvariantCulture);
 	}
 
-	// The TextBox carries no per-cell baked state: display is a OneWay MultiBinding through a shared
-	// stateless converter, MaxLength is bound, and the edit commit reads its target from the cell
-	// captured on GotFocus (not a closure), so a pooled editor safely rebinds onto the next cell on a
-	// DataContext change instead of being rebuilt.
 	private Control CreateTextBoxEditor()
 	{
 		var gridStyle = surface.GridStyle;
@@ -239,16 +204,14 @@ internal sealed class TransposedCellTemplateFactory(
 		};
 		GridFontApplier.ApplyCellFont(textBox, gridStyle);
 
-		// Bound, not baked: a null MaxLength maps to 0 (Semi's "unlimited"), matching the old
-		// leave-MaxLength-unset behavior while still tracking the recycled cell's descriptor.
+		// null MaxLength maps to 0 (Semi's "unlimited").
 		textBox.Bind(TextBox.MaxLengthProperty, new Binding(nameof(PropertyTextCellViewModel.MaxLength))
 		{
 			Mode = BindingMode.OneWay,
 			Converter = _maxLengthConverter,
 		});
 
-		// OneWay display only (a MultiBinding cannot ConvertBack). FormatKind is bound so the shared
-		// converter formats each recycled cell correctly; the commit is owned by the handlers below.
+		// OneWay only — a MultiBinding cannot ConvertBack; commit is owned by the handlers below.
 		textBox.Bind(TextBox.TextProperty, new MultiBinding
 		{
 			Mode = BindingMode.OneWay,
@@ -260,9 +223,7 @@ internal sealed class TransposedCellTemplateFactory(
 			},
 		});
 
-		// No read-only-parameter leg here: the cell factory routes read-only descriptors to
-		// ReadOnlyCellViewModel before the property-text kind, so a TextBox cell is never
-		// column-level read-only.
+		// A TextBox cell is never column-level read-only (read-only descriptors route to ReadOnlyCellViewModel), so no read-only leg.
 		textBox.Bind(InputElement.IsEnabledProperty, CreateTextBoxEditableBinding());
 
 		textBox.GotFocus += (sender, _) => OnEditorGotFocus(sender);
@@ -294,10 +255,7 @@ internal sealed class TransposedCellTemplateFactory(
 		}
 	}
 
-	// Enter commits an always-live editor by moving focus off it; the LostFocus handler parses and
-	// pushes the pending text (canonical parity: Enter ends the cell edit). Escape overwrites the
-	// typed-but-uncommitted text with the captured cell's value before defocusing (canonical parity:
-	// Escape cancels the cell edit) — the ensuing commit re-parses that reverted text to a no-op write.
+	// Enter commits by defocusing; Escape reverts the TextBox to the captured value first so the ensuing commit re-parses to a no-op.
 	private static void OnEditorKeyDown(object? sender, KeyEventArgs e)
 	{
 		if (sender is not TextBox textBox || e.Key is not (Key.Enter or Key.Escape))
@@ -315,13 +273,7 @@ internal sealed class TransposedCellTemplateFactory(
 		e.Handled = true;
 	}
 
-	// Commit writes ONLY to the cell captured on GotFocus, never the current DataContext, so a
-	// recycled-out editor commits its edit to the cell the user was editing and a recycled-in editor
-	// never receives a stale write. The display is snapped back to the model value only while the
-	// editor still shows the captured cell — a rejected, read-only-dropped, or unchanged write leaves
-	// the source untouched, so the OneWay binding would otherwise keep showing the never-committed
-	// text; if the editor was recycled onto another cell, its binding already shows that cell and must
-	// not be overwritten.
+	// Commit writes only to the captured cell; snap the display back only while the editor still shows it, else it was recycled onto another cell.
 	internal static void CommitEditor(TextBox textBox)
 	{
 		if (textBox.GetValue(_editingCellProperty) is not { } cell)
@@ -341,16 +293,11 @@ internal sealed class TransposedCellTemplateFactory(
 		}
 	}
 
-	// The read-only TextBlock holds no per-cell baked state: both the step-start-time and the
-	// display-converter legs are OneWay bindings. The step-start-time vs display split keys off the
-	// descriptor's ColumnType, which is invariant per slot position (every column's cell at a given row
-	// shares one parameter descriptor), so the chosen leg stays correct across reuse.
 	private Control CreateReadOnlyTextBlock(ReadOnlyCellViewModel cell)
 	{
 		var textBlock = CreateDisplayTextBlock(stretch: false);
 
-		// Step start time arrives pre-formatted (HH:MM:SS + units) from the surface refresh tail,
-		// so it binds directly; other read-only cells format through the shared display converter.
+		// Step start time arrives pre-formatted from the surface refresh, so it binds directly.
 		if (ColumnTypes.IsStepStartTimeColumn(cell.Descriptor.ColumnType))
 		{
 			textBlock.Bind(TextBlock.TextProperty, new Binding(nameof(ParameterCellViewModel.Value))
@@ -375,9 +322,6 @@ internal sealed class TransposedCellTemplateFactory(
 		return textBlock;
 	}
 
-	// Canonical ApplyInputBlocking parity: a column-level read-only combo is permanently
-	// non-hit-testable and non-focusable; otherwise both follow per-cell applicability.
-	// IsEnabled additionally tracks the surface read-only state.
 	private void ApplyInputBlocking(ComboBox comboBox)
 	{
 		comboBox.Bind(InputElement.IsHitTestVisibleProperty, CreateInteractiveBinding());

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsHost.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsHost.cs
@@ -4,16 +4,13 @@ using Avalonia.VisualTree;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Lightweight seam between the recycled ListBox container and a pooled column-cells presenter. It sits
-// in the ItemTemplate (so it IS rebuilt on every recycle, but it carries no cell subtree of its own), and
-// on realize it borrows a presenter from the view's pool, binds it to the column, and hosts it; on
-// recycle-out it commits any active edit and returns the presenter. This keeps the heavy cell subtrees
-// out of the rebuilt-on-recycle content while the ListBox still virtualizes the columns.
 internal sealed class TransposedColumnCellsHost : Decorator
 {
 	private TransposedRecipeGridView? _view;
 	private TransposedColumnCellsPool? _acquiredPool;
 	private TransposedColumnCellsPresenter? _presenter;
+	private ListBoxItem? _containerItem;
+	private IDisposable? _selectionSubscription;
 
 	protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
 	{
@@ -36,8 +33,7 @@ internal sealed class TransposedColumnCellsHost : Decorator
 
 	private void AcquireAndBind()
 	{
-		// The surface (and its pool) can change under the singleton view on a config swap; always take
-		// the current pool and remember which one lent the presenter so it is returned to its origin.
+		// Pool can change on config swap; take the current pool and remember which one lent the presenter.
 		if (_view?.ColumnCellsPool is not { } pool || DataContext is not StepColumnViewModel column)
 		{
 			return;
@@ -55,16 +51,63 @@ internal sealed class TransposedColumnCellsHost : Decorator
 		{
 			Child = _presenter;
 		}
+
+		SyncSelectionFromContainer();
 	}
 
-	private void ReleasePresenter()
+	// Container can be null before attach so re-resolve each bind; it's stable across in-place
+	// recycle, so only resubscribe when it changes.
+	private void SyncSelectionFromContainer()
 	{
 		if (_presenter is null)
 		{
 			return;
 		}
 
+		var container = this.FindAncestorOfType<ListBoxItem>();
+		if (!ReferenceEquals(container, _containerItem))
+		{
+			_selectionSubscription?.Dispose();
+			_selectionSubscription = null;
+			_containerItem = container;
+
+			if (container is not null)
+			{
+				// GetObservable pushes the current IsSelected synchronously on Subscribe, seeding IsColumnSelected.
+				_selectionSubscription = container
+					.GetObservable(ListBoxItem.IsSelectedProperty)
+					.Subscribe(isSelected =>
+					{
+						if (_presenter is not null)
+						{
+							_presenter.IsColumnSelected = isSelected;
+						}
+					});
+			}
+			else
+			{
+				_presenter.IsColumnSelected = false;
+			}
+
+			return;
+		}
+
+		_presenter.IsColumnSelected = container?.IsSelected ?? false;
+	}
+
+	private void ReleasePresenter()
+	{
+		_selectionSubscription?.Dispose();
+		_selectionSubscription = null;
+		_containerItem = null;
+
+		if (_presenter is null)
+		{
+			return;
+		}
+
 		_presenter.CommitActiveEditor();
+		_presenter.IsColumnSelected = false;
 		Child = null;
 		_acquiredPool?.Return(_presenter);
 		_presenter = null;

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPool.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPool.cs
@@ -2,12 +2,6 @@
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// A small view-owned pool of reusable column-cells presenters. The transposed ListBox recycles its
-// containers by detaching and rebuilding their ItemTemplate content, so a presenter placed inside that
-// content would be rebuilt on every scroll. The pool holds presenters OUTSIDE that recycled content and
-// hands one to each realized column (via TransposedColumnCellsHost), so the built cell subtrees are
-// reused across recycling instead of rebuilt. The pool only ever grows to the realized-container count
-// (a viewport of columns), so never-scrolled columns cost nothing.
 internal sealed class TransposedColumnCellsPool(
 	IReadOnlyList<ParameterDescriptor> descriptors,
 	TransposedCellTemplateFactory cellFactory,

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPresenter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedColumnCellsPresenter.cs
@@ -9,18 +9,21 @@ using SemiStep.Core.Recipes;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// One reusable presenter for a step column's cells. Built ONCE with a fixed slot per ParameterDescriptor
-// (cell count and row order are constant across columns), each slot a cell Border whose child is a plain
-// editor control - NOT a ContentControl - so it survives the detach/reattach a recycled ListBox container
-// forces and only rebinds on a DataContext change instead of being rebuilt. Presenters are pooled across
-// containers (see TransposedColumnCellsPool): rebinding a column is a single DataContext assignment that
-// re-resolves every slot's Cells[i], turning a viewport jump from N column rebuilds into N rebinds.
 internal sealed class TransposedColumnCellsPresenter : StackPanel
 {
+	// Cell background reads this directly (Source=this) instead of a RelativeSource ancestor lookup
+	// that fails while the presenter is pooled/detached.
+	public static readonly DirectProperty<TransposedColumnCellsPresenter, bool> IsColumnSelectedProperty =
+		AvaloniaProperty.RegisterDirect<TransposedColumnCellsPresenter, bool>(
+			nameof(IsColumnSelected),
+			presenter => presenter._isColumnSelected,
+			(presenter, value) => presenter.IsColumnSelected = value);
+
 	private readonly IReadOnlyList<ParameterDescriptor> _descriptors;
 	private readonly TransposedCellTemplateFactory _cellFactory;
 	private readonly double _cellHeight;
 	private bool _slotsBuilt;
+	private bool _isColumnSelected;
 
 	public TransposedColumnCellsPresenter(
 		IReadOnlyList<ParameterDescriptor> descriptors,
@@ -33,19 +36,19 @@ internal sealed class TransposedColumnCellsPresenter : StackPanel
 		Orientation = Orientation.Vertical;
 	}
 
-	// Binds the presenter to a column: builds the slots on first use (from the config-constant
-	// descriptor count, touching Cells only for this actually-realized column so the never-realized
-	// column's Lazy stays untouched), then rebinds every slot by assigning the column DataContext.
+	public bool IsColumnSelected
+	{
+		get => _isColumnSelected;
+		set => SetAndRaise(IsColumnSelectedProperty, ref _isColumnSelected, value);
+	}
+
 	public void BindColumn(StepColumnViewModel column)
 	{
 		EnsureSlotsBuilt(column);
 		DataContext = column;
 	}
 
-	// Commits/closes any editing slot (text or combo) inside this presenter before it is released or
-	// rebound, so pending text is never lost to the rebind's OneWay display binding and a combo drops back
-	// to its display. Walks the slot subtree directly (not via focus) so it works even while the presenter
-	// is already detached from its top level during a recycle.
+	// Walks the slot subtree directly (not via focus) so it commits even while detached during a recycle.
 	public void CommitActiveEditor()
 	{
 		foreach (var slot in this.GetVisualDescendants().OfType<TransposedLazyCellPresenter>())
@@ -63,6 +66,19 @@ internal sealed class TransposedColumnCellsPresenter : StackPanel
 		base.OnDataContextBeginUpdate();
 	}
 
+	// The cell background MultiBinding resolves its brushes through the attached slot Border. A pooled
+	// presenter's legs settle while it is still detached, so the converter runs once with an unreachable
+	// resource host and yields no brush. Re-announcing the selection leg on attach re-runs the converter
+	// now that the Border can reach the palette resources (the old RelativeSource-ancestor leg did this
+	// implicitly by re-emitting once its ListBoxItem ancestor was found). The old value is fabricated as
+	// the negation to force the notification (a truthful old==new would be coalesced away); this is safe
+	// because the sole consumer is the background MultiBinding, which reads only the new value.
+	protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+	{
+		base.OnAttachedToVisualTree(e);
+		RaisePropertyChanged(IsColumnSelectedProperty, !_isColumnSelected, _isColumnSelected);
+	}
+
 	private void EnsureSlotsBuilt(StepColumnViewModel column)
 	{
 		if (_slotsBuilt)
@@ -70,8 +86,7 @@ internal sealed class TransposedColumnCellsPresenter : StackPanel
 			return;
 		}
 
-		// Slot count is descriptor-driven and constant across columns (one cell per ParameterDescriptor);
-		// derive it from the descriptors, not this column's Cells, so the count is orientation-invariant.
+		// Slot count is descriptor-driven and constant across columns; derive it from the descriptors.
 		var cells = column.Cells;
 		for (var slotIndex = 0; slotIndex < _descriptors.Count; slotIndex++)
 		{
@@ -88,9 +103,6 @@ internal sealed class TransposedColumnCellsPresenter : StackPanel
 		_slotsBuilt = true;
 	}
 
-	// Rebuilds the cell Border in code (the XAML equivalent lived in the inner ItemsControl item
-	// template): the transposed-cell chrome classes, the flattened background-state MultiBinding, and a
-	// fixed row height. The editor is the Border's direct child.
 	private Border BuildCellSlot(Control editor)
 	{
 		var border = new Border
@@ -125,13 +137,7 @@ internal sealed class TransposedColumnCellsPresenter : StackPanel
 				new Binding(readOnlyParameterPath),
 				new Binding(nameof(ParameterCellViewModel.IsApplicable)),
 				new Binding(nameof(ParameterCellViewModel.IsChanged)),
-				new Binding(nameof(ListBoxItem.IsSelected))
-				{
-					RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
-					{
-						AncestorType = typeof(ListBoxItem),
-					},
-				},
+				new Binding(nameof(IsColumnSelected)) { Source = this },
 			},
 		});
 

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedComboCellPresenter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedComboCellPresenter.cs
@@ -2,12 +2,6 @@
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Lazy display/editor slot for a ComboBox cell. Renders a lightweight display TextBlock showing the
-// selected item's text by default and builds the full ComboBox only when the edit coordinator enters
-// edit here, opening the dropdown so the second press behaves like clicking a live combo. The ComboBox is
-// the heaviest single cell control, so keeping it out of the resident tree until edit removes the bulk of
-// the realized-column cost (a not-in-edit column now instantiates zero ComboBoxes). Writeback stays owned
-// by the ComboBox's SelectionChanged, so there is no deferred content to flush on commit/recycle.
 internal sealed class TransposedComboCellPresenter : TransposedLazyCellPresenter
 {
 	public TransposedComboCellPresenter(
@@ -18,8 +12,6 @@ internal sealed class TransposedComboCellPresenter : TransposedLazyCellPresenter
 	{
 	}
 
-	// The combo carries no seeded text; opening the dropdown on entry matches the click-to-open affordance
-	// of a live combo (the second press / F2 gesture reads as "open this combo").
 	protected override void OnEnteredEdit(Control editor, string? initialText)
 	{
 		if (editor is ComboBox comboBox)
@@ -28,10 +20,7 @@ internal sealed class TransposedComboCellPresenter : TransposedLazyCellPresenter
 		}
 	}
 
-	// SelectionChanged already wrote the selection back as the user picked, so there is nothing to flush.
-	// The commit-before-rebind / recycle path swaps the ComboBox out for the display without a blur, so the
-	// dropdown would stay open on the pooled ComboBox: close it here (mirroring CloseActiveEditor) so a
-	// detached popup cannot orphan and a later re-edit's IsDropDownOpen=true actually reopens it.
+	// Close the dropdown so a pooled ComboBox swapped out without a blur can't orphan its popup.
 	protected override void CommitEditorContent(Control editor)
 	{
 		if (editor is ComboBox comboBox)
@@ -40,9 +29,7 @@ internal sealed class TransposedComboCellPresenter : TransposedLazyCellPresenter
 		}
 	}
 
-	// The dropdown popup lives in its own visual root; opening it blurs the ComboBox. Keep editing while
-	// the dropdown is open so the popup interaction is not torn down, and revert to the display only when
-	// focus leaves the closed combo.
+	// The dropdown popup has its own visual root; keep editing while open so it isn't torn down.
 	protected override bool ShouldExitOnEditorLostFocus(Control editor)
 	{
 		return editor is not ComboBox { IsDropDownOpen: true };

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridCellLocator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridCellLocator.cs
@@ -6,8 +6,6 @@ namespace SemiStep.UI.RecipeGrid.Transposed;
 
 internal static class TransposedGridCellLocator
 {
-	// Walks the visual tree upward from the press/focus source until a cell's DataContext is
-	// found or the step ListBox itself is reached (header/marker presses resolve no cell).
 	public static ParameterCellViewModel? ResolveCell(Visual source, ListBox stepListBox)
 	{
 		var current = source;

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridNavigator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridNavigator.cs
@@ -5,9 +5,6 @@ using Avalonia.VisualTree;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Operator mental model: Right = next step (column), Down = next parameter (cell below).
-// Keys inside an open ComboBox dropdown and caret movement inside a focused TextBox keep
-// their native meaning.
 internal sealed class TransposedGridNavigator(ListBox stepListBox)
 {
 	public void HandleTunnelKeyDown(TransposedRecipeGridSurface? surface, KeyEventArgs e)
@@ -149,9 +146,7 @@ internal sealed class TransposedGridNavigator(ListBox stepListBox)
 		}
 	}
 
-	// Arrow navigation traverses cells by focusing the lazy display presenters (property-text and combo
-	// alike): the heavy editor is built only on edit entry, so navigation targets the display visual and a
-	// focused display then enters edit on F2 (text also on a printable keystroke).
+	// Navigation focuses the lazy display presenter, not the editor (editor built only on edit entry).
 	private Control? FindFocusableCellPresenter(
 		TransposedRecipeGridSurface surface,
 		int columnIndex,

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridSelectionController.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedGridSelectionController.cs
@@ -3,16 +3,9 @@ using Avalonia.Input;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Cell presses drive the canonical select-then-edit model. A plain press on a not-yet
-// selected column selects it WITHOUT focusing the editor (focus goes to the container, so
-// Delete/Ctrl+C stay live); a second plain press on the already selected column falls
-// through to the editor (a live ComboBox, or edit entry for a lazy text cell — the caller
-// decides on the reported fall-through). Ctrl/Shift presses toggle/extend the multi-selection
-// (the editor would otherwise swallow them — spike finding) and never enter an editor.
 internal sealed class TransposedGridSelectionController(ListBox stepListBox)
 {
-	// Returns true when the press was NOT consumed for selection — a second press on the already
-	// single-selected column — so the caller can route it to edit entry (or leave it to a live editor).
+	// Returns true when NOT consumed (second press on the already-selected column) so the caller routes to edit.
 	public bool HandleCellSelectionPress(
 		TransposedRecipeGridSurface? surface,
 		ParameterCellViewModel pressedCell,

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedLazyCellPresenter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedLazyCellPresenter.cs
@@ -6,13 +6,6 @@ using Avalonia.Media;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Shared lazy display/editor slot for a transposed cell. Renders a lightweight display control by default
-// and builds the heavy editor (TextBox / ComboBox) only when the edit coordinator enters edit here,
-// releasing it back to the display on blur/commit/recycle. This removes the always-live editor weight
-// from the fresh-container build and the resident visual tree while preserving the select-then-edit
-// gesture, click-and-type, and keyboard-driven edit entry. A transparent background makes the whole cell
-// hit-testable so a press anywhere in it enters edit; Focusable makes it an arrow-navigation target from
-// which F2 opens the editor. Subclasses supply the per-kind editor build/commit and edit-entry specifics.
 internal abstract class TransposedLazyCellPresenter : Border
 {
 	private readonly TransposedTextEditCoordinator _coordinator;
@@ -40,13 +33,9 @@ internal abstract class TransposedLazyCellPresenter : Border
 
 	public Control? Editor => _editor;
 
-	// Applicability + surface read-only fold into the presenter's bound IsEnabled, so a disabled presenter
-	// is non-focusable and blocks edit entry (read-only / inapplicable / read-only-surface all gate here).
 	public bool CanEnterEdit => IsEffectivelyEnabled;
 
-	// Swaps the display for the editor, focuses it, and hands off to the subclass for the just-entered
-	// state (seed text / open dropdown). Synchronous so the paired TextInput of a printable keystroke
-	// lands on the now-focused editor.
+	// Synchronous so the paired TextInput of a printable keystroke lands on the now-focused editor.
 	public void EnterEdit(string? initialText)
 	{
 		if (!IsEffectivelyEnabled)
@@ -66,10 +55,6 @@ internal abstract class TransposedLazyCellPresenter : Border
 		_editor?.Focus();
 	}
 
-	// Commit-before-rebind: flush the editor's content to its captured cell (text parses/writes; combo is
-	// a no-op) and drop back to the display without moving focus. Called when a pooled presenter is
-	// recycled out or rebound to a new column so the edit lands on the cell the user was editing before the
-	// display binding rebinds. Idempotent: a second call after ShowDisplay is a no-op.
 	public void CommitEdit()
 	{
 		if (!IsEditing || _editor is null)
@@ -84,34 +69,27 @@ internal abstract class TransposedLazyCellPresenter : Border
 
 	protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
 	{
-		// A recycle detaches this slot while it may still be editing. Commit/close the editor before the
-		// pooled presenter is reused, so a rebind can never silently overwrite pending state.
+		// A recycle detaches while editing; commit before reuse so a rebind can't overwrite pending state.
 		CommitEdit();
 
 		base.OnDetachedFromVisualTree(e);
 	}
 
-	// Applies the just-entered edit state after the editor is built, swapped in, and focused.
 	protected abstract void OnEnteredEdit(Control editor, string? initialText);
 
-	// Pushes the editor's pending content to the model on commit-before-rebind.
 	protected abstract void CommitEditorContent(Control editor);
 
-	// A printable KeyDown reached a focused display. Subclasses that accept typed entry override to enter
-	// edit (text seeds with replace semantics); the combo ignores typing (F2 / pointer are its gestures), so
-	// the base no-op leaves it alone.
+	// Base no-op: the combo ignores typing (F2/pointer are its gestures).
 	protected virtual void OnPrintableKeyDown(KeyEventArgs e)
 	{
 	}
 
-	// A TextInput reached a focused display without a preceding printable KeyDown (the pure TextInput /
-	// IME route). Subclasses that accept typed entry override to seed the editor with the carried character.
+	// The pure TextInput/IME route: a TextInput with no preceding printable KeyDown.
 	protected virtual void OnDisplayTextInputCore(TextInputEventArgs e)
 	{
 	}
 
-	// Whether an editor LostFocus ends the edit. Text always exits; a combo whose dropdown is open keeps
-	// editing (focus moved into the popup's own visual root, not away from the cell).
+	// A combo with an open dropdown keeps editing (focus moved into the popup's own visual root, not away).
 	protected virtual bool ShouldExitOnEditorLostFocus(Control editor)
 	{
 		return true;
@@ -148,9 +126,6 @@ internal abstract class TransposedLazyCellPresenter : Border
 		_editor.AddHandler(LostFocusEvent, OnEditorLostFocus, RoutingStrategies.Bubble);
 	}
 
-	// The editor blurs on commit (Enter / click-away), on recycle (Avalonia detaches the container), when
-	// focus moves into another cell's editor, and (for a combo) when its dropdown opens. Swap back to the
-	// display and tell the coordinator the edit ended, unless the subclass keeps editing across this blur.
 	private void OnEditorLostFocus(object? sender, RoutedEventArgs e)
 	{
 		if (_editor is null || !ShouldExitOnEditorLostFocus(_editor))

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedRecipeGridView.axaml.cs
@@ -37,10 +37,7 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 		_gridNavigator = new TransposedGridNavigator(StepListBox);
 		_gridSelectionController = new TransposedGridSelectionController(StepListBox);
 
-		// The cell-presenter pool and style resources must be in place before the first layout pass
-		// realizes containers (each container's host borrows a presenter from the pool), and
-		// WhenActivated only fires on Loaded (after that pass) — so this subscription lives on the
-		// constructor, keyed off the DataContext-driven ViewModel property.
+		// Pool and style resources must exist before the first layout pass; WhenActivated fires only on Loaded, so this lives in the constructor.
 		this.WhenAnyValue(x => x.ViewModel)
 			.Subscribe(surface =>
 			{
@@ -57,12 +54,9 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 			StepListBox.ContainerPrepared += OnContainerPrepared;
 			StepListBox.ContainerClearing += OnContainerClearing;
 			StepListBox.SelectionChanged += OnSelectionChanged;
-			// Tunnel: a press inside a TextBox/ComboBox cell never bubbles to the ListBoxItem
-			// (the editor swallows it), so column selection and changed-cell click-away hook in
-			// before the editor sees the press.
+			// Tunnel: a press inside a cell editor never bubbles to the ListBoxItem, so selection/click-away must hook first.
 			StepListBox.AddHandler(PointerPressedEvent, OnGridPointerPressed, RoutingStrategies.Tunnel);
-			// Tunnel: arrow keys must not fall through to the always-live editors (a closed
-			// ComboBox cycles its value on arrows), so grid navigation intercepts first.
+			// Tunnel: arrow keys must not reach a closed ComboBox (it cycles its value on arrows).
 			AddHandler(KeyDownEvent, OnTunnelKeyDown, RoutingStrategies.Tunnel);
 
 			// Activation fires on Loaded, after the first layout pass has already realized
@@ -122,9 +116,7 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 		_stepColumnClassBinder.OnContainerClearing(e.Container);
 	}
 
-	// Re-applies the surface's selection to the ListBox. The host calls this when the view
-	// becomes active after an orientation flip: the surface received the carried-over selection
-	// while the view was flipped away, so the visual selection is stale by then.
+	// Re-applies selection after an orientation flip: the surface got the selection while the view was flipped away.
 	internal void SyncSelectionFromSurface()
 	{
 		if (ViewModel is null || StepListBox.SelectedItems is not { } selectedItems)
@@ -211,16 +203,13 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 			return;
 		}
 
-		// Header/marker presses resolve no cell: native ListBoxItem selection handles them and
-		// the pending changed cell stays armed (canonical parity: only cell presses resolve).
+		// Header/marker presses resolve no cell; the pending changed cell stays armed.
 		if (TransposedGridCellLocator.ResolveCell(source, StepListBox) is not { } pressedCell)
 		{
 			return;
 		}
 
-		// Selection is a left-button gesture (canonical parity: right/middle clicks never
-		// collapse a multi-selection); click-away resolution runs for any button, matching
-		// canonical's CellPointerPressed.
+		// Selection is left-button only; click-away resolution runs for any button.
 		if (e.GetCurrentPoint(StepListBox).Properties.IsLeftButtonPressed)
 		{
 			if (_gridSelectionController.HandleCellSelectionPress(ViewModel, pressedCell, e))
@@ -230,21 +219,13 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 		}
 		else
 		{
-			// A right/middle press over a cell must not reach the ListBoxItem's native selection (which
-			// would collapse a multi-selection). The lazy display TextBlock does not swallow it the way the
-			// always-live editor once did, so consume it here. The context menu opens off ContextRequested,
-			// which is independent of the handled state of this press.
+			// Consume a right/middle press so native ListBoxItem selection doesn't collapse the multi-selection.
 			e.Handled = true;
 		}
 
 		ResolveChangedCellClickAway(pressedCell);
 	}
 
-	// Select-then-edit under the lazy display: the selection controller reports a fall-through only on a
-	// second press of the already-single-selected column. That press builds and focuses the cell's editor
-	// (a TextBox for property-text, a ComboBox with its dropdown opened for a combo). A read-only /
-	// inapplicable cell's display is non-hit-testable, so the press never resolves to its presenter and
-	// falls through to plain column selection.
 	private void TryEnterEditFromPointer(
 		Visual source,
 		ParameterCellViewModel pressedCell,
@@ -256,9 +237,7 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 			return;
 		}
 
-		// A press inside the already-open editor must reach the live TextBox to reposition the caret, so
-		// leave it unhandled: only the entry press (a display not yet editing) is consumed. This is the
-		// tunnel phase, so a handled press never reaches the editor.
+		// A press inside the open editor must reach the TextBox to reposition the caret; only the entry press is consumed.
 		if (presenter.IsEditing)
 		{
 			return;
@@ -268,10 +247,7 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 		e.Handled = true;
 	}
 
-	// Click-away rule: a changed (orange) cell clears the moment any OTHER cell is pressed. This
-	// is not an edit, so it must run even while the surface is read-only during PLC sync — no
-	// IsReadOnly guard (mirror of CanonicalRecipeGridView.OnCellPointerPressed). The clear routes
-	// through the surface so the sibling orientation surface clears too.
+	// No IsReadOnly guard: click-away is not an edit, so it must run during PLC-sync read-only.
 	private void ResolveChangedCellClickAway(ParameterCellViewModel pressedCell)
 	{
 		var (cellToClear, newPending) = ChangedCellClickResolver.Resolve(
@@ -307,18 +283,12 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 		TransposedCellTemplateFactory.CommitByDefocusing(editor);
 	}
 
-	// Editing is defined off the coordinator, which owns the one active lazy edit for both cell kinds (the
-	// heavy editor exists only while editing). A focused display visual is NOT editing, so arrow-navigating
-	// onto a cell leaves IsEditing false and the step-level hotkeys stay live. A combo whose dropdown is
-	// open still counts (the coordinator holds it as editing until the dropdown closes and focus leaves).
+	// A focused display is NOT editing, so arrow-navigating onto a cell keeps step-level hotkeys live.
 	private Control? GetActiveEditor()
 	{
 		return _editCoordinator.ActiveEditor;
 	}
 
-	// A fresh pool per surface: the singleton view is rebound to a new surface on a config swap, whose
-	// descriptor set (and thus the built cell subtrees) differ, so presenters must not carry across.
-	// Hosts return their borrowed presenter to the pool that lent it, so the stale pool drains to GC.
 	private void BuildColumnCellsPool(TransposedRecipeGridSurface? surface)
 	{
 		// The prior surface's pooled presenters (and their editors) are discarded with the pool, so the
@@ -333,9 +303,6 @@ public partial class TransposedRecipeGridView : ReactiveUserControl<TransposedRe
 				surface.GridStyle.RowHeight);
 	}
 
-	// The step-number header cell is the transposed analog of canonical's step-number cells (cell
-	// font, per ColumnBuilder.AddNumberingColumn); the parameter-name column is the analog of
-	// canonical's column headers (header font). Both inherit through TextElement attached values.
 	private void ApplyGridStyle(GridStyleOptions gridStyle)
 	{
 		Resources[CellHeightResourceKey] = gridStyle.RowHeight;

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedStepColumnClassBinder.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedStepColumnClassBinder.cs
@@ -4,10 +4,7 @@ using Avalonia.Data;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Peer of RecipeRowExecutionClassBinder for ListBoxItem step-column containers. Unlike DataGrid
-// rows (whose value store owns the BindClass lifecycle), ListBox containers are recycled through
-// ContainerPrepared/ContainerClearing, so bindings are tracked per container and torn down on
-// clearing to avoid stacking duplicate class bindings on a recycled container.
+// ListBox containers are recycled, so class bindings are tracked per container and torn down on clearing to avoid stacking duplicates.
 internal sealed class TransposedStepColumnClassBinder
 {
 	private static readonly IReadOnlyList<(string ClassName, string BindingPath)> _classBindings =

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedTextCellPresenter.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedTextCellPresenter.cs
@@ -3,11 +3,6 @@ using Avalonia.Input;
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Lazy display/editor slot for a property-text cell. Renders a lightweight display TextBlock by default
-// and builds the full TextBox editor only when the edit coordinator enters edit here, releasing it back
-// to the display on blur/commit/recycle. This removes the always-live TextBox weight (~34 per wide
-// column) from the fresh-container build and the resident visual tree while preserving click-and-type and
-// keyboard-driven edit entry. See TransposedLazyCellPresenter for the shared machinery.
 internal sealed class TransposedTextCellPresenter : TransposedLazyCellPresenter
 {
 	public TransposedTextCellPresenter(
@@ -46,9 +41,7 @@ internal sealed class TransposedTextCellPresenter : TransposedLazyCellPresenter
 		}
 	}
 
-	// Enter edit and clear the cell so the character delivered by the paired TextInput (a separate raw
-	// event that lands on the now-focused editor) types fresh — replace semantics, matching the canonical
-	// grid. No seed here, so the char is neither dropped nor doubled.
+	// Seed '' so the paired TextInput types fresh (replace semantics); char neither dropped nor doubled.
 	protected override void OnPrintableKeyDown(KeyEventArgs e)
 	{
 		if (IsPrintable(e.KeySymbol, e.KeyModifiers))

--- a/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedTextEditCoordinator.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/Transposed/TransposedTextEditCoordinator.cs
@@ -2,22 +2,14 @@
 
 namespace SemiStep.UI.RecipeGrid.Transposed;
 
-// Owns THE ONE active lazy edit for the transposed surface across both cell kinds. Property-text and
-// ComboBox cells render a lightweight display by default (TransposedLazyCellPresenter subclasses); the
-// heavy TextBox / ComboBox editor is built only when this coordinator enters edit on a cell, and released
-// back to the display on exit. A single active edit gives one place to reset on cell change, on blur, and
-// before a pooled presenter is recycled, and one definition of "editing" for the view's exit gating.
 internal sealed class TransposedTextEditCoordinator
 {
 	private TransposedLazyCellPresenter? _active;
 
-	// The live editor of the current edit (a TextBox or a ComboBox), or null when no cell is being edited.
-	// A focused display visual is NOT editing; only a built-and-editing presenter counts.
+	// A focused display is NOT editing; only a built-and-editing presenter counts.
 	public Control? ActiveEditor => _active is { IsEditing: true } presenter ? presenter.Editor : null;
 
-	// Enters edit on a cell: swaps its display for the editor, focuses it, and applies the entry state
-	// (see the subclass OnEnteredEdit). initialText is meaningful only to the text cell; the combo ignores
-	// it. Focusing the new editor blurs any previous one, which self-exits.
+	// Focusing the new editor blurs any previous one, which self-exits.
 	public void BeginEdit(TransposedLazyCellPresenter presenter, string? initialText)
 	{
 		if (!presenter.CanEnterEdit)
@@ -35,9 +27,7 @@ internal sealed class TransposedTextEditCoordinator
 		presenter.EnterEdit(initialText);
 	}
 
-	// Called by a presenter whose editor lost focus (blur / commit / recycle). Clears the active slot only
-	// when it is still the one that ended, so a focus MOVE into a new edit (which blurs the old one after
-	// _active has already advanced) does not wipe the newly active edit.
+	// Clear only when still the active slot, so a focus MOVE into a new edit doesn't wipe it.
 	public void NotifyEditEnded(TransposedLazyCellPresenter presenter)
 	{
 		if (ReferenceEquals(_active, presenter))
@@ -46,8 +36,7 @@ internal sealed class TransposedTextEditCoordinator
 		}
 	}
 
-	// Drops the active edit reference without touching visuals; used when the view is rebound to a new
-	// surface and the pooled presenters (and their editors) are discarded.
+	// Drops the active edit without touching visuals (pooled presenters are discarded on surface rebind).
 	public void Reset()
 	{
 		_active = null;


### PR DESCRIPTION
Round 3 of the transposed grid work: fix a fragile selection binding leg and unify the diagnostics channel.

- Replace the `RelativeSource FindAncestor ListBoxItem` cell-selection leg (which logged ~1155 `Ancestor not found` binding errors on scroll and froze the debugger) with a presenter-sourced `IsColumnSelected` property, synced imperatively from the container
- Forward Avalonia framework diagnostics to Serilog instead of `LogToTrace` (structured, throttled, min Warning)
- Add a headless `BindingErrorGuard` for zero-binding-error regression coverage

Correctness + logging infra, not the felt lag. Stacked on the realize-cost PR — **base is `transposed-grid-realize-cost-reduction`**; merge last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
