### PR TITLE
refactor(ui): show view-model dialogs via Interactions (#114)

### DIFF
--- a/Docs/architecture/dialogs-and-interactions.md
+++ b/Docs/architecture/dialogs-and-interactions.md
@@ -1,0 +1,51 @@
+# Dialogs and Interactions
+
+How a view-model-driven dialog reaches the screen without the view model depending on
+`Avalonia.Controls.Window`. Read this before adding a new dialog that a view model opens.
+
+## The convention
+
+A view model that needs to show a dialog declares a ReactiveUI `Interaction<TInput, TOutput>` as a
+property, constructed in its constructor, and calls `await interaction.Handle(input)` where it once
+newed a window. It never references `Window`, never news a concrete dialog type, and never holds a
+back-reference to the view.
+
+The view supplies the window. `MainWindow.WhenActivated` registers one handler per interaction with
+`.RegisterHandler(HandleX).DisposeWith(disposables)`; the handler news the concrete dialog, `await`s
+`ShowDialog(this)`, and calls `context.SetOutput(...)` with the result. This is the same idiom the
+file pickers already use (`RecipeFileViewModel.OpenFileInteraction` / `SaveFileInteraction`), so a new
+VM-driven dialog follows an established pattern rather than inventing one.
+
+`MainWindowViewModel` routes three dialogs this way:
+
+- `ShowStyleEditorInteraction` (`Interaction<GridStyleEditorViewModel, Unit>`) — the grid style editor.
+  The VM builds and `LoadAsync`es the editor view model, then hands it to the interaction; the handler
+  news `GridStyleEditorWindow { DataContext = context.Input }`.
+- `ResolveConflictInteraction` (`Interaction<PlcConflictDialogViewModel, bool?>`) — the PLC recipe
+  conflict dialog. Output encodes the three outcomes: `null` = cancelled, `true` = keep local,
+  `false` = load from PLC. The handler news `PlcConflictDialog(context.Input)` and reports
+  `dialog.Confirmed ? dialog.KeepLocal : null`.
+- `RequestCloseInteraction` (`Interaction<Unit, Unit>`) — `File > Exit`. The handler calls `Close()`,
+  which runs `OnWindowClosing`'s dirty-close guard (see `exit-flow.md`).
+
+Because the dialog now goes through an interaction, the flow is unit-testable headless: a test
+registers a fake handler and asserts the VM behavior with no `Window` in play. A missing handler
+raises `UnhandledInteractionException` instead of silently dropping the dialog, so the conflict flow's
+try/catch turns that into a reported failure rather than a no-op.
+
+## The view-side boundary
+
+Two dialogs deliberately stay in view code-behind and are **not** routed through VM interactions,
+because they are window-lifecycle concerns the view model cannot own:
+
+- **Exit confirmation** — `ExitConfirmationDialog`, shown from `MainWindow.OnWindowClosing` via
+  `ShowExitChoiceAsync`. It hangs off `WindowClosingEventArgs` / `e.Cancel` / `Close()`, state that
+  belongs to the window's own `Closing` event.
+- **Style-editor restart prompt** — `RestartPromptDialog`, shown from
+  `GridStyleEditorWindow.OnSaveCompleted`. It belongs to the style-editor window's own save flow.
+
+A view showing a dialog in response to its own lifecycle event is correct MVVM, not a violation. Both
+paths run as `async void` event handlers, so they carry their own try/catch guards; the global backstop
+installs no Avalonia dispatcher hook and cannot catch an `async void` throw. Those guards remain in
+place and are not superseded by the interaction convention above. See `error-reporting.md` for the
+guard rationale and `exit-flow.md` for the exit path.

--- a/Docs/architecture/error-reporting.md
+++ b/Docs/architecture/error-reporting.md
@@ -89,6 +89,9 @@ The two async-void dialog paths (`OnWindowClosing`, `OnSaveCompleted`) carry the
 Those are the current cover for dialog faults the global backstop cannot catch: it installs no Avalonia
 dispatcher hook, so an async-void throw would otherwise unwind the dispatcher into `Program.Main`.
 
+For the VM-driven dialogs that route through `Interaction`s registered in `WhenActivated` (rather than
+view code-behind), see `dialogs-and-interactions.md` for the convention.
+
 ## Global backstop (last-resort ring)
 
 The per-command pipe above catches faults on a *subscribed* `ThrownExceptions`. What escapes every

--- a/Docs/architecture/exit-flow.md
+++ b/Docs/architecture/exit-flow.md
@@ -16,8 +16,10 @@ runs the guard and terminates the app. The process-exit cascade itself is not ob
 headless test harness (it installs no classic-desktop lifetime); it is covered by manual
 verification. The routing up to `MainWindow.Close()` is what the automated tests assert.
 
-- `File > Exit` (`MainWindowViewModel.ExecuteExit`) calls `MainWindow?.Close()` — same guard as the
-  window's close button. Covered by `MainWindowExitFlowTests`.
+- `File > Exit` (`MainWindowViewModel.ExitCommand`) fires `RequestCloseInteraction`, whose handler in
+  `MainWindow.WhenActivated` calls `Close()` — same guard as the window's close button. The view model
+  no longer holds a `Window` reference (see `dialogs-and-interactions.md`). Covered by
+  `MainWindowExitFlowTests`.
 
 ## No forced-shutdown path remains
 

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowConflictResolutionTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowConflictResolutionTests.cs
@@ -1,0 +1,112 @@
+﻿using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using SemiStep.Core.Recipes;
+
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.MainWindow;
+using SemiStep.UI.MessageService;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.MainWindow;
+
+[Trait("Component", "UI")]
+[Trait("Area", "PlcConflict")]
+[Trait("Category", "Integration")]
+public sealed class MainWindowConflictResolutionTests : IAsyncLifetime
+{
+	private readonly UIFixture _fixture = new();
+	private MainWindowViewModel _viewModel = null!;
+
+	public async ValueTask InitializeAsync()
+	{
+		await _fixture.InitializeAsync();
+		_viewModel = _fixture.CreateMainWindowViewModel();
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		_viewModel.Dispose();
+		return _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public async Task HandleConflict_KeepLocal_ResolvesKeepingLocalRecipe()
+	{
+		_viewModel.ResolveConflictInteraction.RegisterHandler(context => context.SetOutput(true));
+		var callsBefore = _fixture.PlcSyncService.NotifyRecipeChangedCallCount;
+
+		await _viewModel.HandleConflictAsync(CurrentRecipe, CurrentRecipe);
+
+		_fixture.PlcSyncService.NotifyRecipeChangedCallCount.Should().Be(
+			callsBefore + 1,
+			"keeping local must resolve the conflict by pushing the local recipe back to the PLC");
+		_fixture.MessagePanel.Entries.Should().NotContain(
+			entry => entry.Severity == MessageSeverity.Error,
+			"a successful keep-local resolution must not report an error");
+	}
+
+	[AvaloniaFact]
+	public async Task HandleConflict_LoadFromPlc_ResolvesLoadingPlcRecipe()
+	{
+		_viewModel.ResolveConflictInteraction.RegisterHandler(context => context.SetOutput(false));
+		var callsBefore = _fixture.PlcSyncService.NotifyRecipeChangedCallCount;
+
+		await _viewModel.HandleConflictAsync(CurrentRecipe, CurrentRecipe);
+
+		// HandleConflictAsync is driven directly, so no pending PLC recipe was seeded by a real
+		// conflict; the load branch therefore fails on the missing pending recipe. That failure is
+		// the faithful observable proof that keepLocal=false reached RecipeCoordinator.ResolveConflict,
+		// distinct from the keep-local branch which pushes via NotifyRecipeChanged instead.
+		_fixture.PlcSyncService.NotifyRecipeChangedCallCount.Should().Be(
+			callsBefore,
+			"loading from the PLC must not push the local recipe back");
+		_fixture.MessagePanel.Entries.Should().Contain(
+			entry => entry.Severity == MessageSeverity.Error && entry.Message.Contains("pending PLC recipe"),
+			"the load-from-PLC branch must route through ResolveConflict(false)");
+	}
+
+	[AvaloniaFact]
+	public async Task HandleConflict_Cancel_DoesNothing()
+	{
+		_viewModel.ResolveConflictInteraction.RegisterHandler(context => context.SetOutput(null));
+		var callsBefore = _fixture.PlcSyncService.NotifyRecipeChangedCallCount;
+
+		await _viewModel.HandleConflictAsync(CurrentRecipe, CurrentRecipe);
+
+		_fixture.PlcSyncService.NotifyRecipeChangedCallCount.Should().Be(
+			callsBefore,
+			"cancelling the dialog must not resolve the conflict either way");
+		_fixture.MessagePanel.Entries.Should().NotContain(
+			entry => entry.Severity == MessageSeverity.Error,
+			"cancelling must not report any error");
+	}
+
+	[AvaloniaFact]
+	public async Task HandleConflict_HandlerThrows_ContainsFaultAndReports()
+	{
+		_viewModel.ResolveConflictInteraction.RegisterHandler(
+			_ => throw new InvalidOperationException("dialog boom"));
+
+		var act = async () => await _viewModel.HandleConflictAsync(CurrentRecipe, CurrentRecipe);
+
+		await act.Should().NotThrowAsync("a dialog fault must be contained on the fire-and-forget path");
+		_fixture.MessagePanel.Entries.Should().Contain(
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Failed to show PLC conflict dialog");
+	}
+
+	[AvaloniaFact]
+	public async Task HandleConflict_NoHandlerRegistered_ReportsInsteadOfVanishing()
+	{
+		await _viewModel.HandleConflictAsync(CurrentRecipe, CurrentRecipe);
+
+		_fixture.MessagePanel.Entries.Should().Contain(
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Failed to show PLC conflict dialog",
+			"an unhandled interaction must convert today's silent drop into a report");
+	}
+
+	private Recipe CurrentRecipe => _fixture.Coordinator.CurrentRecipe;
+}

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowExitFlowTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowExitFlowTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System.Reactive;
+using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 
 using Avalonia.Headless.XUnit;
@@ -291,5 +292,22 @@ public sealed class MainWindowExitFlowTests : IAsyncLifetime
 		await _viewModel.ExitCommand.Execute();
 
 		_window.IsVisible.Should().BeFalse("File > Exit on a clean session must close the window");
+	}
+
+	[AvaloniaFact]
+	public async Task ExitCommand_InvokesRequestCloseInteraction()
+	{
+		// Registered after Show(): interaction handlers are invoked LIFO, so this handler
+		// wins over the window's own close handler and keeps the window open for the assertion.
+		var invoked = false;
+		_viewModel.RequestCloseInteraction.RegisterHandler(context =>
+		{
+			invoked = true;
+			context.SetOutput(Unit.Default);
+		});
+
+		await _viewModel.ExitCommand.Execute();
+
+		invoked.Should().BeTrue("File > Exit must route through the close interaction");
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowStyleEditorInteractionTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowStyleEditorInteractionTests.cs
@@ -1,0 +1,88 @@
+﻿using System.IO;
+using System.Reactive;
+using System.Reactive.Linq;
+
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using SemiStep.Core.Configuration;
+
+using SemiStep.Tests.Config.Helpers;
+using SemiStep.Tests.Helpers;
+using SemiStep.Tests.UI.Helpers;
+
+using SemiStep.UI.MainWindow;
+using SemiStep.UI.StyleEditor;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.MainWindow;
+
+[Trait("Component", "UI")]
+[Trait("Area", "StyleEditor")]
+[Trait("Category", "Integration")]
+public sealed class MainWindowStyleEditorInteractionTests : IAsyncLifetime
+{
+	private readonly UIFixture _fixture = new();
+
+	public ValueTask InitializeAsync()
+	{
+		return _fixture.InitializeAsync();
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		return _fixture.DisposeAsync();
+	}
+
+	[AvaloniaFact]
+	public async Task OpenStyleEditorCommand_InvokesInteractionWithLoadedViewModel()
+	{
+		using var configDir = CopyShippedConfig("MBE");
+		var facade = new GridStyleEditorFacade();
+		var loaded = (await facade.Load(configDir.Path)).Value;
+
+		var viewModel = _fixture.CreateMainWindowViewModel(
+			styleEditorFactory: () => new GridStyleEditorViewModel(
+				facade,
+				configDir.Path,
+				loaded,
+				NullLogger<GridStyleEditorViewModel>.Instance));
+
+		try
+		{
+			GridStyleEditorViewModel? captured = null;
+			viewModel.ShowStyleEditorInteraction.RegisterHandler(context =>
+			{
+				captured = context.Input;
+				context.SetOutput(Unit.Default);
+			});
+
+			await viewModel.OpenStyleEditorCommand.Execute();
+
+			captured.Should().NotBeNull("the command must route the loaded editor VM through the interaction");
+			captured!.ErrorMessage.Should().BeNull("a loadable config means LoadAsync succeeds before the dialog opens");
+		}
+		finally
+		{
+			viewModel.Dispose();
+		}
+	}
+
+	private static TempDirectory CopyShippedConfig(string equipment)
+	{
+		var source = ShippedConfigLocator.GetConfigDirectory(equipment);
+		var tempDir = new TempDirectory();
+		var uiDir = Path.Combine(tempDir.Path, "ui");
+		Directory.CreateDirectory(uiDir);
+		File.Copy(
+			Path.Combine(source, "ui", "grid_style.yaml"),
+			Path.Combine(uiDir, "grid_style.yaml"),
+			overwrite: true);
+
+		return tempDir;
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/MainWindowViewModelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindowViewModelReportingTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reactive.Linq;
 
-using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 
@@ -53,8 +52,6 @@ public sealed class MainWindowViewModelReportingTests : IAsyncLifetime
 
 		try
 		{
-			viewModel.MainWindow = new Window();
-
 			try
 			{
 				await viewModel.OpenStyleEditorCommand.Execute();

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
@@ -9,8 +9,10 @@ using Avalonia.Platform.Storage;
 using ReactiveUI;
 using ReactiveUI.Avalonia;
 
+using SemiStep.UI.Plc;
 using SemiStep.UI.Reactive;
 using SemiStep.UI.ShutdownService;
+using SemiStep.UI.StyleEditor;
 
 namespace SemiStep.UI.MainWindow;
 
@@ -32,7 +34,6 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 				return;
 			}
 
-			ViewModel.MainWindow = this;
 			ViewModel.Clipboard.SetClipboard(Clipboard);
 
 			ViewModel.RecipeFile.OpenFileInteraction
@@ -41,6 +42,18 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
 			ViewModel.RecipeFile.SaveFileInteraction
 				.RegisterHandler(HandleSaveFileDialogAsync)
+				.DisposeWith(disposables);
+
+			ViewModel.ShowStyleEditorInteraction
+				.RegisterHandler(HandleStyleEditorDialogAsync)
+				.DisposeWith(disposables);
+
+			ViewModel.ResolveConflictInteraction
+				.RegisterHandler(HandleResolveConflictDialogAsync)
+				.DisposeWith(disposables);
+
+			ViewModel.RequestCloseInteraction
+				.RegisterHandler(HandleRequestCloseAsync)
 				.DisposeWith(disposables);
 		});
 	}
@@ -247,5 +260,27 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
 		var selectedPath = file?.Path.LocalPath;
 		context.SetOutput(selectedPath);
+	}
+
+	private async Task HandleStyleEditorDialogAsync(IInteractionContext<GridStyleEditorViewModel, Unit> context)
+	{
+		var window = new GridStyleEditorWindow { DataContext = context.Input };
+		await window.ShowDialog(this);
+		context.SetOutput(Unit.Default);
+	}
+
+	private async Task HandleResolveConflictDialogAsync(IInteractionContext<PlcConflictDialogViewModel, bool?> context)
+	{
+		var dialog = new PlcConflictDialog(context.Input);
+		await dialog.ShowDialog(this);
+		context.SetOutput(dialog.Confirmed ? dialog.KeepLocal : null);
+	}
+
+	private Task HandleRequestCloseAsync(IInteractionContext<Unit, Unit> context)
+	{
+		Close();
+		context.SetOutput(Unit.Default);
+
+		return Task.CompletedTask;
 	}
 }

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
@@ -4,8 +4,6 @@ using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
-using Avalonia.Controls;
-
 using Microsoft.Extensions.Logging;
 
 using ReactiveUI;
@@ -56,7 +54,11 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		MessagePanel = messagePanel;
 		PlcMonitor = plcMonitor;
 
-		ExitCommand = ReactiveCommand.Create(ExecuteExit);
+		ShowStyleEditorInteraction = new Interaction<GridStyleEditorViewModel, Unit>();
+		ResolveConflictInteraction = new Interaction<PlcConflictDialogViewModel, bool?>();
+		RequestCloseInteraction = new Interaction<Unit, Unit>();
+
+		ExitCommand = ReactiveCommand.CreateFromTask(RequestCloseAsync);
 		ToggleSyncCommand = ReactiveCommand.CreateFromTask(ExecuteToggleSyncAsync);
 		OpenStyleEditorCommand = ReactiveCommand.CreateFromTask(ExecuteOpenStyleEditorAsync);
 		ToggleToolBarCommand = ReactiveCommand.Create(ExecuteToggleToolBar);
@@ -72,6 +74,9 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 			.DisposeWith(_disposables);
 
 		OpenStyleEditorCommand.ReportThrownExceptions(MessagePanel, _logger, "Style editor failed")
+			.DisposeWith(_disposables);
+
+		ExitCommand.ReportThrownExceptions(MessagePanel, _logger, "Exit failed")
 			.DisposeWith(_disposables);
 
 		ToggleOrientationCommand.ReportThrownExceptions(MessagePanel, _logger, "Orientation toggle failed")
@@ -100,7 +105,12 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 			.DisposeWith(_disposables);
 	}
 
