### PR TITLE
fix: perf workflow YAML parse error (line 46)

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -43,7 +43,8 @@ jobs:
       # Dev-testbed byte baselines are not comparable here: an empty metrics document flips byte gates to
       # record-only; invariant/ratio gates (thresholds in probe code) keep asserting. See Docs/perf/README.md, CI.
       - name: neutralize byte baselines (telemetry-only on CI)
-        run: echo '{ "context": { "testbed": "ci-hosted" }, "metrics": {} }' > Docs/perf/baselines.json
+        run: |
+          echo '{ "context": { "testbed": "ci-hosted" }, "metrics": {} }' > Docs/perf/baselines.json
 
       - name: run perf gates
         run: dotnet run --project SemiStep/SemiStep.Tests/SemiStep.Tests.csproj -c Release --no-build -- -explicit only


### PR DESCRIPTION
GitHub rejected `.github/workflows/perf.yml` at parse time: a plain scalar after `run:` cannot contain `: ` inside the echoed JSON (`"testbed": "ci-hosted"` read as a nested mapping). Converted the step to a block scalar; `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)