### PR TITLE
build(repo): move the solution to the repository root

### DIFF
--- a/.claude/skills/make-release/SKILL.md
+++ b/.claude/skills/make-release/SKILL.md
@@ -118,7 +118,7 @@ Then re-run from Step 3 with the corrected version or message.
 Do not run this unless the user asks. Commands to build the installer locally:
 
 ```powershell
-dotnet clean SemiStep/SemiStep.slnx -c Release
+dotnet clean SemiStep.slnx -c Release
 dotnet publish SemiStep/SemiStep.UI/SemiStep.UI.csproj -c Release -p:Version=<version>
 & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=<version> Installer\SemiStep.iss
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
           global-json-file: global.json
 
       - name: restore
-        run: dotnet restore SemiStep/SemiStep.slnx
+        run: dotnet restore SemiStep.slnx
 
       - name: build
-        run: dotnet build SemiStep/SemiStep.slnx -c Release --no-restore
+        run: dotnet build SemiStep.slnx -c Release --no-restore
 
       - name: test
         run: dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"

--- a/.run/Debug MBE.run.xml
+++ b/.run/Debug MBE.run.xml
@@ -1,9 +1,9 @@
-<component name="ProjectRunConfigurationManager">
+﻿<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug MBE" type="DotNetProject" factoryName=".NET Project">
     <log_file alias="semistep.log" path="$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log" checked="true" skipped_content="true" />
-    <option name="EXE_PATH" value="$PROJECT_DIR$/Artifacts/bin/SemiStep.UI/debug/SemiStep.UI.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--config-dir &quot;$PROJECT_DIR$/../ConfigFiles/MBE&quot; --log-file &quot;$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log&quot; --logging-level verbose" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Artifacts/bin/SemiStep.UI/debug" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/SemiStep/Artifacts/bin/SemiStep.UI/debug/SemiStep.UI.exe" />
+    <option name="PROGRAM_PARAMETERS" value="--config-dir &quot;$PROJECT_DIR$/ConfigFiles/MBE&quot; --log-file &quot;$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log&quot; --logging-level verbose" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SemiStep/Artifacts/bin/SemiStep.UI/debug" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="ENV_FILE_PATHS" value="" />
     <option name="REDIRECT_INPUT_PATH" value="" />
@@ -11,7 +11,7 @@
     <option name="USE_MONO" value="0" />
     <option name="RUNTIME_ARGUMENTS" value="" />
     <option name="AUTO_ATTACH_CHILDREN" value="0" />
-    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SemiStep.UI/SemiStep.UI.csproj" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SemiStep/SemiStep.UI/SemiStep.UI.csproj" />
     <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />

--- a/.run/Debug MOCVD.run.xml
+++ b/.run/Debug MOCVD.run.xml
@@ -1,9 +1,9 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Debug RIE" type="DotNetProject" factoryName=".NET Project">
+﻿<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug MOCVD" type="DotNetProject" factoryName=".NET Project">
     <log_file alias="semistep.log" path="$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log" />
-    <option name="EXE_PATH" value="$PROJECT_DIR$/Artifacts/bin/SemiStep.UI/debug/SemiStep.UI.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--config-dir &quot;$PROJECT_DIR$/../ConfigFiles/RIE&quot; --log-file &quot;$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log&quot; --logging-level verbose" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Artifacts/bin/SemiStep.UI/debug" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/SemiStep/Artifacts/bin/SemiStep.UI/debug/SemiStep.UI.exe" />
+    <option name="PROGRAM_PARAMETERS" value="--config-dir &quot;$PROJECT_DIR$/ConfigFiles/MOCVD&quot; --log-file &quot;$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log&quot; --logging-level verbose" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SemiStep/Artifacts/bin/SemiStep.UI/debug" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="ENV_FILE_PATHS" value="" />
     <option name="REDIRECT_INPUT_PATH" value="" />
@@ -11,7 +11,7 @@
     <option name="USE_MONO" value="0" />
     <option name="RUNTIME_ARGUMENTS" value="" />
     <option name="AUTO_ATTACH_CHILDREN" value="0" />
-    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SemiStep.UI/SemiStep.UI.csproj" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SemiStep/SemiStep.UI/SemiStep.UI.csproj" />
     <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />

--- a/.run/Debug RIE.run.xml
+++ b/.run/Debug RIE.run.xml
@@ -1,9 +1,9 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Debug MOCVD" type="DotNetProject" factoryName=".NET Project">
+﻿<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug RIE" type="DotNetProject" factoryName=".NET Project">
     <log_file alias="semistep.log" path="$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log" />
-    <option name="EXE_PATH" value="$PROJECT_DIR$/Artifacts/bin/SemiStep.UI/debug/SemiStep.UI.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--config-dir &quot;$PROJECT_DIR$/../ConfigFiles/MOCVD&quot; --log-file &quot;$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log&quot; --logging-level verbose" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Artifacts/bin/SemiStep.UI/debug" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/SemiStep/Artifacts/bin/SemiStep.UI/debug/SemiStep.UI.exe" />
+    <option name="PROGRAM_PARAMETERS" value="--config-dir &quot;$PROJECT_DIR$/ConfigFiles/RIE&quot; --log-file &quot;$USER_HOME$/AppData/Local/Temp/Semistep/semistep.log&quot; --logging-level verbose" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SemiStep/Artifacts/bin/SemiStep.UI/debug" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="ENV_FILE_PATHS" value="" />
     <option name="REDIRECT_INPUT_PATH" value="" />
@@ -11,7 +11,7 @@
     <option name="USE_MONO" value="0" />
     <option name="RUNTIME_ARGUMENTS" value="" />
     <option name="AUTO_ATTACH_CHILDREN" value="0" />
-    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SemiStep.UI/SemiStep.UI.csproj" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SemiStep/SemiStep.UI/SemiStep.UI.csproj" />
     <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />

--- a/.run/Perf Gates.run.xml
+++ b/.run/Perf Gates.run.xml
@@ -1,8 +1,8 @@
-<component name="ProjectRunConfigurationManager">
+﻿<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Perf Gates" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/Artifacts/bin/SemiStep.Tests/release/SemiStep.Tests.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/SemiStep/Artifacts/bin/SemiStep.Tests/release/SemiStep.Tests.exe" />
     <option name="PROGRAM_PARAMETERS" value="-explicit only" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Artifacts/bin/SemiStep.Tests/release" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SemiStep/Artifacts/bin/SemiStep.Tests/release" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="ENV_FILE_PATHS" value="" />
     <option name="REDIRECT_INPUT_PATH" value="" />
@@ -10,7 +10,7 @@
     <option name="USE_MONO" value="0" />
     <option name="RUNTIME_ARGUMENTS" value="" />
     <option name="AUTO_ATTACH_CHILDREN" value="0" />
-    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SemiStep.Tests/SemiStep.Tests.csproj" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SemiStep/SemiStep.Tests/SemiStep.Tests.csproj" />
     <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />

--- a/.run/Publish.run.xml
+++ b/.run/Publish.run.xml
@@ -1,8 +1,8 @@
 ﻿<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="dotnet_restore" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="dotnet restore SemiStep.slnx" />
-    <option name="INDEPENDENT_SCRIPT_PATH" value="false" />
-    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/../.run/dotnet_restore.ps1" />
+  <configuration default="false" name="publish" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="dotnet publish SemiStep/SemiStep.UI/SemiStep.UI.csproj -c Release 2&gt;&amp;1" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
     <option name="SCRIPT_OPTIONS" value="" />
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
@@ -12,6 +12,8 @@
     <option name="EXECUTE_IN_TERMINAL" value="true" />
     <option name="EXECUTE_SCRIPT_FILE" value="false" />
     <envs />
-    <method v="2" />
+    <method v="2">
+      <option name="CleanSolution" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.run/dotnet_restore.run.xml
+++ b/.run/dotnet_restore.run.xml
@@ -1,8 +1,8 @@
 ﻿<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="publish" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="dotnet publish UI/SemiStep.UI.csproj -c Release 2&gt;&amp;1" />
-    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
-    <option name="SCRIPT_PATH" value="" />
+  <configuration default="false" name="dotnet_restore" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="dotnet restore SemiStep.slnx" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="false" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/.run/dotnet_restore.ps1" />
     <option name="SCRIPT_OPTIONS" value="" />
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
@@ -12,8 +12,6 @@
     <option name="EXECUTE_IN_TERMINAL" value="true" />
     <option name="EXECUTE_SCRIPT_FILE" value="false" />
     <envs />
-    <method v="2">
-      <option name="CleanSolution" enabled="true" />
-    </method>
+    <method v="2" />
   </configuration>
 </component>

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -11,7 +11,7 @@
   {
     "label": "Build Solution",
     "command": "dotnet",
-    "args": ["build", "SemiStep/SemiStep.slnx"],
+    "args": ["build", "SemiStep.slnx"],
     "cwd": "$ZED_WORKTREE_ROOT",
   },
   {
@@ -58,7 +58,7 @@
   {
     "label": "format",
     "command": "dotnet",
-    "args": ["format", "SemiStep/SemiStep.slnx"],
+    "args": ["format", "SemiStep.slnx"],
     "cwd": "$ZED_WORKTREE_ROOT",
   },
   {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,15 @@
 
 SemiStep is a recipe table editor/runtime for PLC integration (S7 protocol).
 Platform: .NET 10, Windows, C# 14. UI: Avalonia 12.0.3 + ReactiveUI (MVVM).
-Solution: `SemiStep/SemiStep.slnx`. All commands run from repository root.
+Solution: `SemiStep.slnx`. All commands run from repository root.
 
 ## Build
 
 ```powershell
 dotnet build SemiStep/SemiStep.UI/SemiStep.UI.csproj            # recommended (entry executable)
