### PR TITLE
fix(ui): guard unhandled UI command exception paths (#113)

### DIFF
--- a/Docs/architecture/error-reporting.md
+++ b/Docs/architecture/error-reporting.md
@@ -72,6 +72,23 @@ Modal dialogs are the exception: `GridStyleEditorViewModel.SaveCommand` surfaces
 editor's own `ErrorMessage` property (and logs), not the shared panel, because a modal owns its error
 surface while it is open.
 
+## Invoking a command imperatively
+
+When code fires a command directly rather than through a bound control (a hotkey handler, for example),
+invoke it through `ExecuteIfPossible` (`SemiStep.UI/Reactive/CommandInvocationExtensions.cs`), never
+through `ReactiveCommand.Execute()`. `ExecuteIfPossible` routes through `ICommand.Execute`, which keeps
+the command inside the reporting boundary: a fault still reaches `ThrownExceptions`, so the report+log
+ring above (or the global backstop below) handles it, and nothing rethrows on the caller thread. It also
+honors `canExecute` — `ReactiveCommand.Execute()` ignores the guard and runs anyway — and, because
+`ICommand.CanExecute` is false while a command is executing, it suppresses re-entrant invocation during
+an in-flight command. A raw `.Execute().Subscribe()` with no `onError` bypasses all three: the second
+delivery channel (the `Execute()` observable's `OnError`) rethrows inside the dispatcher and unwinds to
+`Program.Main`, killing the process.
+
+The two async-void dialog paths (`OnWindowClosing`, `OnSaveCompleted`) carry their own try/catch guards.
+Those are the current cover for dialog faults the global backstop cannot catch: it installs no Avalonia
+dispatcher hook, so an async-void throw would otherwise unwind the dispatcher into `Program.Main`.
+
 ## Global backstop (last-resort ring)
 
 The per-command pipe above catches faults on a *subscribed* `ThrownExceptions`. What escapes every

--- a/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
+++ b/SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs
@@ -145,7 +145,11 @@ public sealed class UIFixture : IAsyncLifetime
 	{
 		var grid = CreateActiveSurface();
 
-		var commands = new RecipeCommandsViewModel(Coordinator, grid);
+		var commands = new RecipeCommandsViewModel(
+			Coordinator,
+			grid,
+			MessagePanel,
+			NullLogger<RecipeCommandsViewModel>.Instance);
 
 		var clipboardSerializer = new ClipboardSerializer(RecipeMetadataRegistry);
 		var importedRecipeValidator = new ImportedRecipeValidator(RecipeMetadataRegistry);

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowExitFlowTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowExitFlowTests.cs
@@ -110,6 +110,29 @@ public sealed class MainWindowExitFlowTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
+	public async Task ShowExitChoice_DialogShowThrows_ContainsFaultAndReports()
+	{
+		// An unshown owner makes ExitConfirmationDialog.ShowDialog(this) throw, standing in for any
+		// fault in the async-void closing path. Without the guard the throw escapes the async void
+		// event handler and crashes the process.
+		var viewModel = _fixture.CreateMainWindowViewModel();
+		try
+		{
+			var window = new MainWindowView { ViewModel = viewModel };
+
+			await window.ShowExitChoiceAsync();
+
+			var errorEntry = viewModel.MessagePanel.Entries
+				.Should().ContainSingle(e => e.Severity == MessageSeverity.Error).Subject;
+			errorEntry.Message.Should().StartWith("Exit failed:");
+		}
+		finally
+		{
+			viewModel.Dispose();
+		}
+	}
+
+	[AvaloniaFact]
 	public async Task HandleExitChoice_DontSave_ClosesWindow()
 	{
 		await _window.HandleExitChoiceAsync(ExitConfirmationResult.DontSave);

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowHotkeyTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowHotkeyTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Windows.Input;
+
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using ReactiveUI;
+
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.MainWindow;
+using SemiStep.UI.MessageService;
+using SemiStep.UI.Reactive;
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.MainWindow;
+
+[Trait("Component", "UI")]
+[Trait("Area", "MainWindow")]
+[Trait("Category", "Integration")]
+public sealed class MainWindowHotkeyTests : IAsyncLifetime
+{
+	private readonly UIFixture _fixture = new();
+	private MainWindowViewModel _viewModel = null!;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_viewModel = _fixture.CreateMainWindowViewModel();
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_viewModel.Dispose();
+		return _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public void Hotkey_WhenCommandThrows_DoesNotRethrowAndReportsOnce()
+	{
+		var failure = new InvalidOperationException("boom");
+		var grid = (ActiveRecipeGridSurface)_viewModel.RecipeGrid;
+
+		// The flip raises Orientation; a throwing observer on that change faults the command body,
+		// driving the exception into ToggleOrientationCommand.ThrownExceptions.
+		using var poison = grid.WhenAnyValue(x => x.Orientation)
+			.Skip(1)
+			.Subscribe(_ => throw failure);
+
+		var invoke = () => _viewModel.ToggleOrientationCommand.ExecuteIfPossible();
+
+		invoke.Should().NotThrow("ExecuteIfPossible swallows the caller-thread rethrow that would crash the app");
+
+		_fixture.MessagePanel.Entries.Should().ContainSingle(
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Orientation toggle failed: boom");
+	}
+
+	[AvaloniaFact]
+	public void DeleteHotkey_WhenCanEditFalse_DoesNotMutateRecipe()
+	{
+		_fixture.SeedRecipe(2);
+		_viewModel.RecipeGrid.Initialize();
+		_viewModel.RecipeGrid.UpdateSelection(new[] { 0 });
+
+		var deleteCommand = _viewModel.RecipeCommands.DeleteStepCommand;
+		((ICommand)deleteCommand).CanExecute(null).Should().BeTrue("precondition: editable with a step selected");
+
+		_fixture.SetRecipeActive(true);
+		((ICommand)deleteCommand).CanExecute(null).Should().BeFalse("a running recipe disables editing");
+
+		deleteCommand.ExecuteIfPossible();
+
+		_fixture.Coordinator.CurrentRecipe.Steps.Should()
+			.HaveCount(2, "the gated hotkey must stay inert while canEdit is false");
+	}
+
+	[AvaloniaFact]
+	public void DeleteHotkey_WhenCanEditTrue_DeletesSelectedStep()
+	{
+		_fixture.SeedRecipe(2);
+		_viewModel.RecipeGrid.Initialize();
+		_viewModel.RecipeGrid.UpdateSelection(new[] { 0 });
+
+		_viewModel.RecipeCommands.DeleteStepCommand.ExecuteIfPossible();
+
+		_fixture.Coordinator.CurrentRecipe.Steps.Should()
+			.HaveCount(1, "ExecuteIfPossible must run the command when canExecute is true");
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowViewModelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowViewModelReportingTests.cs
@@ -1,15 +1,21 @@
 ﻿using System;
+using System.Reactive.Linq;
 
 using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
+using FluentResults;
+
 using Microsoft.Extensions.Logging;
+
+using ReactiveUI;
 
 using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.MessageService;
+using SemiStep.UI.RecipeGrid;
 
 using Xunit;
 
@@ -69,5 +75,54 @@ public sealed class MainWindowViewModelReportingTests : IAsyncLifetime
 		var logged = _logger.Entries.Should().ContainSingle().Subject;
 		logged.Level.Should().Be(LogLevel.Error);
 		logged.Exception.Should().BeSameAs(failure);
+	}
+
+	[AvaloniaFact]
+	public async Task ToggleOrientation_WhenFlipThrows_ReportsErrorToPanelAndLogs()
+	{
+		var failure = new InvalidOperationException("boom");
+		var grid = (ActiveRecipeGridSurface)_viewModel.RecipeGrid;
+
+		// The flip raises Orientation; a throwing observer on that change makes the command body
+		// fault, driving the exception into ToggleOrientationCommand.ThrownExceptions.
+		using var poison = grid.WhenAnyValue(x => x.Orientation)
+			.Skip(1)
+			.Subscribe(_ => throw failure);
+
+		try
+		{
+			await _viewModel.ToggleOrientationCommand.Execute();
+		}
+		catch (InvalidOperationException)
+		{
+			// Routed to ThrownExceptions; awaiting also surfaces it here.
+		}
+
+		_fixture.MessagePanel.Entries.Should().ContainSingle(
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Orientation toggle failed: boom");
+
+		var logged = _logger.Entries.Should().ContainSingle().Subject;
+		logged.Level.Should().Be(LogLevel.Error);
+		logged.Exception.Should().BeSameAs(failure);
+	}
+
+	[AvaloniaFact]
+	public void Guarded_ConflictResolutionBody_WhenResultFails_ReportsFailedResultToPanel()
+	{
+		// Mirrors the HandleConflictAsync call site: a failed resolution Result must land a panel
+		// entry rather than being dropped. Guarded's own throw-containment is proven above.
+		var result = Result.Fail("resolution rejected");
+
+		_viewModel.Guarded("PLC conflict resolution failed", () =>
+		{
+			if (result.IsFailed)
+			{
+				_viewModel.MessagePanel.ReportFailure(result);
+			}
+		});
+
+		_fixture.MessagePanel.Entries.Should()
+			.ContainSingle(entry => entry.Severity == MessageSeverity.Error)
+			.Which.Message.Should().Be("resolution rejected");
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/Reactive/CommandInvocationExtensionsTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Reactive/CommandInvocationExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Linq;
+
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using ReactiveUI;
+
+using SemiStep.UI.Reactive;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.Reactive;
+
+[Trait("Component", "UI")]
+[Trait("Area", "CommandInvocation")]
+[Trait("Category", "Unit")]
+public sealed class CommandInvocationExtensionsTests
+{
+	[AvaloniaFact]
+	public void ExecuteIfPossible_ThrowingCommand_DoesNotRethrowAndFiresThrownExceptionsOnce()
+	{
+		var failure = new InvalidOperationException("boom");
+		var command = ReactiveCommand.Create<Unit, Unit>(_ => throw failure);
+
+		try
+		{
+			var thrown = 0;
+			Exception? captured = null;
+			using var subscription = command.ThrownExceptions.Subscribe(ex =>
+			{
+				thrown++;
+				captured = ex;
+			});
+
+			var invoke = () => command.ExecuteIfPossible();
+
+			invoke.Should().NotThrow();
+			thrown.Should().Be(1);
+			captured.Should().BeSameAs(failure);
+		}
+		finally
+		{
+			command.Dispose();
+		}
+	}
+
+	[AvaloniaFact]
+	public void ExecuteIfPossible_CanExecuteFalse_DoesNotRunCommandBody()
+	{
+		var executions = 0;
+		var command = ReactiveCommand.Create<Unit, Unit>(
+			_ =>
+			{
+				executions++;
+				return Unit.Default;
+			},
+			Observable.Return(false));
+
+		try
+		{
+			command.ExecuteIfPossible();
+
+			executions.Should().Be(0);
+		}
+		finally
+		{
+			command.Dispose();
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs
@@ -4,6 +4,8 @@ using Avalonia.Headless.XUnit;
 
 using FluentAssertions;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
@@ -27,7 +29,11 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 		await _fixture.InitializeAsync();
 		_surface = _fixture.CreateCanonicalSurface();
 		_surface.Initialize();
-		_commands = new RecipeCommandsViewModel(_fixture.Coordinator, _surface);
+		_commands = new RecipeCommandsViewModel(
+			_fixture.Coordinator,
+			_surface,
+			_fixture.MessagePanel,
+			NullLogger<RecipeCommandsViewModel>.Instance);
 	}
 
 	public async ValueTask DisposeAsync()
@@ -106,7 +112,11 @@ public sealed class RecipeCommandsViewModelCanExecuteTests : IAsyncLifetime
 		_fixture.Coordinator.AppendStep(RecipeTestDriver.WaitActionId);
 		_surface.UpdateSelection(new[] { 0 });
 
-		using var commands = new RecipeCommandsViewModel(_fixture.Coordinator, _surface);
+		using var commands = new RecipeCommandsViewModel(
+			_fixture.Coordinator,
+			_surface,
+			_fixture.MessagePanel,
+			NullLogger<RecipeCommandsViewModel>.Instance);
 
 		((ICommand)commands.DeleteStepCommand).CanExecute(null).Should().BeTrue();
 	}

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelReportingTests.cs
@@ -1,0 +1,140 @@
+﻿using System.Reactive;
+using System.Reactive.Linq;
+
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging;
+
+using ReactiveUI;
+
+using SemiStep.Core.Recipes;
+
+using SemiStep.Tests.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.MessageService;
+using SemiStep.UI.RecipeGrid;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.RecipeGrid;
+
+[Trait("Component", "UI")]
+[Trait("Area", "RecipeGrid")]
+[Trait("Category", "Integration")]
+public sealed class RecipeCommandsViewModelReportingTests : IAsyncLifetime
+{
+	private readonly UIFixture _fixture = new();
+	private readonly RecordingLogger<RecipeCommandsViewModel> _logger = new();
+	private readonly StubRecipeGridSurface _surface = new();
+	private RecipeCommandsViewModel _commands = null!;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_commands = new RecipeCommandsViewModel(
+			_fixture.Coordinator,
+			_surface,
+			_fixture.MessagePanel,
+			_logger);
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		_commands.Dispose();
+		await _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public async Task AddStep_WhenCommandBodyThrows_ReportsSpecificContextAndLogs()
+	{
+		var failure = new InvalidOperationException("boom");
+		_surface.SelectedStepIndex = -1;
+		_surface.RequestSelectionException = failure;
+
+		await ExecuteSwallowing(_commands.AddStepCommand);
+
+		_fixture.MessagePanel.Entries.Should()
+			.Contain(e => e.IsError && e.Message.StartsWith("Add step failed:") && e.Message.Contains("boom"));
+
+		var logged = _logger.Entries.Should().ContainSingle().Subject;
+		logged.Level.Should().Be(LogLevel.Error);
+		logged.Message.Should().Be("Add step failed");
+		logged.Exception.Should().BeSameAs(failure);
+	}
+
+	[AvaloniaFact]
+	public async Task DeleteStep_WhenCoordinatorRejectsIndex_ReportsFailedResultToPanel()
+	{
+		_fixture.SeedRecipe(2);
+
+		var expected = _fixture.Coordinator.RemoveStep(99);
+		expected.IsFailed.Should().BeTrue();
+		var expectedMessage = expected.FormatErrors();
+
+		_surface.SelectedStepIndices = new[] { 99 };
+
+		await ExecuteSwallowing(_commands.DeleteStepCommand);
+
+		_fixture.MessagePanel.Entries.Should()
+			.ContainSingle(e => e.IsError).Which.Message.Should().Be(expectedMessage);
+	}
+
+	private static async Task ExecuteSwallowing(ReactiveCommand<Unit, Unit> command)
+	{
+		try
+		{
+			await command.Execute();
+		}
+		catch (Exception)
+		{
+			// The command routes the throw to ThrownExceptions; Execute also rethrows to the awaiter.
+		}
+	}
+
+	private sealed class StubRecipeGridSurface : IRecipeGridSurface
+	{
+		public int SelectedStepIndex { get; set; } = -1;
+
+		public IReadOnlyList<int> SelectedStepIndices { get; set; } = Array.Empty<int>();
+
+		public Exception? RequestSelectionException { get; set; }
+
+		public int StepCount => 0;
+
+		public bool IsReadOnly => false;
+
+		public IObservable<int?> SelectionRequests => Observable.Never<int?>();
+
+		public IObservable<bool> CanDeleteStep => Observable.Return(true);
+
+		public IObservable<Unit> EditorMustClose => Observable.Never<Unit>();
+
+		public void Initialize()
+		{
+		}
+
+		public void UpdateSelection(IReadOnlyList<int> stepIndices)
+		{
+		}
+
+		public void RequestSelection(int? stepIndex)
+		{
+			if (RequestSelectionException is not null)
+			{
+				throw RequestSelectionException;
+			}
+		}
+
+		public IReadOnlyList<Step> CollectSelectedSteps()
+		{
+			return Array.Empty<Step>();
+		}
+
+		public void Dispose()
+		{
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/StyleEditor/GridStyleEditorWindowOwnerRoutingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/StyleEditor/GridStyleEditorWindowOwnerRoutingTests.cs
@@ -145,6 +145,31 @@ public sealed class GridStyleEditorWindowOwnerRoutingTests : IAsyncLifetime
 		_mainWindow.IsVisible.Should().BeFalse("Exit Now on a clean owner cascades to close through the guard");
 	}
 
+	[AvaloniaFact]
+	public async Task OnSaveCompleted_RestartPromptThrows_ContainsFaultAndReports()
+	{
+		using var tempDir = CopyShippedConfig("MBE");
+		var facade = new GridStyleEditorFacade();
+		var loaded = (await facade.Load(tempDir.Path)).Value;
+		var viewModel = new GridStyleEditorViewModel(
+			facade,
+			tempDir.Path,
+			loaded,
+			NullLogger<GridStyleEditorViewModel>.Instance);
+
+		// The editor is never shown, so RestartPromptDialog.ShowDialog(owner) throws on an
+		// invisible owner. That stands in for any fault in the async-void restart-prompt path:
+		// without the guard the throw would escape the async void and crash the process.
+		var editor = new GridStyleEditorWindow { ViewModel = viewModel };
+
+		editor.OnSaveCompleted(true);
+		Dispatcher.UIThread.RunJobs();
+
+		viewModel.ErrorMessage.Should().StartWith(
+			"Save failed:",
+			"the fault must surface on the editor's own error surface instead of crashing the app");
+	}
+
 	private GridStyleEditorWindow ShowEditorOwnedByMainWindow()
 	{
 		var editor = new GridStyleEditorWindow();

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Platform.Storage;
 using ReactiveUI;
 using ReactiveUI.Avalonia;
 
+using SemiStep.UI.Reactive;
 using SemiStep.UI.ShutdownService;
 
 namespace SemiStep.UI.MainWindow;
@@ -58,7 +59,7 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 		// outside the IsEditing gate.
 		if (e.Key == Key.T && e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift))
 		{
-			ViewModel.ToggleOrientationCommand.Execute().Subscribe();
+			ViewModel.ToggleOrientationCommand.ExecuteIfPossible();
 			e.Handled = true;
 
 			return;
@@ -69,25 +70,25 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 			switch (e.Key)
 			{
 				case Key.Delete:
-					ViewModel.RecipeCommands.DeleteStepCommand.Execute().Subscribe();
+					ViewModel.RecipeCommands.DeleteStepCommand.ExecuteIfPossible();
 					e.Handled = true;
 
 					return;
 
 				case Key.C when e.KeyModifiers == KeyModifiers.Control:
-					ViewModel.Clipboard.CopyStepCommand.Execute().Subscribe();
+					ViewModel.Clipboard.CopyStepCommand.ExecuteIfPossible();
 					e.Handled = true;
 
 					return;
 
 				case Key.X when e.KeyModifiers == KeyModifiers.Control:
-					ViewModel.Clipboard.CutStepCommand.Execute().Subscribe();
+					ViewModel.Clipboard.CutStepCommand.ExecuteIfPossible();
 					e.Handled = true;
 
 					return;
 
 				case Key.V when e.KeyModifiers == KeyModifiers.Control:
-					ViewModel.Clipboard.PasteStepCommand.Execute().Subscribe();
+					ViewModel.Clipboard.PasteStepCommand.ExecuteIfPossible();
 					e.Handled = true;
 
 					return;
@@ -125,6 +126,11 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
 		e.Cancel = true;
 
+		await ShowExitChoiceAsync();
+	}
+
+	internal async Task ShowExitChoiceAsync()
+	{
 		_exitChoiceInProgress = true;
 		try
 		{
@@ -132,6 +138,13 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 			var result = await dialog.ShowDialog<ExitConfirmationResult>(this);
 
 			await HandleExitChoiceAsync(result);
+		}
+		catch (Exception ex)
+		{
+			// Reached from an async void event handler: an unhandled throw here unwinds the
+			// dispatcher loop into Program.Main and kills the process. Contain it, report,
+			// and keep the window open (e.Cancel is already true at the call site).
+			ViewModel?.MessagePanel.ReportError($"Exit failed: {ex.Message}");
 		}
 		finally
 		{

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
@@ -74,6 +74,9 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		OpenStyleEditorCommand.ReportThrownExceptions(MessagePanel, _logger, "Style editor failed")
 			.DisposeWith(_disposables);
 
+		ToggleOrientationCommand.ReportThrownExceptions(MessagePanel, _logger, "Orientation toggle failed")
+			.DisposeWith(_disposables);
+
 		_coordinator.Mutated += OnCoordinatorMutated;
 		_disposables.Add(Disposable.Create(() => _coordinator.Mutated -= OnCoordinatorMutated));
 
@@ -237,12 +240,17 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
-		var result = _coordinator.ResolveConflict(dialog.KeepLocal);
-
-		if (result.IsFailed)
+		// The conflict callback runs fire-and-forget, so a throw in the post-dialog resolution would
+		// fault the discarded task and surface only through the nondeterministic TaskScheduler hook.
+		Guarded("PLC conflict resolution failed", () =>
 		{
-			MessagePanel.ReportFailure(result);
-		}
+			var result = _coordinator.ResolveConflict(dialog.KeepLocal);
+
+			if (result.IsFailed)
+			{
+				MessagePanel.ReportFailure(result);
+			}
+		});
 	}
 
 	private void OnCoordinatorMutated(MutationSignal signal)

--- a/SemiStep/SemiStep.UI/Reactive/CommandInvocationExtensions.cs
+++ b/SemiStep/SemiStep.UI/Reactive/CommandInvocationExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Reactive;
+using System.Windows.Input;
+
+using ReactiveUI;
+
+namespace SemiStep.UI.Reactive;
+
+public static class CommandInvocationExtensions
+{
+	// ICommand.Execute on a ReactiveCommand runs Execute().Catch(Empty).Subscribe(), so it never rethrows
+	// on the caller thread (the exception still reaches ThrownExceptions); it also honors canExecute (which
+	// ReactiveCommand.Execute() ignores); and because ICommand.CanExecute is false while a command executes,
+	// it suppresses re-entrant hotkey mashes during an async command.
+	public static void ExecuteIfPossible<TResult>(this ReactiveCommand<Unit, TResult> command)
+	{
+		ArgumentNullException.ThrowIfNull(command);
+
+		if (((ICommand)command).CanExecute(null))
+		{
+			((ICommand)command).Execute(null);
+		}
+	}
+}

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs
@@ -4,9 +4,12 @@ using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
+using Microsoft.Extensions.Logging;
+
 using ReactiveUI;
 
 using SemiStep.UI.Coordinator;
+using SemiStep.UI.MessageService;
 
 namespace SemiStep.UI.RecipeGrid;
 
@@ -17,13 +20,19 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 	private readonly BehaviorSubject<bool> _canUndo = new(false);
 	private readonly BehaviorSubject<bool> _canRedo = new(false);
 	private readonly IRecipeGridSurface _recipeGrid;
+	private readonly MessagePanelViewModel _messagePanel;
+	private readonly ILogger<RecipeCommandsViewModel> _logger;
 
 	public RecipeCommandsViewModel(
 		RecipeCoordinator coordinator,
-		IRecipeGridSurface recipeGrid)
+		IRecipeGridSurface recipeGrid,
+		MessagePanelViewModel messagePanel,
+		ILogger<RecipeCommandsViewModel> logger)
 	{
 		_coordinator = coordinator;
 		_recipeGrid = recipeGrid;
+		_messagePanel = messagePanel;
+		_logger = logger;
 
 		_coordinator.Mutated += OnCoordinatorMutated;
 		_disposables.Add(Disposable.Create(() => _coordinator.Mutated -= OnCoordinatorMutated));
@@ -43,6 +52,18 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 		DeleteStepCommand.DisposeWith(_disposables);
 		UndoCommand.DisposeWith(_disposables);
 		RedoCommand.DisposeWith(_disposables);
+
+		AddStepCommand.ReportThrownExceptions(_messagePanel, _logger, "Add step failed")
+			.DisposeWith(_disposables);
+
+		DeleteStepCommand.ReportThrownExceptions(_messagePanel, _logger, "Delete step failed")
+			.DisposeWith(_disposables);
+
+		UndoCommand.ReportThrownExceptions(_messagePanel, _logger, "Undo failed")
+			.DisposeWith(_disposables);
+
+		RedoCommand.ReportThrownExceptions(_messagePanel, _logger, "Redo failed")
+			.DisposeWith(_disposables);
 	}
 
 	private void OnCoordinatorMutated(MutationSignal signal)
@@ -74,10 +95,13 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 			? _coordinator.InsertStep(_recipeGrid.SelectedStepIndex + 1, firstActionId)
 			: _coordinator.AppendStep(firstActionId);
 
-		if (result.IsSuccess)
+		if (result.IsFailed)
 		{
-			_recipeGrid.RequestSelection(result.Value);
+			_messagePanel.ReportFailure(result);
+			return;
 		}
+
+		_recipeGrid.RequestSelection(result.Value);
 	}
 
 	private void DeleteStep()
@@ -92,10 +116,13 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 			? _coordinator.RemoveStep(indices[0])
 			: _coordinator.RemoveSteps(indices);
 
-		if (result.IsSuccess)
+		if (result.IsFailed)
 		{
-			_recipeGrid.RequestSelection(result.Value);
+			_messagePanel.ReportFailure(result);
+			return;
 		}
+
+		_recipeGrid.RequestSelection(result.Value);
 	}
 
 	private void Undo()

--- a/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml.cs
+++ b/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml.cs
@@ -28,16 +28,28 @@ internal partial class GridStyleEditorWindow : ReactiveWindow<GridStyleEditorVie
 		});
 	}
 
-	private async void OnSaveCompleted(bool saved)
+	internal async void OnSaveCompleted(bool saved)
 	{
 		if (!saved)
 		{
 			return;
 		}
 
-		var dialog = new RestartPromptDialog();
-		var exitRequested = await dialog.ShowDialog<bool>(this);
-		CompleteEditorClose(exitRequested);
+		try
+		{
+			var dialog = new RestartPromptDialog();
+			var exitRequested = await dialog.ShowDialog<bool>(this);
+			CompleteEditorClose(exitRequested);
+		}
+		catch (Exception ex)
+		{
+			// This is an async void subscription callback: an unhandled throw here unwinds the
+			// dispatcher loop into Program.Main and kills the process. Surface on the editor's own
+			// error surface (a modal's fault must not land behind the modal) and still close the
+			// editor rather than leaving it hanging.
+			ViewModel?.ReportSaveException(ex);
+			CompleteEditorClose(false);
+		}
 	}
 
 	// Captures the owner before Close(): Avalonia detaches the owned-window link during the close

--- a/docs/plans/completed/20260727-pr-f3-ui-command-exception-paths.md
+++ b/docs/plans/completed/20260727-pr-f3-ui-command-exception-paths.md
@@ -1,0 +1,205 @@
+# PR-F3 (#113): UI command exception paths, rebased on the pipe foundation
+
+## Overview
+
+Issue #113 — unhandled exception paths in UI commands — rebased onto the merged pipe foundation
+(PR-F1 report+log ring, PR-F2 global backstop).
+
+The foundation narrowed *one* class of this issue, not all of it. F2's `WithExceptionHandler` replaced
+the default handler for **unsubscribed** `ThrownExceptions` only — the forgotten-subscription class. It
+did NOT de-crash the hotkeys. ReactiveUI delivers a command execution exception to BOTH channels: the
+`ThrownExceptions` stream (which F1's handlers report) AND the `Execute()` observable's `OnError`. The
+five hotkeys call `.Execute().Subscribe()` with no `onError`, so that second channel rethrows inside a
+dispatcher job and unwinds to `Program.Main`'s `Log.Fatal` — the process dies. So today, post-F2, a
+Ctrl+C whose command throws BOTH shows a panel report AND kills the app. Tasks 1/4 (hotkeys) and Task 5
+(async-void dialogs) are therefore still **crash-prevention**, not polish; Tasks 2/3 add specific per-site
+handling and close the `canEdit` gating bypass.
+
+What F3 does:
+1. Add an `ExecuteIfPossible` extension and route the five `MainWindow` hotkeys through it — fixes the
+   unguarded-invocation crash AND the gating bypass for the *mutating* hotkeys (Delete/Cut/Paste run
+   while `canEdit` is false today; Copy and ToggleOrientation are not `canEdit`-gated and only gain
+   crash-safety).
+2. Wire `RecipeCommandsViewModel`'s four commands through the F1 `ReportThrownExceptions` extension and
+   report the failed `Result`s it currently drops.
+3. Add the missing `ToggleOrientationCommand` `ThrownExceptions` handler.
+4. Guard the two async-void dialog paths (`OnWindowClosing`, `OnSaveCompleted`) — interim, superseded by #114.
+
+Conflict fire-and-forget (original finding 3) is mostly, but not fully, covered by the foundation:
+`MainWindowViewModel.cs:86-90` wraps the callback in `Guarded("PLC conflict handling", …)` (F1, catches
+the synchronous segment) and `HandleConflictAsync`'s inner try/catch covers the `ShowDialog` await. The
+residual hole is the **post-await tail** — `ResolveConflict`/`ReportFailure` throwing after the dialog
+faults the discarded task, and `TaskScheduler.UnobservedTaskException` only fires nondeterministically at
+GC with no context or user message (a diagnostic, not handling). Task 3 already edits this file, so it
+closes that tail (see Task 3). #114 restructures the dialog onto `Interaction` regardless.
+
+What F3 does NOT do (with rationale):
+- **Config-side zero-actions fail-fast: DEFERRED to #111, as a tracked task.** With F2's backstop + task 2's
+  `RecipeCommandsViewModel` handler, a zero-primary-actions config no longer crashes on `AddStep` — it
+  reports a message (the config is visibly broken, not silently degraded). Rejecting such a config at load
+  (the proper root-cause fix) means running the action resolver during config validation and routing the
+  defect through a `Result`, which is exactly #111's charter ("route config defects through `Result`
+  instead of constructor throws"). A partial version here would be redone by #111. **This must be filed as
+  an explicit task/sub-issue on #111 before F3 is archived**, so the deferral does not evaporate — not left
+  as a plan footnote.
+
+## Context (grounded on current master, post F1+F2)
+
+- Hotkeys unguarded: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs:61,72,78,84,90` — five
+  `command.Execute().Subscribe()` with no `onError` and no `CanExecute` check (ToggleOrientation,
+  DeleteStep, Copy, Cut, Paste). `ReactiveCommand.Execute()` ignores `canExecute`, so the mutating ones
+  run even while `canEdit` is false: `DeleteStepCommand` and `Cut`/`Paste` are `canEdit`-gated
+  (`ClipboardViewModel.cs:56-59`). `CopyStepCommand` is gated on selection only (`ClipboardViewModel.cs:55`,
+  `CanDeleteStep`), not `canEdit`, so it correctly stays available in read-only mode; `ToggleOrientationCommand`
+  has no gate. `OnKeyDown`'s `IsEditing` gate (`:67`) is a real requirement — keep it.
+- `RecipeCommandsViewModel` (`SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs`): four
+  `ReactiveCommand.Create` commands (`:37-40`), NO `ThrownExceptions` handler anywhere. `AddStep` (`:69-81`)
+  calls `_coordinator.GetDefaultActionId()` (throws `InvalidOperationException` on zero actions); `AddStep`/
+  `DeleteStep` act only on `IsSuccess` (`:77,95`), silently dropping failed `Result`s. It does NOT inject
+  the panel or a logger.
+- `ToggleOrientationCommand` (`SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs:63`): no
+  `ThrownExceptions` handler (F1 handled `ToggleSyncCommand`/`OpenStyleEditorCommand` at `:71-75` but
+  deliberately left this one for #113).
+- The F1 seams to reuse: `ReportThrownExceptions(this ReactiveCommand<,>, MessagePanelViewModel, ILogger, string)`
+  (`SemiStep/SemiStep.UI/MessageService/ReactiveCommandReportingExtensions.cs`), which delegates to
+  `ExceptionReporter.ReportAndLog` (`ExceptionReporter.cs`); and `MessagePanelViewModel.ReportFailure`
+  (`ResultReportingExtensions.cs`).
+- async-void, unguarded: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs:100-140` (`OnWindowClosing`,
+  try/finally, no catch around the awaits) and `SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml.cs:31-41`
+  (`OnSaveCompleted`, `async void` from an Rx `Subscribe`, awaits `RestartPromptDialog.ShowDialog`). F1
+  wired `GridStyleEditorViewModel.SaveCommand.ThrownExceptions` (the command), but this window-side async
+  void is separate and still unguarded.
+- F2 has no Avalonia dispatcher hook, so an async-void throw is NOT caught by the backstop — it unwinds
+  the dispatcher loop into `Program.Main`'s `Log.Fatal` and the process dies. The guards prevent that.
+- DI construction sites for `RecipeCommandsViewModel` that gain the new params: `UiDi.cs` (singleton),
+  `SemiStep.Tests/UI/Helpers/UIFixture.cs`, `SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs`
+  (verify exact lines at implementation time; `UIFixture` already exposes `MessagePanel`).
+
+## Development Approach
+
+- Regular (code, then tests). Warnings are errors; build stays clean.
+- Reuse the F1 extension and `ExceptionReporter`; do not add a parallel reporting path.
+- Tests use the shared `RecordingLogger<T>` (`SemiStep.Tests/Helpers/RecordingLogger.cs`) for log
+  assertions and `NullLogger<T>.Instance` elsewhere.
+- `dotnet build SemiStep.slnx` (0 warnings) + `dotnet test` after each task.
+
+## Acceptance Evidence
+
+**Automatable:**
+1. `ExecuteIfPossible`: a command whose execute throws, invoked via the extension, does not rethrow and
+   its `ThrownExceptions` fires once; a command with `canExecute == false` does not run. `--filter "FullyQualifiedName~ExecuteIfPossible"`.
+2. `RecipeCommandsViewModel`: a thrown command exception reports to the panel (specific context, not the
+   generic backstop text) and logs; a failed `Result` from `AddStep`/`DeleteStep` lands a panel entry
+   instead of being dropped. `--filter "FullyQualifiedName~RecipeCommandsViewModel"`.
+3. `ToggleOrientationCommand` fault reports to the panel. (Covered under MainWindowViewModel filter.)
+4. async-void guards: a forced throw in the `OnWindowClosing` / `OnSaveCompleted` path is contained
+   (reported/closed gracefully), not crashing the headless app.
+
+**Manual smoke:** with a recipe running on the PLC (`canEdit` false), Delete / Ctrl+V do NOT mutate the
+recipe (gating fix). Full suite green + `dotnet build SemiStep.slnx` (0 warnings) is the gate.
+
+## Progress Tracking
+
+Mark `[x]` on completion; `➕` new tasks; `⚠️` blockers.
+
+## Implementation Steps
+
+### Task 1: Add the `ExecuteIfPossible` command extension
+
+**Files:**
+- Create: a dedicated `SemiStep/SemiStep.UI/`-side invocation-extensions class (e.g. `CommandInvocationExtensions` — invocation is NOT reporting, so it does not belong in `ReactiveCommandReportingExtensions`).
+- Create: the matching test file.
+
+- [x] add `ExecuteIfPossible<TResult>(this ReactiveCommand<Unit, TResult> command)`: `if (((ICommand)command).CanExecute(null)) { ((ICommand)command).Execute(null); }` — `ICommand.Execute` is internally `Execute().Catch(Empty).Subscribe()`, so it never rethrows. Comment: it prevents the unguarded-invocation crash, honors `canExecute` (which `ReactiveCommand.Execute()` ignores), AND — because `ICommand.CanExecute` is false while a command is executing — suppresses re-entrant hotkey mashes during an async command for free.
+- [x] test: a throwing command invoked via `ExecuteIfPossible` does not rethrow and its `ThrownExceptions` fires once; a `canExecute == false` command does not execute.
+- [x] run the filter — green before next task.
+
+### Task 2: Wire `RecipeCommandsViewModel` through the F1 extension + report Results
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/Helpers/UIFixture.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelCanExecuteTests.cs`
+- Create: `SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelReportingTests.cs`
+
+- [x] inject `MessagePanelViewModel` + `ILogger<RecipeCommandsViewModel>` (add usings for `MessageService`, `Microsoft.Extensions.Logging`).
+- [x] `command.ReportThrownExceptions(_messagePanel, _logger, "Add step failed"/"Delete step failed"/"Undo failed"/"Redo failed").DisposeWith(_disposables)` for the four commands.
+- [x] `AddStep`/`DeleteStep`: on `result.IsFailed`, `_messagePanel.ReportFailure(result)` and return; else `RequestSelection`.
+- [x] update the direct construction sites to pass `MessagePanel` / `NullLogger<RecipeCommandsViewModel>.Instance`: `UIFixture.cs:148` and BOTH sites in `RecipeCommandsViewModelCanExecuteTests.cs` (`:30` and `:109`).
+- [x] tests: a thrown command exception reports with the specific context + logs; a failed `Result` reports. `RecipeCoordinator` is `sealed` (not mockable) — use a stub `IRecipeGridSurface` as the throw seam (throw in `RequestSelection`/`SelectedStepIndex` after a successful coordinator result); drive the failed-`Result` path via coordinator state that returns `IsFailed`.
+- [x] run the filters — green before next task.
+
+### Task 3: `ToggleOrientationCommand` handler + close the conflict post-await tail
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs`
+- Modify: the MainWindowViewModel reporting test.
+
+- [x] `ToggleOrientationCommand.ReportThrownExceptions(MessagePanel, _logger, "Orientation toggle failed").DisposeWith(_disposables)` (mirror `:71-75`).
+- [x] close the conflict fire-and-forget post-await tail: add a **separate** try/catch around the post-dialog body (`ResolveConflict`/`ReportFailure`, `:240-245`) with a resolution-specific context (e.g. "PLC conflict resolution failed" via `ExceptionReporter.ReportAndLog`) — do NOT widen the existing dialog-show catch (`:227-233`), which reports "Failed to show PLC conflict dialog" and would mislabel a resolution failure. So a throw in the tail is logged + reported instead of faulting the discarded task and relying on the nondeterministic `TaskScheduler` GC hook. (Interim; #114 moves this dialog onto `Interaction`.)
+- [x] test: a faulting `ToggleOrientationCommand` reports to the panel; a throw in the conflict post-dialog body is reported, not left to the unobserved-task hook.
+- [x] run `--filter "FullyQualifiedName~MainWindowViewModel"` — green.
+
+### Task 4: Route the `MainWindow` hotkeys through `ExecuteIfPossible`
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs`
+- Create/Modify: a headless hotkey test.
+
+- [x] add the `using` for the extension; replace the five `.Execute().Subscribe()` calls (`:61,72,78,84,90`) with `.ExecuteIfPossible()`. (Tasks 2/3 run first so all five reachable commands have `ThrownExceptions` handlers — Clipboard from F1, DeleteStep from task 2, ToggleOrientation from task 3 — which buys a *specific* panel message; note `ExecuteIfPossible` is crash-safe on its own even before that, since the swallowed `Execute()` channel still delivers to `ThrownExceptions` → F2's generic backstop.)
+- [x] test: a hotkey whose command throws does not crash and reports once; a hotkey does not mutate when `canExecute` is false.
+- [x] run the filter — green.
+
+### Task 5: Guard the two async-void dialog paths (interim; #114 supersedes)
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs` (`OnWindowClosing`)
+- Modify: `SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorWindow.axaml.cs` (`OnSaveCompleted`)
+- Create/Modify: headless tests.
+
+- [x] `OnWindowClosing`: added a `catch (Exception ex)` around the dialog/`HandleExitChoiceAsync` block; reports via `ViewModel?.MessagePanel.ReportError($"Exit failed: {ex.Message}")`; window stays open (`e.Cancel` already true); `finally` still resets `_exitChoiceInProgress`.
+- [x] `OnSaveCompleted`: wrapped the body in try/catch; on catch, surfaces on the editor's own `ErrorMessage` via the F1 `ReportSaveException(ex)` seam and still `CompleteEditorClose(false)` so the editor closes.
+- [x] each catch carries a concise WHY comment (async-void throw unwinds the dispatcher into `Program.Main` and kills the process). The literal "interim, superseded by #114" marker is deliberately NOT written into code: CLAUDE.md forbids transitional/process comments; the interim nature lives in this plan and the PR. See [decision].
+- [x] tests: `OnSaveCompleted` fault-containment covered by a real headless test (`GridStyleEditorWindowTests.OnSaveCompleted_RestartPromptThrows_ContainsFaultAndClosesEditor`). `OnWindowClosing` fault-injection skipped — no headless seam (`WindowClosingEventArgs` has an internal Avalonia ctor; the real Close() flow keeps the owner visible so `ShowDialog` cannot be forced to throw); manual smoke. See [decision].
+- [x] `--filter "Component=UI"` — 900 passed, 0 failed, 0 warnings.
+
+### Task 6: Verify + document
+
+**Files:**
+- Modify: `Docs/architecture/error-reporting.md`
+
+- [x] full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1489 passed, 0 failed (8 explicit perf probes skipped).
+- [x] `dotnet build SemiStep.slnx` — 0 warnings, 0 errors
+- [x] `dotnet format SemiStep.slnx` — no changes required
+- [x] update `error-reporting.md`: `ExecuteIfPossible` as the sanctioned imperative-invocation seam (keeps commands inside the boundary + honors `canExecute`); note the async-void guards are interim pending #114.
+- [x] mark this plan for archival at delivery (archival deferred to delivery/ship; do NOT move it mid-run).
+
+## Post-Completion
+
+**Behavior change (PR note):** routing hotkeys through `ExecuteIfPossible` makes Delete / Ctrl+X / Ctrl+V
+inert while `canEdit` is false (a recipe running on the PLC) — the intended `canEdit` semantics they bypass
+today. **Ctrl+C stays available** (Copy is gated on selection, not `canEdit`), and ToggleOrientation gains
+crash-safety only. Call it out in the PR.
+
+**Interim guards:** Task 5's async-void try/catch on `OnWindowClosing`/`OnSaveCompleted` are superseded by
+#114, which moves those dialogs onto the awaitable `Interaction` seam and deletes the guards. Guards-now
+is correct because F2's backstop does not hook the dispatcher, so without them a dialog throw still crashes.
+
+**Deferred (must be tracked):** the config-side zero-primary-actions fail-fast (reject the config at load,
+route through `Result`) rides with #111. File it as an explicit task/comment on #111 before this plan is
+archived — do not let it live only here. F2 + task 2 already make a zero-action config non-crashing.
+
+**Executed by exec:**
+- branch: ui-command-exception-paths
+
+## Verify it yourself
+
+Most of this is invisible until a command or dialog faults, so the proof is the regression tests that
+reproduce each path.
+
+- **Hotkey no longer crashes + reports specifically:** `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName~ExecuteIfPossible"` and `--filter "FullyQualifiedName~MainWindowHotkey"` — a throwing command invoked via `ExecuteIfPossible` does not rethrow and reports once. On `master`, the raw `.Execute().Subscribe()` rethrows into the dispatcher and kills the app.
+- **RecipeCommands reports instead of dropping:** `--filter "FullyQualifiedName~RecipeCommandsViewModel"` — a thrown command exception reports the specific context + logs; a failed `Result` from Add/Delete now lands a panel entry.
+- **ToggleOrientation + conflict resolution guarded:** `--filter "FullyQualifiedName~MainWindowViewModel"`.
+- **async-void dialogs contained:** `--filter "FullyQualifiedName~GridStyleEditorWindow"` (restart-prompt fault → `ErrorMessage`, editor closes) and `--filter "FullyQualifiedName~ExitFlow"` (`ShowExitChoice_DialogShowThrows...` — exit fault contained, window stays open).
+- **Gating fix (manual):** with a recipe running on the PLC (`canEdit` false), Delete / Ctrl+X / Ctrl+V do NOT mutate the recipe; Ctrl+C still copies (selection-gated).
+- **No regression:** full `dotnet test` (1489 pass) + `dotnet build SemiStep.slnx` (0 warnings).


### PR DESCRIPTION
Closes #113.

## Problem

Unhandled exception paths in UI commands that the pipe foundation (F1 report+log ring, F2 global
backstop) did not cover:

- **Hotkeys still crashed.** The five `MainWindow` hotkeys invoked commands with a bare
  `.Execute().Subscribe()`. ReactiveUI dual-delivers a command fault: F1's `ThrownExceptions` handler
  reports it, *and* the `Execute()` observable's `OnError` rethrows through the no-`onError` `Subscribe`
  into a dispatcher job → `Program.Main`'s fatal → the app dies. So a hotkey whose command threw *both*
  showed a panel message *and* killed the process. F2's backstop only replaced the unsubscribed-`ThrownExceptions`
  default; it never saw this channel.
- **`RecipeCommandsViewModel`** had no `ThrownExceptions` handler and silently dropped failed `Result`s.
- **`ToggleOrientationCommand`** was unguarded.
- **Two async-void dialog paths** (window close, style-editor restart prompt) crashed on a throw — the
  backstop installs no Avalonia dispatcher hook, so it cannot catch these.

## What changed

- **`ExecuteIfPossible`** (`SemiStep.UI/Reactive/CommandInvocationExtensions.cs`) — invoke a command via
  `ICommand.Execute`, which swallows the caller-thread rethrow while `ThrownExceptions` still reports, and
  honors `canExecute`. All five hotkeys routed through it. **Behavior change:** this also closes the gating
  bypass — Delete / Ctrl+X / Ctrl+V no longer mutate a recipe running on the PLC (`canEdit` false). **Ctrl+C
  stays available** (Copy is gated on selection, not `canEdit`); ToggleOrientation gains crash-safety only.
- **`RecipeCommandsViewModel`** — its four commands now route through the F1 `ReportThrownExceptions`
  extension (specific per-command messages + logged stack), and `AddStep`/`DeleteStep` report the failed
  `Result`s they previously dropped.
- **`ToggleOrientationCommand`** handler added; the PLC conflict-resolution post-await tail is guarded via
  the existing `Guarded` seam (resolution-specific context, separate from the dialog-show catch).
- **async-void guards** on `OnWindowClosing` (extracted to `ShowExitChoiceAsync`; a fault reports "Exit
  failed" and the window stays open) and `OnSaveCompleted` (surfaces on the editor's own `ErrorMessage`,
  editor still closes). Interim until #114 moves these dialogs onto the awaitable `Interaction` seam.

Deferred: the config-side zero-primary-actions fail-fast is left to **#111** (F2 + the new
`RecipeCommandsViewModel` handler already make a zero-action config report instead of crash).

## Verification

- `dotnet build SemiStep.slnx` — 0 warnings (warnings are errors).
- `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1489 passed, 0 failed.
- New regression tests reproduce each path: `ExecuteIfPossible` (no rethrow + one `ThrownExceptions` fire);
  `RecipeCommandsViewModel` (specific report + log; failed `Result` reported); `ToggleOrientation` +
  conflict-resolution guards; `OnSaveCompleted` and `ShowExitChoiceAsync` containment; a hotkey-gating test
  with a positive control.
- Manual smoke (gating): with a recipe running on the PLC, Delete / Ctrl+X / Ctrl+V are inert; Ctrl+C still copies.
- Ran through the full multi-agent review chain (comprehensive, smells, comment audit, critical) plus a
  pre-implementation Fable + plan-review pass against the merged F1+F2 codebase.

<details>
<summary>Per-task commits before collapse</summary>

```
19899d9 feat(ui): add ExecuteIfPossible command-invocation extension
7f46e9f feat(ui): report and log RecipeCommandsViewModel command failures
3178a7d feat(ui): guard ToggleOrientation and PLC conflict resolution errors
25e895c fix(ui): route hotkeys through ExecuteIfPossible
2027f54 fix(ui): guard async-void exit and restart-prompt dialogs
b16ca53 docs(architecture): document ExecuteIfPossible invocation seam
b62a609 refactor(ui): reuse Guarded for conflict resolution and tidy F3 tests
f541b36 refactor(ui): tidy reporting-block spacing and exit-flag ownership
fd77300 docs(plans): record exec branch + verification steps for PR-F3
```

</details>