-	public Window? MainWindow { get; set; }
+	public Interaction<GridStyleEditorViewModel, Unit> ShowStyleEditorInteraction { get; }
+
+	// Result: null = cancel, true = keep local, false = load from PLC.
+	internal Interaction<PlcConflictDialogViewModel, bool?> ResolveConflictInteraction { get; }
+
+	public Interaction<Unit, Unit> RequestCloseInteraction { get; }
 
 	public IRecipeGridSurface RecipeGrid { get; }
 
@@ -169,29 +179,23 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		RaiseAllStateProperties();
 	}
 
-	private void ExecuteExit()
-	{
-		// Route through the window so MainWindow.OnWindowClosing runs its dirty-close guard.
-		MainWindow?.Close();
-	}
-
 	private void ExecuteToggleToolBar()
 	{
 		IsToolBarVisible = !IsToolBarVisible;
 	}
 
+	// Closing routes through the window handler so MainWindow.OnWindowClosing runs its dirty-close guard.
+	private async Task RequestCloseAsync()
+	{
+		await RequestCloseInteraction.Handle(Unit.Default);
+	}
+
 	private async Task ExecuteOpenStyleEditorAsync()
 	{
-		if (MainWindow is null)
-		{
-			return;
-		}
-
 		var viewModel = _gridStyleEditorViewModelFactory();
 		await viewModel.LoadAsync();
 
-		var window = new GridStyleEditorWindow { DataContext = viewModel };
-		await window.ShowDialog(MainWindow);
+		await ShowStyleEditorInteraction.Handle(viewModel);
 	}
 
 	private async Task ExecuteToggleSyncAsync()