-dotnet build SemiStep/SemiStep.slnx                    # all projects
+dotnet build SemiStep.slnx                    # all projects
 dotnet run   --project SemiStep/SemiStep.UI/SemiStep.UI.csproj
-dotnet format SemiStep/SemiStep.slnx                   # pre-commit hook enforces this
+dotnet format SemiStep.slnx                   # pre-commit hook enforces this
 ```
 
 ## Test

--- a/SemiStep.slnx
+++ b/SemiStep.slnx
@@ -1,0 +1,5 @@
+<Solution>
+    <Project Path="SemiStep/SemiStep.Core/SemiStep.Core.csproj" />
+    <Project Path="SemiStep/SemiStep.Tests/SemiStep.Tests.csproj" />
+    <Project Path="SemiStep/SemiStep.UI/SemiStep.UI.csproj" />
+</Solution>

--- a/SemiStep/SemiStep.slnx
+++ b/SemiStep/SemiStep.slnx
@@ -1,5 +1,0 @@
-<Solution>
-    <Project Path="SemiStep.Core/SemiStep.Core.csproj" />
-    <Project Path="SemiStep.Tests/SemiStep.Tests.csproj" />
-    <Project Path="SemiStep.UI/SemiStep.UI.csproj" />
-</Solution>


### PR DESCRIPTION
## Problem

Rider takes the solution's own directory as the project root. With `SemiStep.slnx` under
`SemiStep/`, everything above it — `Docs/`, `Installer/`, `.github/`, `.zed/` — sat outside the
project, and the IDE's MCP server enforces that boundary. It refused to open files under
`Docs/plans/`, which is where every plan in this repository lives.

Underneath that, the layout did not match the .NET convention: the solution belongs at the
repository root with the projects beneath it, which is also what `CLAUDE.md` already claimed
with "all commands run from repository root". The nested form came from the Visual Studio
template default rather than from a decision.

## What changed

- `SemiStep/SemiStep.slnx` → `SemiStep.slnx`, project paths prefixed with `SemiStep/`
- `SemiStep/.run/` → `.run/`. Rider looks for run configurations under the project root, and
  every configuration resolved `$PROJECT_DIR$` as `SemiStep/`, so the csproj, `Artifacts` and
  `ConfigFiles` paths inside them are rebased
- `.github/workflows/ci.yml`, `.zed/tasks.json`, `CLAUDE.md`, `.claude/skills/make-release/SKILL.md`
  follow the new solution path
- `Publish.run.xml` was already broken before this change — it ran `dotnet publish` against
  `UI/SemiStep.UI.csproj`, a path that does not exist here — and is corrected rather than moved
  as-is

`Directory.Build.props` and `Directory.Packages.props` deliberately stay under `SemiStep/`.
MSBuild resolves them upward from each csproj rather than from the solution, so the build is
unaffected and the change stays minimal.

## Verification

From the repository root:

- `dotnet build SemiStep.slnx -c Release` — 0 warnings, 0 errors
- `dotnet format SemiStep.slnx --verify-no-changes` — clean
- `dotnet test SemiStep.slnx` — 1444 passed, 0 failed

The IDE boundary is confirmed fixed: the MCP server now opens files under `Docs/` with the
repository root as the project path, which it refused before.

## Note for reviewers

`.git/hooks/pre-commit` is not versioned and still calls `dotnet format` with the old solution
path on any machine that has it installed. Update it locally after pulling.