@@ -213,19 +217,13 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		RaiseConnectionStateProperties();
 	}
 
-	private async Task HandleConflictAsync(Recipe local, Recipe plc)
+	internal async Task HandleConflictAsync(Recipe local, Recipe plc)
 	{
-		if (MainWindow is null)
-		{
-			return;
-		}
-
-		var viewModel = new PlcConflictDialogViewModel(local.StepCount, plc.StepCount);
-		var dialog = new PlcConflictDialog(viewModel);
-
+		bool? keepLocal;
 		try
 		{
-			await dialog.ShowDialog(MainWindow);
+			keepLocal = await ResolveConflictInteraction.Handle(
+				new PlcConflictDialogViewModel(local.StepCount, plc.StepCount));
 		}
 		catch (Exception ex)
 		{
@@ -235,7 +233,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 			return;
 		}
 
-		if (!dialog.Confirmed)
+		if (keepLocal is null)
 		{
 			return;
 		}
@@ -244,7 +242,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		// fault the discarded task and surface only through the nondeterministic TaskScheduler hook.
 		Guarded("PLC conflict resolution failed", () =>
 		{
-			var result = _coordinator.ResolveConflict(dialog.KeepLocal);
+			var result = _coordinator.ResolveConflict(keepLocal.Value);
 
 			if (result.IsFailed)
 			{

--- a/docs/plans/completed/20260728-pr-114-dialog-interactions.md
+++ b/docs/plans/completed/20260728-pr-114-dialog-interactions.md
@@ -1,0 +1,145 @@
+# PR-114: Route MainWindowViewModel dialogs through Interactions
+
+## Overview
+
+Issue #114 — `MainWindowViewModel` depends on `Avalonia.Controls.Window` and news two concrete window
+types to show dialogs, which makes the style-editor and PLC-conflict flows untestable headless and is
+inconsistent with the same file's own use of ReactiveUI `Interaction` for file pickers (via
+`RecipeFileViewModel`).
+
+The fix: route the two VM-driven dialogs through `Interaction`s handled in `MainWindow.WhenActivated`
+(the established `OpenFileInteraction`/`SaveFileInteraction` pattern), replace `ExecuteExit`'s
+`MainWindow?.Close()` with an interaction, and delete the `Window? MainWindow` property entirely. Both
+flows become unit-testable by registering a test handler; the silent `if (MainWindow is null) return;`
+drops disappear.
+
+### Scope (deliberately tight) and a roadmap correction
+
+The issue's mechanism section names exactly two dialogs the VM news — the **style editor**
+(`ExecuteOpenStyleEditorAsync`) and the **PLC conflict** (`HandleConflictAsync`) — plus the
+`Window? MainWindow` property and `ExecuteExit`. Those are this PR.
+
+Two dialogs stay view-side and are **out of scope**, because they are genuine window-lifecycle concerns,
+not VM MVVM violations:
+- **Exit confirmation** (`MainWindow.axaml.cs:137`, shown from `OnWindowClosing`/`ShowExitChoiceAsync`).
+  It hangs off `WindowClosingEventArgs`/`e.Cancel`/`Close()`/`_forceClose` — state the VM cannot own. A
+  view showing a dialog in response to its own Closing event is correct MVVM.
+- **Restart prompt** (`GridStyleEditorWindow.axaml.cs:40`, from `OnSaveCompleted`). It belongs to the
+  style-editor window's own save flow, not `MainWindowViewModel`; any cleanup there is #118's area.
+
+**Correction to the pipe roadmap:** it claimed "#114 deletes F3's interim async-void guards." That is
+wrong. F3's guards are on `ShowExitChoiceAsync` (exit) and `OnSaveCompleted` (restart prompt) — both
+view-side and both out of #114's scope. They are **not** interim and this PR does not remove them. The
+only F3 code near a moved dialog is `HandleConflictAsync`'s try/catch and the fire-and-forget `Guarded`
+wrapper on the conflict subscription; both are **kept** (the try/catch now guards an interaction-handler
+failure instead of a `ShowDialog` failure, and the subscription still cannot await, so it stays
+fire-and-forget-with-Guarded).
+
+## Context (grounded on current master, post F1+F2+F3)
+
+- `MainWindowViewModel.cs:103` — `public Window? MainWindow { get; set; }`, set only at `MainWindow.axaml.cs:35` (`ViewModel.MainWindow = this;`). (`App.axaml.cs:41,60-61` set `desktop.MainWindow`, Avalonia's lifetime property — unrelated, do not touch.)
+- `ExecuteOpenStyleEditorAsync` (`:183-195`) — `if (MainWindow is null) return;`, then `new GridStyleEditorWindow { DataContext = viewModel }; await window.ShowDialog(MainWindow);`. The VM builds the `GridStyleEditorViewModel` via `_gridStyleEditorViewModelFactory()` and `await viewModel.LoadAsync()` first.
+- `HandleConflictAsync` (`:216-254`) — `if (MainWindow is null) return;`, news `PlcConflictDialogViewModel(local.StepCount, plc.StepCount)` + `PlcConflictDialog(viewModel)`, `await dialog.ShowDialog(MainWindow)` inside a try/catch ("Failed to show PLC conflict dialog"), then reads `dialog.Confirmed`/`dialog.KeepLocal` and runs the F3 `Guarded("PLC conflict resolution failed", …)` resolution tail. Called fire-and-forget from the subscription at `:89-93` via `Guarded("PLC conflict handling", () => _ = HandleConflictAsync(...))`.
+- `ExecuteExit` (`:172-176`) — `MainWindow?.Close()`, with a comment that this routes through `OnWindowClosing`'s dirty-close guard.
+- `PlcConflictDialog` (`SemiStep.UI/Plc/PlcConflictDialog.axaml.cs`) — `internal` ctor takes `PlcConflictDialogViewModel`; exposes `bool Confirmed` / `bool KeepLocal` set by the two button handlers before `Close()`.
+- The `Interaction` pattern to mirror: `RecipeFileViewModel` declares `public Interaction<Unit, string?> OpenFileInteraction { get; }` etc.; `MainWindow.axaml.cs:38-44` registers handlers in `WhenActivated` with `.RegisterHandler(...).DisposeWith(disposables)`; a handler is `async Task Handle(IInteractionContext<TIn,TOut> ctx) { …; ctx.SetOutput(value); }` (`:217-250`).
+
+## Development Approach
+
+- Regular (code, then tests). Warnings are errors; build stays clean after every task.
+- Each task must build — so the `Window? MainWindow` property is removed only in the task that migrates
+  its LAST remaining usage (Task 2), never before.
+- Reuse the file-picker `Interaction` idiom exactly (declaration on the VM, handler in `WhenActivated`).
+- Tests register a fake interaction handler and assert the VM behavior headless (`[AvaloniaFact]`).
+- `dotnet build SemiStep.slnx` (0 warnings) + `dotnet test` after each task.
+
+## Acceptance Evidence
+
+**Automatable (the whole point of the issue — headless testability):**
+1. Style editor: a test registers a `ShowStyleEditorInteraction` handler and asserts `OpenStyleEditorCommand` builds the editor VM, calls `LoadAsync`, and invokes the interaction with it — no `Window`. `--filter "FullyQualifiedName~MainWindowViewModel"`.
+2. Conflict: a test registers a `ResolveConflictInteraction` handler returning "keep local" / "load from PLC" / cancelled, and asserts `HandleConflictAsync` calls `RecipeCoordinator.ResolveConflict(keepLocal)` (which delegates through to `PlcLifecycleManager.ResolveConflict`) for the first two and does nothing on cancel; a handler that throws is contained + reported ("Failed to show PLC conflict dialog").
+3. Exit: `ExitCommand` invokes the exit/close interaction (assert the handler is called).
+4. The `Window? MainWindow` property no longer exists (compile-time — grep confirms removal).
+
+**Manual smoke:** open the style editor from the toolbar (dialog shows, edits apply); trigger a PLC recipe conflict and resolve both ways; File→Exit closes with the dirty guard intact.
+
+Full suite green + `dotnet build SemiStep.slnx` (0 warnings) is the gate.
+
+## Progress Tracking
+
+Mark `[x]` on completion; `➕` new tasks; `⚠️` blockers.
+
+## Solution Overview
+
+- Add three `Interaction`s as properties on `MainWindowViewModel`, constructed in the ctor
+  (`ShowStyleEditorInteraction`/`RequestCloseInteraction` public; `ResolveConflictInteraction` `internal`):
+  - `Interaction<GridStyleEditorViewModel, Unit> ShowStyleEditorInteraction` — input is the loaded editor VM; output `Unit`.
+  - `Interaction<PlcConflictDialogViewModel, bool?> ResolveConflictInteraction` — output `null` = cancelled/not-confirmed, `true` = keep local, `false` = load from PLC. This property is `internal`, not public, because CS0053 forbids exposing the `internal sealed PlcConflictDialogViewModel` through a public member. A one-line doc comment on the property spells out the three states; no wrapper record — a binary dialog does not need one (same YAGNI call as no `IMessageSink`).
+  - `Interaction<Unit, Unit> RequestCloseInteraction` — for `ExecuteExit`.
+- `MainWindow.WhenActivated` registers a handler for each: style-editor handler news `GridStyleEditorWindow { DataContext = ctx.Input }` and `await ShowDialog(this)`; conflict handler news `PlcConflictDialog(ctx.Input)`, `await ShowDialog(this)`, then `ctx.SetOutput(dialog.Confirmed ? dialog.KeepLocal : null)`; close handler calls `Close()`. Remove `ViewModel.MainWindow = this;`.
+- Remove `public Window? MainWindow` and the `if (MainWindow is null) return;` guards; drop `using Avalonia.Controls;` from the VM if now unused.
+
+## Implementation Steps
+
+### Task 1: Migrate the style-editor and conflict dialogs to Interactions
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs`
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs`
+- Create/Modify: `SemiStep/SemiStep.Tests/UI/MainWindow/` tests
+
+- [x] add `ShowStyleEditorInteraction` (`Interaction<GridStyleEditorViewModel, Unit>`, public) and `ResolveConflictInteraction` (`Interaction<PlcConflictDialogViewModel, bool?>`, `internal` — CS0053 forbids a public member exposing the `internal sealed PlcConflictDialogViewModel`) as properties, constructed in the ctor, each with a one-line doc comment (the conflict one spells out null=cancel / true=keep-local / false=load-from-PLC).
+- [x] rewrite `ExecuteOpenStyleEditorAsync`: build + `LoadAsync` the editor VM as today, then `await ShowStyleEditorInteraction.Handle(viewModel)` (no `MainWindow`, no `new GridStyleEditorWindow`).
+- [x] rewrite `HandleConflictAsync`: `var keepLocal = await ResolveConflictInteraction.Handle(new PlcConflictDialogViewModel(local.StepCount, plc.StepCount))` inside the existing try/catch (keep the "Failed to show PLC conflict dialog" report on handler failure — it now also covers `UnhandledInteractionException` when no handler is registered, converting today's silent drop into a report); on `keepLocal is null` return; else run the existing `Guarded("PLC conflict resolution failed", …)` tail with `keepLocal.Value`. Keep the fire-and-forget `Guarded` subscription wrapper at `:89-93` unchanged.
+- [x] in `MainWindow.WhenActivated`, register the two handlers (news the respective window, `ShowDialog(this)`, `SetOutput`), disposing with `disposables`, mirroring the file-picker handlers. Do NOT yet remove `ViewModel.MainWindow = this;` (ExecuteExit still uses it — removed in Task 2).
+- [x] tests (register fake handlers; no `Window`):
+  - style-editor: the interaction fires with a non-null editor VM. For a happy-path `LoadAsync`-succeeded assertion, use a loadable config via the `CopyShippedConfig("MBE")` pattern (`GridStyleEditorWindowOwnerRoutingTests` does this) — the fixture's default factory points at a non-existent path (`UIFixture.cs:174-179`) so `LoadAsync` would fault; otherwise assert only that the interaction was invoked with a non-null VM.
+  - conflict branches: `HandleConflictAsync` is `private` and `RecipeCoordinator` is sealed (not mockable). Provide a seam — make `HandleConflictAsync` `internal` (mirroring `Guarded`/`OnSubscriptionError`) and assert an observable coordinator effect of `ResolveConflict(true/false)`, OR drive a real conflict via `PlcRecipeConflictDetected` and check the recipe outcome. Assert: confirm-keep → `ResolveConflict(true)`, confirm-load → `ResolveConflict(false)`, cancel (`null`) → no-op.
+  - a throwing conflict handler is contained + reported; AND no handler registered reports "Failed to show PLC conflict dialog" (the `UnhandledInteractionException` path) rather than silently vanishing.
+- [x] `dotnet build SemiStep.slnx` (0 warnings) + `--filter "FullyQualifiedName~MainWindowViewModel"` green — before next task.
+
+### Task 2: Route ExecuteExit through an interaction and delete the `MainWindow` property
+
+**Files:**
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs`
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/MainWindowViewModelReportingTests.cs` (namespace `SemiStep.Tests.UI` — NOT the same-named file under `UI/MainWindow/`). Line 56 does `viewModel.MainWindow = new Window();` inside `OpenStyleEditor_WhenFactoryThrows_...` — a compile break once the property is deleted. Drop that line; the test still validates (the factory throws before any interaction, reported via `OpenStyleEditorCommand.ReportThrownExceptions("Style editor failed")`).
+
+- [x] add `RequestCloseInteraction` (`Interaction<Unit, Unit>`); change `ExitCommand` from `ReactiveCommand.Create(ExecuteExit)` to `ReactiveCommand.CreateFromTask(async () => await RequestCloseInteraction.Handle(Unit.Default))`, and add `ExitCommand.ReportThrownExceptions(MessagePanel, _logger, "Exit failed").DisposeWith(_disposables)`. This routes exit through the command's own error channel (a handler failure or missing handler reports with context, no fire-and-forget). Do NOT use `_ = Handle(...).Subscribe()` — it reintroduces the unobserved-fault path this series eliminates. Delete the old `ExecuteExit` method. Keep a comment that closing routes through `OnWindowClosing`'s dirty guard.
+- [x] in `MainWindow.WhenActivated`, register the close handler (`ctx => { Close(); ctx.SetOutput(Unit.Default); }`) and REMOVE `ViewModel.MainWindow = this;`.
+- [x] delete `public Window? MainWindow { get; set; }` and the two `if (MainWindow is null) return;` guards; remove `using Avalonia.Controls;` from the VM if now unused.
+- [x] tests: `ExitCommand` invokes the close interaction; grep-confirm no `MainWindow` property remains on the VM. The existing `MainWindowExitFlowTests.ExitCommand_DirtySession_DoesNotCloseAndShowsConfirmation` (`:270`) and `ExitCommand_CleanSession_ClosesWindow` (`:289`) — which `await ExitCommand.Execute()` against a shown window — MUST stay green **unmodified**; they are the real regression for the `CreateFromTask` + `RequestCloseInteraction` migration and the dirty-close routing (the shown window registers the close handler in `WhenActivated`; `Close()` runs `OnWindowClosing`'s dirty guard). Note: "Exit failed" is now a report context in two disjoint sites — the VM's `ExitCommand.ReportThrownExceptions` (Handle/no-handler throw) and the view's `ShowExitChoiceAsync` catch (dialog-show throw); they never both fire for one failure.
+- [x] `dotnet build SemiStep.slnx` (0 warnings) + full UI slice green — before next task.
+
+### Task 3: Verify + document
+
+**Files:**
+- Modify: `Docs/architecture/error-reporting.md` or the relevant architecture doc (whichever documents dialog/interaction conventions)
+
+- [x] full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1496 passed, 0 failed, 0 skipped (Performance explicit probes not run by default).
+- [x] `dotnet build SemiStep.slnx` — 0 warnings, 0 errors
+- [x] `dotnet format SemiStep.slnx` — no changes
+- [x] document the convention: VM-driven dialogs go through `Interaction`s registered in `WhenActivated` (like the file pickers); the VM does not depend on `Window`. Note that the exit-confirmation and restart-prompt dialogs remain legitimately view-side (window-lifecycle) — so F3's async-void guards on them stay and are not superseded here. Added `Docs/architecture/dialogs-and-interactions.md` (focused new doc, cross-linked from/to `error-reporting.md` and `exit-flow.md`); also corrected the stale `ExecuteExit` reference in `exit-flow.md`.
+- [x] mark this plan for archival at delivery (do NOT move it mid-run). (archival deferred to delivery/ship)
+
+## Post-Completion
+
+**Manual verification:** the three smoke scenarios in Acceptance Evidence need a running app.
+
+**Follow-ups (not this PR):** the restart-prompt dialog (`GridStyleEditorWindow.OnSaveCompleted`) could move
+to an `Interaction` on `GridStyleEditorViewModel` as part of #118's style-editor cleanup; the exit flow is
+a genuine window-lifecycle concern and is expected to stay view-side.
+
+**Executed by exec:**
+- branch: dialog-interactions
+
+## Verify it yourself
+
+The win is headless testability; the proof is that the dialog flows now run in tests with no `Window`.
+
+- **The `Window` dependency is gone:** `grep -n "Window? MainWindow\|Avalonia.Controls" SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs` returns nothing.
+- **Dialogs run headless via Interactions:** `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName~MainWindowConflictResolution"` and `--filter "FullyQualifiedName~MainWindowStyleEditorInteraction"` — register a fake handler, drive the command, assert the branch. No window.
+- **Silent drop → report:** `MainWindowConflictResolutionTests` includes a no-handler test — a conflict with no registered handler now reports "Failed to show PLC conflict dialog" instead of vanishing (the old `if (MainWindow is null) return;`).
+- **Exit routing intact:** `--filter "FullyQualifiedName~ExitFlow"` — the two existing `ExitCommand_*` tests pass unmodified (`Close()` still runs `OnWindowClosing`'s dirty guard); the new `ExitCommand_InvokesRequestCloseInteraction` proves the command drives the close interaction.
+- **No regression:** full `dotnet test` (1496 pass) + `dotnet build SemiStep.slnx` (0 warnings).
+- **Manual smoke:** open the style editor from the toolbar; force a PLC recipe conflict and resolve both ways; File→Exit with unsaved changes shows the confirm dialog.


### PR DESCRIPTION
Closes #114.

## Problem

`MainWindowViewModel` depended on `Avalonia.Controls.Window` and newed two concrete window types
to show dialogs: `ExecuteOpenStyleEditorAsync` (`new GridStyleEditorWindow`) and `HandleConflictAsync`
(`new PlcConflictDialog`, then read results back from window properties). That made both flows
impossible to test headless, and was inconsistent with the same class's own use of ReactiveUI
`Interaction` for file pickers. The `Window? MainWindow` property was set by the view injecting
itself, and both flows carried a silent `if (MainWindow is null) return;` drop.

## What changed

- Route the two view-model dialogs through `Interaction`s declared on `MainWindowViewModel` and
  registered in `MainWindow.WhenActivated` — the established `OpenFileInteraction`/`SaveFileInteraction`
  pattern: `ShowStyleEditorInteraction` and `ResolveConflictInteraction` (output `bool?`: null=cancel,
  true=keep local, false=load from PLC).
- Replace `ExecuteExit`'s `MainWindow?.Close()` with a `RequestCloseInteraction`; `ExitCommand` becomes
  `CreateFromTask(RequestCloseAsync)` with `ReportThrownExceptions("Exit failed")` — no fire-and-forget.
- Delete the `Window? MainWindow` property (and `using Avalonia.Controls;`) from the view-model.

Both flows now test **headless** by registering a fake handler. The two silent null-guard drops become
**reported** failures — a conflict with no registered handler now reports "Failed to show PLC conflict
dialog" instead of vanishing.

**Scope (deliberately tight).** The exit-confirmation dialog (off `OnWindowClosing`) and the style
editor's restart-prompt (off `OnSaveCompleted`) are genuine window-lifecycle concerns, not view-model
MVVM violations, so they stay in code-behind. This corrects an earlier roadmap note: #114 does **not**
remove F3's async-void guards on those — they are permanent, not interim.

## Verification

- `dotnet build SemiStep.slnx` — 0 warnings (warnings are errors).
- `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1496 passed, 0 failed.
- New headless tests drive the real command/method with a fake handler: style-editor interaction fired
  with a loaded VM; conflict branches (keep-local / load-from-PLC / cancel); the no-handler-reports case;
  the exit command invokes the close interaction.
- The two existing `ExitCommand_*` dirty-close regression tests pass **unmodified** (the migration keeps
  `Close()` routing through `OnWindowClosing`'s dirty guard).
- Ran through the full multi-agent review chain (comprehensive, smells, comment audit, critical) plus a
  pre-implementation Fable + plan-review pass against current master.

## Note

`ResolveConflictInteraction` is `internal` (not public): its `PlcConflictDialogViewModel` input is
`internal sealed`, so a public property would be a CS0053 accessibility error. The view and tests reach
it via the existing `InternalsVisibleTo`.

<details>
<summary>Per-task commits before collapse</summary>

```
fc945e5 refactor(ui): route style-editor and conflict dialogs through Interactions
8340fc4 refactor(ui): route exit through interaction and remove Window from MainWindowViewModel
ff29826 docs(architecture): document VM-dialog Interaction convention
b6910f5 docs: cross-link dialog conventions and reconcile PR-114 plan
5cf068a refactor(ui): align dialog interaction handlers with file-picker idiom
8f2645b docs(plans): record exec branch + verification steps for PR-114
```

</details>
