### PR TITLE
feat(ui): localize operational and error messages (#115)

### DIFF
--- a/Docs/architecture/error-reporting.md
+++ b/Docs/architecture/error-reporting.md
@@ -105,11 +105,13 @@ always English; only the panel seams localize.
 A command whose `Execute` throws (file I/O, PLC calls) faults on `ReactiveCommand.ThrownExceptions`.
 These faults route through one extension:
 
-- `IDisposable ReportThrownExceptions<TParam, TResult>(this ReactiveCommand<TParam, TResult>, MessagePanelViewModel panel, ILogger logger, string context)`
+- `IDisposable ReportThrownExceptions<TParam, TResult>(this ReactiveCommand<TParam, TResult>, MessagePanelViewModel panel, ILogger logger, LocalizedText context)`
   (`SemiStep.UI/MessageService/ReactiveCommandReportingExtensions.cs`). Per thrown exception it both
-  `logger.LogError(ex, "{Context} failed", context)` **and** `panel.ReportError($"{context}: {ex.Message}")`.
-  The panel keeps the user-facing message it always showed; the log now carries the exception type and
-  full stack that the message drops.
+  `logger.LogError(ex, "{Context}", context.Invariant)` **and** `panel.ReportError($"{context.Localized}: {ex.Message}")`.
+  The split is deliberate: the log gets `context.Invariant` (English, stable for grepping), the panel gets
+  `context.Localized` (the current-culture value) — see `ui-localization.md`'s "Operational, error, and status
+  messages" section. The panel keeps the user-facing message it always showed; the log now carries the
+  exception type and full stack that the message drops.
 
 The `logger` argument is the caller's own `ILogger<TVm>`, so the Serilog `{SourceContext}` field names
 the originating view model in every logged fault. The extension takes the concrete

--- a/Docs/architecture/ui-localization.md
+++ b/Docs/architecture/ui-localization.md
@@ -83,9 +83,42 @@ tags instead of throwing).
 `CurrentCulture` is **never** assigned. Resource lookup keys off `UICulture`; number/date formatting
 and Serilog timestamps key off `CurrentCulture` and stay invariant/English. So `{elapsed:0.0}`, step
 counts, and log timestamps stay invariant regardless of UI language — the surrounding words localize,
-the numbers do not. Log message templates and notification-panel diagnostic strings (which carry
-exception text) stay hardcoded English by design. Typed Core failures, by contrast, localize on type at
-the panel seams through `ReasonLocalizer` — see `error-reporting.md` ("Localizing failures on type").
+the numbers do not. Log message templates stay hardcoded English by design. The operational/error/status
+strings the operator sees (command-fault contexts, report/success messages, file-picker titles) localize —
+see "Operational, error, and status messages" below. Typed Core failures localize on type at the panel
+seams through `ReasonLocalizer` — see `error-reporting.md` ("Localizing failures on type"); free-text
+`Result.Fail("…")` and exception `.Message` detail stay English until their per-subsystem waves.
+
+## Operational, error, and status messages
+
+The UI-composed strings on the error and status paths — the ones an operator reads when a command fails
+or a file is saved — go through resx like the rest of the chrome. They split into two shapes by whether
+the same string is also logged.
+
+**Report+log context (dual-use).** Command faults funnel through a single `context` argument that is BOTH
+logged AND shown in the notification panel (`ExceptionReporter.ReportAndLog` logs the context, then reports
+`"{context}: {ex.Message}"`). Logs must stay English (they align with the English log templates) while the
+panel must localize. A `LocalizedText` (in `SemiStep.UI.Localization`) carries a resx key and resolves it
+two ways: `.Invariant` for the log (`GetString(key, CultureInfo.InvariantCulture)`) and `.Localized` for the
+panel (`GetString(key, Resources.Culture)`). Call sites build it compile-safely against the designer accessor,
+`new LocalizedText(nameof(Resources.CopyStepFailed))` — a typo fails the build because the accessor must exist.
+`ReportThrownExceptions`, `ExceptionReporter.ReportAndLog`, and `MainWindowViewModel.Guarded`/`OnSubscriptionError`
+take `LocalizedText`; so the same fault logs English and shows the current-culture value from one key.
+
+**Panel-only strings.** Sites that only report (no log) take the localized accessor directly:
+`ReportError(Resources.X)`, `ReportFailure(result, Resources.X)`, and
+`ReportSuccess(string.Format(CultureInfo.InvariantCulture, Resources.SavedFormat, name))` for the count/name
+formats. The generic backstop message and the PLC-conflict-dialog-show failure resolve the same way.
+
+**File pickers.** The open/save dialog `Title` and the `FilePickerFileType` display names ("Recipe Files",
+"All Files", "CSV Files") come from resx accessors. The window title is not localized: it is the product
+name plus user data plus a `" *"` dirty marker, and its only natural-language part (the new-recipe placeholder)
+already uses `Resources.WindowTitleNewRecipe`.
+
+**What stays English.** Exception `.Message` detail (the suffix after the localized context), free-text
+Core `Result` text not yet typed by its wave, and every `logger.Log*` template. The `ReasonLocalizer` seam
+localizes typed Core error *content* on type; #115 localizes only the UI-composed *context* around it — a
+disjoint seam. See `error-reporting.md`.
 
 ## `ErrorWindow` is deliberately hardcoded English
 

--- a/SemiStep/SemiStep.Tests/UI/Localization/CategoryBLocalizationTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/CategoryBLocalizationTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Globalization;
+
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using FluentResults;
+
+using SemiStep.UI.Localization;
+using SemiStep.UI.MessageService;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.Localization;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Localization")]
+[Trait("Category", "Unit")]
+public sealed class CategoryBLocalizationTests
+{
+	// PasteStepFailed is a localized context, so the panel entry opens with the Russian prefix.
+	[AvaloniaFact]
+	public void PasteSinkContext_UnderRussianCulture_PrefixesPanelWithRussianText()
+	{
+		using var panel = new MessagePanelViewModel();
+		var result = Result.Fail("bad clipboard");
+
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			panel.ReportFailure(result, Resources.PasteStepFailed);
+		}
+
+		var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+		entry.Message.Should().StartWith("Не удалось вставить:");
+	}
+
+	// StepActionChangeFailedFormat is a localized context, so the panel entry opens with the Russian prefix.
+	[AvaloniaFact]
+	public void ChangeActionSinkContext_UnderRussianCulture_PrefixesPanelWithRussianText()
+	{
+		using var panel = new MessagePanelViewModel();
+		var result = Result.Fail("unknown action");
+
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			panel.ReportFailure(
+				result,
+				string.Format(CultureInfo.InvariantCulture, Resources.StepActionChangeFailedFormat, 1));
+		}
+
+		var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+		entry.Message.Should().StartWith("Шаг 1: не удалось изменить действие");
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Localization/CommandErrorLocalizationTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/CommandErrorLocalizationTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Linq;
+
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging;
+
+using ReactiveUI;
+
+using SemiStep.Tests.Helpers;
+using SemiStep.UI.Localization;
+using SemiStep.UI.MessageService;
+
+using Xunit;
+
+namespace SemiStep.Tests.UI.Localization;
+
+[Trait("Component", "UI")]
+[Trait("Area", "Localization")]
+[Trait("Category", "Unit")]
+public sealed class CommandErrorLocalizationTests
+{
+	[AvaloniaFact]
+	public async Task ReportThrownExceptions_UnderRussianCulture_ReportsRussianPrefixButLogsEnglishContext()
+	{
+		var panel = new MessagePanelViewModel();
+		var logger = new RecordingLogger<object>();
+		var failure = new InvalidOperationException("boom");
+		var command = ReactiveCommand.Create<Unit, Unit>(_ => throw failure);
+		var context = new LocalizedText(nameof(Resources.CopyStepFailed));
+
+		try
+		{
+			using (ResourcesCultureScope.Use("ru"))
+			using (command.ReportThrownExceptions(panel, logger, context))
+			{
+				try
+				{
+					await command.Execute();
+				}
+				catch (InvalidOperationException)
+				{
+					// Routed to ThrownExceptions; awaiting also surfaces it here.
+				}
+
+				var entry = panel.Entries.Should().ContainSingle().Subject;
+				entry.Severity.Should().Be(MessageSeverity.Error);
+				entry.Message.Should().Be("Не удалось скопировать: boom");
+
+				var logged = logger.Entries.Should().ContainSingle().Subject;
+				logged.Level.Should().Be(LogLevel.Error);
+				logged.Exception.Should().BeSameAs(failure);
+				logged.Message.Should().Be("Copy failed");
+			}
+		}
+		finally
+		{
+			command.Dispose();
+			panel.Dispose();
+		}
+	}
+}

--- a/SemiStep/SemiStep.Tests/UI/Localization/ResourceSyncTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ResourceSyncTests.cs
@@ -59,6 +59,22 @@ public sealed class ResourceSyncTests
 	}
 
 	[Fact]
+	public void EveryNeutralKey_HasDesignerAccessor()
+	{
+		// The per-key resolution test walks designer accessors -> resx (designer subset of resx).
+		// This is the reverse leg: every resx data name must have a matching public static string
+		// accessor, so a new resx key without a generated accessor fails the build's contract here.
+		var accessorNames = typeof(Resources)
+			.GetProperties(BindingFlags.Public | BindingFlags.Static)
+			.Where(property => property.PropertyType == typeof(string))
+			.Select(property => property.Name)
+			.ToHashSet();
+
+		_neutral.Keys.Should().BeSubsetOf(accessorNames,
+			"every resx data name must have a matching public static string accessor in Resources.Designer.cs");
+	}
+
+	[Fact]
 	public void EveryValue_IsNonEmpty_InBothSatellites()
 	{
 		_neutral.Values.Should().NotContain(string.Empty, "no English resx value may be blank");

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowConflictResolutionTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowConflictResolutionTests.cs
@@ -3,9 +3,9 @@
 using FluentAssertions;
 
 using SemiStep.Core.Recipes;
-
 using SemiStep.Tests.UI.Helpers;
 
+using SemiStep.UI.Localization;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.MessageService;
 
@@ -95,7 +95,7 @@ public sealed class MainWindowConflictResolutionTests : IAsyncLifetime
 
 		await act.Should().NotThrowAsync("a dialog fault must be contained on the fire-and-forget path");
 		_fixture.MessagePanel.Entries.Should().Contain(
-			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Failed to show PLC conflict dialog");
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == Resources.PlcConflictDialogShowFailed);
 	}
 
 	[AvaloniaFact]
@@ -104,7 +104,7 @@ public sealed class MainWindowConflictResolutionTests : IAsyncLifetime
 		await _viewModel.HandleConflictAsync(CurrentRecipe, CurrentRecipe);
 
 		_fixture.MessagePanel.Entries.Should().Contain(
-			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Failed to show PLC conflict dialog",
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == Resources.PlcConflictDialogShowFailed,
 			"an unhandled interaction must convert today's silent drop into a report");
 	}
 

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowExitFlowTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowExitFlowTests.cs
@@ -10,6 +10,7 @@ using FluentAssertions;
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
+using SemiStep.UI.Localization;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.ShutdownService;
@@ -106,7 +107,7 @@ public sealed class MainWindowExitFlowTests : IAsyncLifetime
 		_window.IsVisible.Should().BeTrue("a save exception must not discard the recipe by closing the window");
 		var errorEntry = _fixture.MessagePanel.Entries
 			.Should().ContainSingle(e => e.Severity == MessageSeverity.Error).Subject;
-		errorEntry.Message.Should().StartWith("Save failed:");
+		errorEntry.Message.Should().StartWith($"{Resources.SaveFailed}:");
 		errorEntry.Message.Should().Contain("disk detached");
 	}
 
@@ -125,7 +126,7 @@ public sealed class MainWindowExitFlowTests : IAsyncLifetime
 
 			var errorEntry = viewModel.MessagePanel.Entries
 				.Should().ContainSingle(e => e.Severity == MessageSeverity.Error).Subject;
-			errorEntry.Message.Should().StartWith("Exit failed:");
+			errorEntry.Message.Should().StartWith(Resources.ExitFailed + ":");
 		}
 		finally
 		{

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowHotkeyTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowHotkeyTests.cs
@@ -10,6 +10,7 @@ using ReactiveUI;
 
 using SemiStep.Tests.UI.Helpers;
 
+using SemiStep.UI.Localization;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.Reactive;
@@ -56,7 +57,7 @@ public sealed class MainWindowHotkeyTests : IAsyncLifetime
 		invoke.Should().NotThrow("ExecuteIfPossible swallows the caller-thread rethrow that would crash the app");
 
 		_fixture.MessagePanel.Entries.Should().ContainSingle(
-			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Orientation toggle failed: boom");
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == $"{Resources.OrientationToggleFailed}: boom");
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowViewModelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindow/MainWindowViewModelReportingTests.cs
@@ -13,6 +13,7 @@ using ReactiveUI;
 
 using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.RecipeGrid;
@@ -43,17 +44,18 @@ public sealed class MainWindowViewModelReportingTests : IAsyncLifetime
 	}
 
 	[AvaloniaTheory]
-	[InlineData("PLC state update")]
-	[InlineData("PLC conflict handling")]
-	[InlineData("Sync time refresh")]
-	public void OnSubscriptionError_ReportsToPanelAndLogsException(string context)
+	[InlineData(nameof(Resources.PlcStateUpdateFailed))]
+	[InlineData(nameof(Resources.PlcConflictHandlingFailed))]
+	[InlineData(nameof(Resources.SyncTimeRefreshFailed))]
+	public void OnSubscriptionError_ReportsToPanelAndLogsException(string contextKey)
 	{
 		var failure = new InvalidOperationException("boom");
+		var context = new LocalizedText(contextKey);
 
 		_viewModel.OnSubscriptionError(context)(failure);
 
 		_fixture.MessagePanel.Entries.Should().ContainSingle(
-			entry => entry.Severity == MessageSeverity.Error && entry.Message == $"{context}: boom");
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == $"{context.Localized}: boom");
 
 		var logged = _logger.Entries.Should().ContainSingle().Subject;
 		logged.Level.Should().Be(LogLevel.Error);
@@ -64,13 +66,14 @@ public sealed class MainWindowViewModelReportingTests : IAsyncLifetime
 	public void Guarded_ThrowInOnNextBody_ReportsToPanelAndLogs_WithoutEscaping()
 	{
 		var failure = new InvalidOperationException("boom");
+		var context = new LocalizedText(nameof(Resources.SyncTimeRefreshFailed));
 
-		var act = () => _viewModel.Guarded("Sync time refresh", () => throw failure);
+		var act = () => _viewModel.Guarded(context, () => throw failure);
 
 		act.Should().NotThrow("a throw in the onNext body must be contained, not propagated to the pipeline");
 
 		_fixture.MessagePanel.Entries.Should().ContainSingle(
-			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Sync time refresh: boom");
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == $"{context.Localized}: boom");
 
 		var logged = _logger.Entries.Should().ContainSingle().Subject;
 		logged.Level.Should().Be(LogLevel.Error);
@@ -81,6 +84,7 @@ public sealed class MainWindowViewModelReportingTests : IAsyncLifetime
 	public async Task ToggleOrientation_WhenFlipThrows_ReportsErrorToPanelAndLogs()
 	{
 		var failure = new InvalidOperationException("boom");
+		var context = new LocalizedText(nameof(Resources.OrientationToggleFailed));
 		var grid = (ActiveRecipeGridSurface)_viewModel.RecipeGrid;
 
 		// The flip raises Orientation; a throwing observer on that change makes the command body
@@ -99,7 +103,7 @@ public sealed class MainWindowViewModelReportingTests : IAsyncLifetime
 		}
 
 		_fixture.MessagePanel.Entries.Should().ContainSingle(
-			entry => entry.Severity == MessageSeverity.Error && entry.Message == "Orientation toggle failed: boom");
+			entry => entry.Severity == MessageSeverity.Error && entry.Message == $"{context.Localized}: boom");
 
 		var logged = _logger.Entries.Should().ContainSingle().Subject;
 		logged.Level.Should().Be(LogLevel.Error);
@@ -113,7 +117,7 @@ public sealed class MainWindowViewModelReportingTests : IAsyncLifetime
 		// entry rather than being dropped. Guarded's own throw-containment is proven above.
 		var result = Result.Fail("resolution rejected");
 
-		_viewModel.Guarded("PLC conflict resolution failed", () =>
+		_viewModel.Guarded(new LocalizedText(nameof(Resources.PlcConflictResolutionFailed)), () =>
 		{
 			if (result.IsFailed)
 			{

--- a/SemiStep/SemiStep.Tests/UI/MainWindowViewModelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MainWindowViewModelReportingTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Threading;
 using FluentAssertions;
 
 using SemiStep.Tests.UI.Helpers;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.MessageService;
 
@@ -65,7 +66,7 @@ public sealed class MainWindowViewModelReportingTests : IAsyncLifetime
 
 			var operationEntry = _fixture.MessagePanel.Entries
 				.Should().ContainSingle(e => e.Severity == MessageSeverity.Error).Subject;
-			operationEntry.Message.Should().StartWith("Style editor failed:");
+			operationEntry.Message.Should().StartWith($"{Resources.StyleEditorFailed}:");
 			operationEntry.Message.Should().Contain("factory boom");
 		}
 		finally

--- a/SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System.Globalization;
+using System.Reactive.Linq;
 
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
@@ -17,6 +18,7 @@ using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
 using SemiStep.UI.Clipboard;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.RecipeFile;
 using SemiStep.UI.RecipeGrid;
@@ -62,7 +64,8 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 
 			var operationEntry = _fixture.MessagePanel.Entries.First();
 			operationEntry.Severity.Should().Be(MessageSeverity.Info);
-			operationEntry.Message.Should().StartWith("Saved:");
+			operationEntry.Message.Should().Be(
+				string.Format(CultureInfo.CurrentCulture, Resources.SavedFormat, Path.GetFileName(filePath)));
 		}
 		finally
 		{
@@ -90,7 +93,8 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 
 			var operationEntry = _fixture.MessagePanel.Entries.First();
 			operationEntry.Severity.Should().Be(MessageSeverity.Info);
-			operationEntry.Message.Should().StartWith("Loaded:");
+			operationEntry.Message.Should().Be(
+				string.Format(CultureInfo.CurrentCulture, Resources.LoadedFormat, Path.GetFileName(filePath)));
 		}
 		finally
 		{
@@ -131,7 +135,8 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 		_surface.RecipeRows[0].SetPropertyValue(RecipeTestDriver.StepDurationColumn, "not_a_valid_number");
 
 		var operationEntry = _fixture.MessagePanel.Entries.Should().ContainSingle(entry => entry.IsError).Subject;
-		operationEntry.Message.Should().StartWith("Step 1:");
+		operationEntry.Message.Should().StartWith(
+			string.Format(CultureInfo.CurrentCulture, Resources.StepFormat, 1) + ":");
 		_fixture.MessagePanel.ErrorCount.Should().Be(0,
 			"a rejected edit is an operation outcome surfaced transiently, not a structural defect counted in the panel");
 	}
@@ -145,7 +150,8 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 		_surface.RecipeRows[0].SetPropertyValue("action", "999999");
 
 		var operationEntry = _fixture.MessagePanel.Entries.Should().ContainSingle(entry => entry.IsError).Subject;
-		operationEntry.Message.Should().StartWith("Step 1: Failed to change action");
+		operationEntry.Message.Should().StartWith(
+			string.Format(CultureInfo.CurrentCulture, Resources.StepActionChangeFailedFormat, 1));
 		_fixture.MessagePanel.ErrorCount.Should().Be(0,
 			"a rejected action change is an operation outcome surfaced transiently, not a structural defect counted in the panel");
 	}
@@ -177,7 +183,7 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 
 			var operationEntry = _fixture.MessagePanel.Entries.First();
 			operationEntry.Severity.Should().Be(MessageSeverity.Error);
-			operationEntry.Message.Should().StartWith("Paste failed:");
+			operationEntry.Message.Should().StartWith(Resources.PasteStepFailed + ":");
 		}
 		finally
 		{

--- a/SemiStep/SemiStep.Tests/UI/MessageService/ReactiveCommandReportingExtensionsTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MessageService/ReactiveCommandReportingExtensionsTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using ReactiveUI;
 
 using SemiStep.Tests.Helpers;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 
 using Xunit;
@@ -29,8 +30,9 @@ public sealed class ReactiveCommandReportingExtensionsTests
 		var logger = new RecordingLogger<object>();
 		var failure = new InvalidOperationException("boom");
 		var command = ReactiveCommand.Create<Unit, Unit>(_ => throw failure);
+		var context = new LocalizedText(nameof(Resources.CopyStepFailed));
 
-		using var subscription = command.ReportThrownExceptions(panel, logger, "Copy failed");
+		using var subscription = command.ReportThrownExceptions(panel, logger, context);
 
 		try
 		{
@@ -38,7 +40,7 @@ public sealed class ReactiveCommandReportingExtensionsTests
 
 			var entry = panel.Entries.Should().ContainSingle().Subject;
 			entry.Severity.Should().Be(MessageSeverity.Error);
-			entry.Message.Should().Be("Copy failed: boom");
+			entry.Message.Should().Be($"{context.Localized}: boom");
 
 			var logged = logger.Entries.Should().ContainSingle().Subject;
 			logged.Level.Should().Be(LogLevel.Error);
@@ -58,7 +60,8 @@ public sealed class ReactiveCommandReportingExtensionsTests
 		var logger = new RecordingLogger<object>();
 		var command = ReactiveCommand.Create<Unit, Unit>(_ => Unit.Default);
 
-		using var subscription = command.ReportThrownExceptions(panel, logger, "Copy failed");
+		using var subscription = command.ReportThrownExceptions(
+			panel, logger, new LocalizedText(nameof(Resources.CopyStepFailed)));
 
 		try
 		{

--- a/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeCoordinatorTests.cs
@@ -14,6 +14,7 @@ using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
 using SemiStep.UI.Coordinator;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 
 using Xunit;
@@ -470,7 +471,7 @@ public sealed class RecipeCoordinatorTests : IAsyncLifetime
 		var operationEntry = _fixture.MessagePanel.Entries[0];
 		operationEntry.Severity.Should().Be(MessageSeverity.Error,
 			"a failed reconnect-apply has no initiating VM, so the coordinator must report it as an operation error");
-		operationEntry.Message.Should().Contain("PLC reconnect",
+		operationEntry.Message.Should().Contain(Resources.PlcReconnect,
 			"the operation message must identify the reconnect-apply origin");
 
 		_fixture.MessagePanel.ErrorCount.Should().Be(0,

--- a/SemiStep/SemiStep.Tests/UI/RecipeFile/RecipeFileViewModelSaveResultTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeFile/RecipeFileViewModelSaveResultTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.RecipeFile;
 
@@ -175,7 +176,7 @@ public sealed class RecipeFileViewModelSaveResultTests : IAsyncLifetime
 		Dispatcher.UIThread.RunJobs();
 		var errorEntry = _fixture.MessagePanel.Entries
 			.Should().ContainSingle(e => e.Severity == MessageSeverity.Error).Subject;
-		errorEntry.Message.Should().StartWith("Save As failed:");
+		errorEntry.Message.Should().StartWith($"{Resources.SaveAsFailed}:");
 		errorEntry.Message.Should().Contain("disk detached");
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelReportingTests.cs
@@ -14,6 +14,7 @@ using SemiStep.Core.Recipes;
 using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.RecipeGrid;
 
@@ -57,7 +58,7 @@ public sealed class RecipeCommandsViewModelReportingTests : IAsyncLifetime
 		await ExecuteSwallowing(_commands.AddStepCommand);
 
 		_fixture.MessagePanel.Entries.Should()
-			.Contain(e => e.IsError && e.Message.StartsWith("Add step failed:") && e.Message.Contains("boom"));
+			.Contain(e => e.IsError && e.Message.StartsWith($"{Resources.AddStepFailed}:") && e.Message.Contains("boom"));
 
 		var logged = _logger.Entries.Should().ContainSingle().Subject;
 		logged.Level.Should().Be(LogLevel.Error);

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedRecipeGridSurfaceTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/Transposed/TransposedRecipeGridSurfaceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Globalization;
 
 using Avalonia.Headless.XUnit;
 
@@ -12,6 +13,7 @@ using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
 using SemiStep.UI.Coordinator;
+using SemiStep.UI.Localization;
 using SemiStep.UI.RecipeGrid.Transposed;
 
 using Xunit;
@@ -468,7 +470,8 @@ public sealed class TransposedRecipeGridSurfaceTests : IAsyncLifetime
 
 		var operationEntry = _fixture.MessagePanel.Entries.Should()
 			.ContainSingle(entry => entry.IsError).Subject;
-		operationEntry.Message.Should().StartWith("Step 1:");
+		operationEntry.Message.Should().StartWith(
+			string.Format(CultureInfo.CurrentCulture, Resources.StepFormat, 1) + ":");
 	}
 
 	[AvaloniaFact]
@@ -481,7 +484,8 @@ public sealed class TransposedRecipeGridSurfaceTests : IAsyncLifetime
 
 		var operationEntry = _fixture.MessagePanel.Entries.Should()
 			.ContainSingle(entry => entry.IsError).Subject;
-		operationEntry.Message.Should().StartWith("Step 1: Failed to change action");
+		operationEntry.Message.Should().StartWith(
+			string.Format(CultureInfo.CurrentCulture, Resources.StepActionChangeFailedFormat, 1));
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.Tests/UI/StyleEditor/GridStyleEditorViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/StyleEditor/GridStyleEditorViewModelTests.cs
@@ -274,7 +274,7 @@ public sealed class GridStyleEditorViewModelTests
 
 		await ExecuteSwallowing(viewModel.SaveCommand);
 
-		viewModel.ErrorMessage.Should().Be("Save failed: disk gone");
+		viewModel.ErrorMessage.Should().Be($"{Resources.SaveFailed}: disk gone");
 		var logged = logger.Entries.Should().ContainSingle().Subject;
 		logged.Level.Should().Be(LogLevel.Error);
 		logged.Exception.Should().BeSameAs(failure);
@@ -293,7 +293,7 @@ public sealed class GridStyleEditorViewModelTests
 
 		viewModel.ReportSaveException(failure);
 
-		viewModel.ErrorMessage.Should().Be("Save failed: boom");
+		viewModel.ErrorMessage.Should().Be($"{Resources.SaveFailed}: boom");
 		var logged = logger.Entries.Should().ContainSingle().Subject;
 		logged.Level.Should().Be(LogLevel.Error);
 		logged.Exception.Should().BeSameAs(failure);

--- a/SemiStep/SemiStep.Tests/UI/StyleEditor/GridStyleEditorWindowOwnerRoutingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/StyleEditor/GridStyleEditorWindowOwnerRoutingTests.cs
@@ -14,6 +14,7 @@ using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
 
+using SemiStep.UI.Localization;
 using SemiStep.UI.MainWindow;
 using SemiStep.UI.ShutdownService;
 using SemiStep.UI.StyleEditor;
@@ -166,7 +167,7 @@ public sealed class GridStyleEditorWindowOwnerRoutingTests : IAsyncLifetime
 		Dispatcher.UIThread.RunJobs();
 
 		viewModel.ErrorMessage.Should().StartWith(
-			"Save failed:",
+			Resources.SaveFailed + ":",
 			"the fault must surface on the editor's own error surface instead of crashing the app");
 	}
 

--- a/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
+++ b/SemiStep/SemiStep.UI/Clipboard/ClipboardViewModel.cs
@@ -17,6 +17,7 @@ using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Helpers;
 
 using SemiStep.UI.Coordinator;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 using SemiStep.UI.RecipeGrid;
 
@@ -58,13 +59,13 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 			canEdit.CombineLatest(canCopyOrCut, (left, right) => left && right));
 		PasteStepCommand = ReactiveCommand.CreateFromTask(PasteStepsAsync, canEdit);
 
-		CopyStepCommand.ReportThrownExceptions(_messagePanel, _logger, "Copy failed")
+		CopyStepCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.CopyStepFailed)))
 			.DisposeWith(_disposables);
 
-		CutStepCommand.ReportThrownExceptions(_messagePanel, _logger, "Cut failed")
+		CutStepCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.CutStepFailed)))
 			.DisposeWith(_disposables);
 
-		PasteStepCommand.ReportThrownExceptions(_messagePanel, _logger, "Paste failed")
+		PasteStepCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.PasteStepFailed)))
 			.DisposeWith(_disposables);
 	}
 
@@ -134,11 +135,7 @@ public class ClipboardViewModel : ReactiveObject, IDisposable
 		var recipeResult = DeserializeStepsFromClipboard(csvText);
 		if (recipeResult.IsFailed)
 		{
-			var errorMessages = string.Join(
-				Environment.NewLine,
-				recipeResult.Errors.Select(e => e.Message));
-
-			_messagePanel.ReportError($"Paste failed: {errorMessages}");
+			_messagePanel.ReportFailure(recipeResult, Resources.PasteStepFailed);
 
 			return;
 		}

--- a/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
+++ b/SemiStep/SemiStep.UI/Coordinator/RecipeCoordinator.cs
@@ -16,6 +16,7 @@ using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Core.Recipes.Import;
 
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 
 namespace SemiStep.UI.Coordinator;
@@ -417,7 +418,7 @@ public sealed class RecipeCoordinator : IDisposable
 				_logger.LogWarning(
 					"Reconnect reconciliation failed to apply PLC recipe: {Errors}",
 					applyResult.FormatErrors());
-				_messagePanel.ReportFailure(applyResult, "PLC reconnect");
+				_messagePanel.ReportFailure(applyResult, Resources.PlcReconnect);
 				return applyResult;
 			}
 

--- a/SemiStep/SemiStep.UI/Localization/LocalizedText.cs
+++ b/SemiStep/SemiStep.UI/Localization/LocalizedText.cs
@@ -1,0 +1,13 @@
+﻿using System.Globalization;
+
+namespace SemiStep.UI.Localization;
+
+// Carries a resx key so a command-error context can render both an invariant/English form for
+// the log and a current-culture form for the panel. No implicit conversion from string exists,
+// so a raw literal can never masquerade as a key.
+public readonly record struct LocalizedText(string ResourceKey)
+{
+	public string Localized => Resources.ResourceManager.GetString(ResourceKey, Resources.Culture) ?? ResourceKey;
+
+	public string Invariant => Resources.ResourceManager.GetString(ResourceKey, CultureInfo.InvariantCulture) ?? ResourceKey;
+}

--- a/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
+++ b/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
@@ -297,4 +297,66 @@ public class Resources
 	public static string ErrorOwnedByAnotherInstance => ResourceManager.GetString("ErrorOwnedByAnotherInstance", resourceCulture) ?? string.Empty;
 
 	public static string ErrorFormulaComputationFailed => ResourceManager.GetString("ErrorFormulaComputationFailed", resourceCulture) ?? string.Empty;
+
+	public static string CopyStepFailed => ResourceManager.GetString("CopyStepFailed", resourceCulture) ?? string.Empty;
+
+	public static string CutStepFailed => ResourceManager.GetString("CutStepFailed", resourceCulture) ?? string.Empty;
+
+	public static string PasteStepFailed => ResourceManager.GetString("PasteStepFailed", resourceCulture) ?? string.Empty;
+
+	public static string SaveFailed => ResourceManager.GetString("SaveFailed", resourceCulture) ?? string.Empty;
+
+	public static string SaveAsFailed => ResourceManager.GetString("SaveAsFailed", resourceCulture) ?? string.Empty;
+
+	public static string LoadFailed => ResourceManager.GetString("LoadFailed", resourceCulture) ?? string.Empty;
+
+	public static string SyncToggleFailed => ResourceManager.GetString("SyncToggleFailed", resourceCulture) ?? string.Empty;
+
+	public static string StyleEditorFailed => ResourceManager.GetString("StyleEditorFailed", resourceCulture) ?? string.Empty;
+
+	public static string ExitFailed => ResourceManager.GetString("ExitFailed", resourceCulture) ?? string.Empty;
+
+	public static string OrientationToggleFailed => ResourceManager.GetString("OrientationToggleFailed", resourceCulture) ?? string.Empty;
+
+	public static string PlcStateUpdateFailed => ResourceManager.GetString("PlcStateUpdateFailed", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictHandlingFailed => ResourceManager.GetString("PlcConflictHandlingFailed", resourceCulture) ?? string.Empty;
+
+	public static string SyncTimeRefreshFailed => ResourceManager.GetString("SyncTimeRefreshFailed", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictResolutionFailed => ResourceManager.GetString("PlcConflictResolutionFailed", resourceCulture) ?? string.Empty;
+
+	public static string AddStepFailed => ResourceManager.GetString("AddStepFailed", resourceCulture) ?? string.Empty;
+
+	public static string DeleteStepFailed => ResourceManager.GetString("DeleteStepFailed", resourceCulture) ?? string.Empty;
+
+	public static string UndoFailed => ResourceManager.GetString("UndoFailed", resourceCulture) ?? string.Empty;
+
+	public static string RedoFailed => ResourceManager.GetString("RedoFailed", resourceCulture) ?? string.Empty;
+
+	public static string PlcConflictDialogShowFailed => ResourceManager.GetString("PlcConflictDialogShowFailed", resourceCulture) ?? string.Empty;
+
+	public static string SaveRecipeFailed => ResourceManager.GetString("SaveRecipeFailed", resourceCulture) ?? string.Empty;
+
+	public static string SavedFormat => ResourceManager.GetString("SavedFormat", resourceCulture) ?? string.Empty;
+
+	public static string LoadedFormat => ResourceManager.GetString("LoadedFormat", resourceCulture) ?? string.Empty;
+
+	public static string PlcReconnect => ResourceManager.GetString("PlcReconnect", resourceCulture) ?? string.Empty;
+
+	public static string StepFormat => ResourceManager.GetString("StepFormat", resourceCulture) ?? string.Empty;
+
+	public static string StepActionChangeFailedFormat => ResourceManager.GetString("StepActionChangeFailedFormat", resourceCulture) ?? string.Empty;
+
+	public static string UnexpectedErrorMessage => ResourceManager.GetString("UnexpectedErrorMessage", resourceCulture) ?? string.Empty;
+
+	public static string OpenRecipeDialogTitle => ResourceManager.GetString("OpenRecipeDialogTitle", resourceCulture) ?? string.Empty;
+
+	public static string SaveRecipeDialogTitle => ResourceManager.GetString("SaveRecipeDialogTitle", resourceCulture) ?? string.Empty;
+
+	public static string RecipeFilesFilter => ResourceManager.GetString("RecipeFilesFilter", resourceCulture) ?? string.Empty;
+
+	public static string AllFilesFilter => ResourceManager.GetString("AllFilesFilter", resourceCulture) ?? string.Empty;
+
+	public static string CsvFilesFilter => ResourceManager.GetString("CsvFilesFilter", resourceCulture) ?? string.Empty;
 }

--- a/SemiStep/SemiStep.UI/Localization/Resources.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.resx
@@ -454,4 +454,97 @@
   <data name="ErrorFormulaComputationFailed" xml:space="preserve">
     <value>Formula computation for target '{0}' failed: {1}</value>
   </data>
+  <data name="CopyStepFailed" xml:space="preserve">
+    <value>Copy failed</value>
+  </data>
+  <data name="CutStepFailed" xml:space="preserve">
+    <value>Cut failed</value>
+  </data>
+  <data name="PasteStepFailed" xml:space="preserve">
+    <value>Paste failed</value>
+  </data>
+  <data name="SaveFailed" xml:space="preserve">
+    <value>Save failed</value>
+  </data>
+  <data name="SaveAsFailed" xml:space="preserve">
+    <value>Save As failed</value>
+  </data>
+  <data name="LoadFailed" xml:space="preserve">
+    <value>Load failed</value>
+  </data>
+  <data name="SyncToggleFailed" xml:space="preserve">
+    <value>Sync toggle failed</value>
+  </data>
+  <data name="StyleEditorFailed" xml:space="preserve">
+    <value>Style editor failed</value>
+  </data>
+  <data name="ExitFailed" xml:space="preserve">
+    <value>Exit failed</value>
+  </data>
+  <data name="OrientationToggleFailed" xml:space="preserve">
+    <value>Orientation toggle failed</value>
+  </data>
+  <data name="PlcStateUpdateFailed" xml:space="preserve">
+    <value>PLC state update failed</value>
+  </data>
+  <data name="PlcConflictHandlingFailed" xml:space="preserve">
+    <value>PLC conflict handling failed</value>
+  </data>
+  <data name="SyncTimeRefreshFailed" xml:space="preserve">
+    <value>Sync time refresh failed</value>
+  </data>
+  <data name="PlcConflictResolutionFailed" xml:space="preserve">
+    <value>PLC conflict resolution failed</value>
+  </data>
+  <data name="AddStepFailed" xml:space="preserve">
+    <value>Add step failed</value>
+  </data>
+  <data name="DeleteStepFailed" xml:space="preserve">
+    <value>Delete step failed</value>
+  </data>
+  <data name="UndoFailed" xml:space="preserve">
+    <value>Undo failed</value>
+  </data>
+  <data name="RedoFailed" xml:space="preserve">
+    <value>Redo failed</value>
+  </data>
+  <data name="PlcConflictDialogShowFailed" xml:space="preserve">
+    <value>Failed to show PLC conflict dialog</value>
+  </data>
+  <data name="SaveRecipeFailed" xml:space="preserve">
+    <value>Failed to save recipe</value>
+  </data>
+  <data name="SavedFormat" xml:space="preserve">
+    <value>Saved: {0}</value>
+  </data>
+  <data name="LoadedFormat" xml:space="preserve">
+    <value>Loaded: {0}</value>
+  </data>
+  <data name="PlcReconnect" xml:space="preserve">
+    <value>PLC reconnect</value>
+  </data>
+  <data name="StepFormat" xml:space="preserve">
+    <value>Step {0}</value>
+  </data>
+  <data name="StepActionChangeFailedFormat" xml:space="preserve">
+    <value>Step {0}: Failed to change action</value>
+  </data>
+  <data name="UnexpectedErrorMessage" xml:space="preserve">
+    <value>An unexpected error occurred; see the log for details.</value>
+  </data>
+  <data name="OpenRecipeDialogTitle" xml:space="preserve">
+    <value>Open Recipe</value>
+  </data>
+  <data name="SaveRecipeDialogTitle" xml:space="preserve">
+    <value>Save Recipe</value>
+  </data>
+  <data name="RecipeFilesFilter" xml:space="preserve">
+    <value>Recipe Files</value>
+  </data>
+  <data name="AllFilesFilter" xml:space="preserve">
+    <value>All Files</value>
+  </data>
+  <data name="CsvFilesFilter" xml:space="preserve">
+    <value>CSV Files</value>
+  </data>
 </root>

--- a/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
@@ -454,4 +454,97 @@
   <data name="ErrorFormulaComputationFailed" xml:space="preserve">
     <value>Вычисление формулы для цели «{0}» не выполнено: {1}</value>
   </data>
+  <data name="CopyStepFailed" xml:space="preserve">
+    <value>Не удалось скопировать</value>
+  </data>
+  <data name="CutStepFailed" xml:space="preserve">
+    <value>Не удалось вырезать</value>
+  </data>
+  <data name="PasteStepFailed" xml:space="preserve">
+    <value>Не удалось вставить</value>
+  </data>
+  <data name="SaveFailed" xml:space="preserve">
+    <value>Не удалось сохранить</value>
+  </data>
+  <data name="SaveAsFailed" xml:space="preserve">
+    <value>Не удалось сохранить как</value>
+  </data>
+  <data name="LoadFailed" xml:space="preserve">
+    <value>Не удалось загрузить</value>
+  </data>
+  <data name="SyncToggleFailed" xml:space="preserve">
+    <value>Не удалось переключить синхронизацию</value>
+  </data>
+  <data name="StyleEditorFailed" xml:space="preserve">
+    <value>Ошибка редактора стилей</value>
+  </data>
+  <data name="ExitFailed" xml:space="preserve">
+    <value>Не удалось выйти</value>
+  </data>
+  <data name="OrientationToggleFailed" xml:space="preserve">
+    <value>Не удалось изменить ориентацию</value>
+  </data>
+  <data name="PlcStateUpdateFailed" xml:space="preserve">
+    <value>Не удалось обновить состояние ПЛК</value>
+  </data>
+  <data name="PlcConflictHandlingFailed" xml:space="preserve">
+    <value>Не удалось обработать конфликт ПЛК</value>
+  </data>
+  <data name="SyncTimeRefreshFailed" xml:space="preserve">
+    <value>Не удалось обновить время синхронизации</value>
+  </data>
+  <data name="PlcConflictResolutionFailed" xml:space="preserve">
+    <value>Не удалось разрешить конфликт ПЛК</value>
+  </data>
+  <data name="AddStepFailed" xml:space="preserve">
+    <value>Не удалось добавить шаг</value>
+  </data>
+  <data name="DeleteStepFailed" xml:space="preserve">
+    <value>Не удалось удалить шаг</value>
+  </data>
+  <data name="UndoFailed" xml:space="preserve">
+    <value>Не удалось отменить</value>
+  </data>
+  <data name="RedoFailed" xml:space="preserve">
+    <value>Не удалось повторить</value>
+  </data>
+  <data name="PlcConflictDialogShowFailed" xml:space="preserve">
+    <value>Не удалось показать диалог конфликта ПЛК</value>
+  </data>
+  <data name="SaveRecipeFailed" xml:space="preserve">
+    <value>Не удалось сохранить рецепт</value>
+  </data>
+  <data name="SavedFormat" xml:space="preserve">
+    <value>Сохранено: {0}</value>
+  </data>
+  <data name="LoadedFormat" xml:space="preserve">
+    <value>Загружено: {0}</value>
+  </data>
+  <data name="PlcReconnect" xml:space="preserve">
+    <value>Переподключение ПЛК</value>
+  </data>
+  <data name="StepFormat" xml:space="preserve">
+    <value>Шаг {0}</value>
+  </data>
+  <data name="StepActionChangeFailedFormat" xml:space="preserve">
+    <value>Шаг {0}: не удалось изменить действие</value>
+  </data>
+  <data name="UnexpectedErrorMessage" xml:space="preserve">
+    <value>Произошла непредвиденная ошибка; подробности см. в журнале.</value>
+  </data>
+  <data name="OpenRecipeDialogTitle" xml:space="preserve">
+    <value>Открыть рецепт</value>
+  </data>
+  <data name="SaveRecipeDialogTitle" xml:space="preserve">
+    <value>Сохранить рецепт</value>
+  </data>
+  <data name="RecipeFilesFilter" xml:space="preserve">
+    <value>Файлы рецептов</value>
+  </data>
+  <data name="AllFilesFilter" xml:space="preserve">
+    <value>Все файлы</value>
+  </data>
+  <data name="CsvFilesFilter" xml:space="preserve">
+    <value>Файлы CSV</value>
+  </data>
 </root>

--- a/SemiStep/SemiStep.UI/Logging/GlobalExceptionBackstop.cs
+++ b/SemiStep/SemiStep.UI/Logging/GlobalExceptionBackstop.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 
 using ReactiveUI.Builder;
 
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 
 using SerilogLog = Serilog.Log;
@@ -18,7 +19,7 @@ namespace SemiStep.UI.Logging;
 
 internal static class GlobalExceptionBackstop
 {
-	internal const string RecoverableUserMessage = "An unexpected error occurred; see the log for details.";
+	internal static string RecoverableUserMessage => Resources.UnexpectedErrorMessage;
 
 	// ReactiveUI 23 dropped the settable RxApp.DefaultExceptionHandler; the pipeline handler is configured
 	// once through the builder (RxState.InitializeExceptionHandler), which runs before the first

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindow.axaml.cs
@@ -14,6 +14,8 @@ using SemiStep.UI.Reactive;
 using SemiStep.UI.ShutdownService;
 using SemiStep.UI.StyleEditor;
 
+using LocalizationResources = SemiStep.UI.Localization.Resources;
+
 namespace SemiStep.UI.MainWindow;
 
 internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
@@ -157,7 +159,7 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 			// Reached from an async void event handler: an unhandled throw here unwinds the
 			// dispatcher loop into Program.Main and kills the process. Contain it, report,
 			// and keep the window open (e.Cancel is already true at the call site).
-			ViewModel?.MessagePanel.ReportError($"Exit failed: {ex.Message}");
+			ViewModel?.MessagePanel.ReportError($"{LocalizationResources.ExitFailed}: {ex.Message}");
 		}
 		finally
 		{
@@ -231,12 +233,12 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 	{
 		var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
 		{
-			Title = "Open Recipe",
+			Title = LocalizationResources.OpenRecipeDialogTitle,
 			AllowMultiple = false,
 			FileTypeFilter =
 			[
-				new FilePickerFileType("Recipe Files") { Patterns = ["*.csv", "*.recipe"] },
-				new FilePickerFileType("All Files") { Patterns = ["*.*"] }
+				new FilePickerFileType(LocalizationResources.RecipeFilesFilter) { Patterns = ["*.csv", "*.recipe"] },
+				new FilePickerFileType(LocalizationResources.AllFilesFilter) { Patterns = ["*.*"] }
 			]
 		});
 
@@ -248,13 +250,13 @@ internal partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 	{
 		var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
 		{
-			Title = "Save Recipe",
+			Title = LocalizationResources.SaveRecipeDialogTitle,
 			DefaultExtension = "csv",
 			SuggestedFileName = context.Input ?? "recipe",
 			FileTypeChoices =
 			[
-				new FilePickerFileType("CSV Files") { Patterns = ["*.csv"] },
-				new FilePickerFileType("Recipe Files") { Patterns = ["*.recipe"] }
+				new FilePickerFileType(LocalizationResources.CsvFilesFilter) { Patterns = ["*.csv"] },
+				new FilePickerFileType(LocalizationResources.RecipeFilesFilter) { Patterns = ["*.recipe"] }
 			]
 		});
 

--- a/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
+++ b/SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs
@@ -70,16 +70,16 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 			.ToProperty(this, x => x.IsTransposedOrientation)
 			.DisposeWith(_disposables);
 
-		ToggleSyncCommand.ReportThrownExceptions(MessagePanel, _logger, "Sync toggle failed")
+		ToggleSyncCommand.ReportThrownExceptions(MessagePanel, _logger, new LocalizedText(nameof(Resources.SyncToggleFailed)))
 			.DisposeWith(_disposables);
 
-		OpenStyleEditorCommand.ReportThrownExceptions(MessagePanel, _logger, "Style editor failed")
+		OpenStyleEditorCommand.ReportThrownExceptions(MessagePanel, _logger, new LocalizedText(nameof(Resources.StyleEditorFailed)))
 			.DisposeWith(_disposables);
 
-		ExitCommand.ReportThrownExceptions(MessagePanel, _logger, "Exit failed")
+		ExitCommand.ReportThrownExceptions(MessagePanel, _logger, new LocalizedText(nameof(Resources.ExitFailed)))
 			.DisposeWith(_disposables);
 
-		ToggleOrientationCommand.ReportThrownExceptions(MessagePanel, _logger, "Orientation toggle failed")
+		ToggleOrientationCommand.ReportThrownExceptions(MessagePanel, _logger, new LocalizedText(nameof(Resources.OrientationToggleFailed)))
 			.DisposeWith(_disposables);
 
 		_coordinator.Mutated += OnCoordinatorMutated;
@@ -87,21 +87,25 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 
 		_coordinator.PlcStateChanged
 			.Subscribe(
-				_ => Guarded("PLC state update", RaiseConnectionStateProperties),
-				OnSubscriptionError("PLC state update"))
+				_ => Guarded(new LocalizedText(nameof(Resources.PlcStateUpdateFailed)), RaiseConnectionStateProperties),
+				OnSubscriptionError(new LocalizedText(nameof(Resources.PlcStateUpdateFailed))))
 			.DisposeWith(_disposables);
 
 		_coordinator.PlcRecipeConflictDetected
 			.Subscribe(
-				conflict => Guarded("PLC conflict handling", () => _ = HandleConflictAsync(conflict.Local, conflict.Plc)),
-				OnSubscriptionError("PLC conflict handling"))
+				conflict => Guarded(
+					new LocalizedText(nameof(Resources.PlcConflictHandlingFailed)),
+					() => _ = HandleConflictAsync(conflict.Local, conflict.Plc)),
+				OnSubscriptionError(new LocalizedText(nameof(Resources.PlcConflictHandlingFailed))))
 			.DisposeWith(_disposables);
 
 		Observable.Interval(TimeSpan.FromSeconds(1))
 			.ObserveOn(RxSchedulers.MainThreadScheduler)
 			.Subscribe(
-				_ => Guarded("Sync time refresh", () => this.RaisePropertyChanged(nameof(LastSyncTimeText))),
-				OnSubscriptionError("Sync time refresh"))
+				_ => Guarded(
+					new LocalizedText(nameof(Resources.SyncTimeRefreshFailed)),
+					() => this.RaisePropertyChanged(nameof(LastSyncTimeText))),
+				OnSubscriptionError(new LocalizedText(nameof(Resources.SyncTimeRefreshFailed))))
 			.DisposeWith(_disposables);
 	}
 
@@ -228,7 +232,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		catch (Exception ex)
 		{
 			_logger.LogWarning("Unexpected error while showing PLC conflict dialog: {Message}", ex.Message);
-			MessagePanel.ReportError("Failed to show PLC conflict dialog");
+			MessagePanel.ReportError(Resources.PlcConflictDialogShowFailed);
 
 			return;
 		}
@@ -240,7 +244,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 
 		// The conflict callback runs fire-and-forget, so a throw in the post-dialog resolution would
 		// fault the discarded task and surface only through the nondeterministic TaskScheduler hook.
-		Guarded("PLC conflict resolution failed", () =>
+		Guarded(new LocalizedText(nameof(Resources.PlcConflictResolutionFailed)), () =>
 		{
 			var result = _coordinator.ResolveConflict(keepLocal.Value);
 
@@ -257,7 +261,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 		RaiseAllStateProperties();
 	}
 
-	internal Action<Exception> OnSubscriptionError(string context)
+	internal Action<Exception> OnSubscriptionError(LocalizedText context)
 	{
 		return ex => ExceptionReporter.ReportAndLog(MessagePanel, _logger, context, ex);
 	}
@@ -265,7 +269,7 @@ public class MainWindowViewModel : ReactiveObject, IDisposable
 	// A throw inside a subscription's onNext body is NOT routed to onError: Rx disposes the
 	// subscription and rethrows up the pipeline (fatal for a dispatcher-scheduled tick). Wrapping
 	// the body here contains it on the same report + log path as a source-observable error.
-	internal void Guarded(string context, Action body)
+	internal void Guarded(LocalizedText context, Action body)
 	{
 		try
 		{

--- a/SemiStep/SemiStep.UI/MessageService/ExceptionReporter.cs
+++ b/SemiStep/SemiStep.UI/MessageService/ExceptionReporter.cs
@@ -2,13 +2,15 @@
 
 using Microsoft.Extensions.Logging;
 
+using SemiStep.UI.Localization;
+
 namespace SemiStep.UI.MessageService;
 
 internal static class ExceptionReporter
 {
-	public static void ReportAndLog(MessagePanelViewModel panel, ILogger logger, string context, Exception exception)
+	public static void ReportAndLog(MessagePanelViewModel panel, ILogger logger, LocalizedText context, Exception exception)
 	{
-		logger.LogError(exception, "{Context}", context);
-		panel.ReportError($"{context}: {exception.Message}");
+		logger.LogError(exception, "{Context}", context.Invariant);
+		panel.ReportError($"{context.Localized}: {exception.Message}");
 	}
 }

--- a/SemiStep/SemiStep.UI/MessageService/ReactiveCommandReportingExtensions.cs
+++ b/SemiStep/SemiStep.UI/MessageService/ReactiveCommandReportingExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Logging;
 
 using ReactiveUI;
 
+using SemiStep.UI.Localization;
+
 namespace SemiStep.UI.MessageService;
 
 public static class ReactiveCommandReportingExtensions
@@ -12,12 +14,11 @@ public static class ReactiveCommandReportingExtensions
 		this ReactiveCommand<TParam, TResult> command,
 		MessagePanelViewModel panel,
 		ILogger logger,
-		string context)
+		LocalizedText context)
 	{
 		ArgumentNullException.ThrowIfNull(command);
 		ArgumentNullException.ThrowIfNull(panel);
 		ArgumentNullException.ThrowIfNull(logger);
-		ArgumentNullException.ThrowIfNull(context);
 
 		return command.ThrownExceptions.Subscribe(ex => ExceptionReporter.ReportAndLog(panel, logger, context, ex));
 	}

--- a/SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive;
+﻿using System.Globalization;
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using ReactiveUI;
 
 using SemiStep.UI.Coordinator;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 
 namespace SemiStep.UI.RecipeFile;
@@ -39,13 +41,13 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 		LoadRecipeCommand = ReactiveCommand.CreateFromTask(LoadRecipeAsync, canEdit);
 		NewRecipeCommand = ReactiveCommand.Create(NewRecipe, canEdit);
 
-		SaveRecipeCommand.ReportThrownExceptions(_messagePanel, _logger, "Save failed")
+		SaveRecipeCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.SaveFailed)))
 			.DisposeWith(_disposables);
 
-		SaveAsRecipeCommand.ReportThrownExceptions(_messagePanel, _logger, "Save As failed")
+		SaveAsRecipeCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.SaveAsFailed)))
 			.DisposeWith(_disposables);
 
-		LoadRecipeCommand.ReportThrownExceptions(_messagePanel, _logger, "Load failed")
+		LoadRecipeCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.LoadFailed)))
 			.DisposeWith(_disposables);
 	}
 
@@ -100,13 +102,14 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportFailure(result, "Failed to save recipe");
+			_messagePanel.ReportFailure(result, Resources.SaveRecipeFailed);
 
 			return false;
 		}
 
 		CurrentFilePath = filePath;
-		_messagePanel.ReportSuccess($"Saved: {Path.GetFileName(filePath)}");
+		_messagePanel.ReportSuccess(
+			string.Format(CultureInfo.InvariantCulture, Resources.SavedFormat, Path.GetFileName(filePath)));
 
 		return true;
 	}
@@ -128,7 +131,8 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 		}
 
 		CurrentFilePath = filePath;
-		_messagePanel.ReportSuccess($"Loaded: {Path.GetFileName(filePath)}");
+		_messagePanel.ReportSuccess(
+			string.Format(CultureInfo.InvariantCulture, Resources.LoadedFormat, Path.GetFileName(filePath)));
 	}
 
 	private void NewRecipe()

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeCommandsViewModel.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using ReactiveUI;
 
 using SemiStep.UI.Coordinator;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 
 namespace SemiStep.UI.RecipeGrid;
@@ -53,16 +54,16 @@ public class RecipeCommandsViewModel : ReactiveObject, IDisposable
 		UndoCommand.DisposeWith(_disposables);
 		RedoCommand.DisposeWith(_disposables);
 
-		AddStepCommand.ReportThrownExceptions(_messagePanel, _logger, "Add step failed")
+		AddStepCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.AddStepFailed)))
 			.DisposeWith(_disposables);
 
-		DeleteStepCommand.ReportThrownExceptions(_messagePanel, _logger, "Delete step failed")
+		DeleteStepCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.DeleteStepFailed)))
 			.DisposeWith(_disposables);
 
-		UndoCommand.ReportThrownExceptions(_messagePanel, _logger, "Undo failed")
+		UndoCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.UndoFailed)))
 			.DisposeWith(_disposables);
 
-		RedoCommand.ReportThrownExceptions(_messagePanel, _logger, "Redo failed")
+		RedoCommand.ReportThrownExceptions(_messagePanel, _logger, new LocalizedText(nameof(Resources.RedoFailed)))
 			.DisposeWith(_disposables);
 	}
 

--- a/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs
+++ b/SemiStep/SemiStep.UI/RecipeGrid/RecipeGridSurfaceBase.cs
@@ -16,6 +16,7 @@ using ReactiveUI;
 using SemiStep.Core.Recipes;
 
 using SemiStep.UI.Coordinator;
+using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 
 namespace SemiStep.UI.RecipeGrid;
@@ -314,7 +315,9 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportFailure(result, $"Step {stepIndex + 1}");
+			_messagePanel.ReportFailure(
+				result,
+				string.Format(CultureInfo.InvariantCulture, Resources.StepFormat, stepIndex + 1));
 			return;
 		}
 
@@ -343,7 +346,9 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportFailure(result, $"Step {stepIndex + 1}");
+			_messagePanel.ReportFailure(
+				result,
+				string.Format(CultureInfo.InvariantCulture, Resources.StepFormat, stepIndex + 1));
 			return;
 		}
 
@@ -369,8 +374,9 @@ public abstract class RecipeGridSurfaceBase<TItem> : ReactiveObject, IRecipeGrid
 
 		if (result.IsFailed)
 		{
-			_messagePanel.ReportError(
-				$"Step {stepIndex + 1}: Failed to change action - {result.FormatErrors()}");
+			_messagePanel.ReportFailure(
+				result,
+				string.Format(CultureInfo.InvariantCulture, Resources.StepActionChangeFailedFormat, stepIndex + 1));
 			return;
 		}
 

--- a/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorViewModel.cs
+++ b/SemiStep/SemiStep.UI/StyleEditor/GridStyleEditorViewModel.cs
@@ -305,7 +305,7 @@ public sealed class GridStyleEditorViewModel : ReactiveObject
 	internal void ReportSaveException(Exception exception)
 	{
 		_logger.LogError(exception, "Style editor save failed");
-		ErrorMessage = $"Save failed: {exception.Message}";
+		ErrorMessage = $"{Resources.SaveFailed}: {exception.Message}";
 	}
 
 	private void Seed(GridStyleOptions options)

--- a/docs/plans/completed/20260728-pr-115-localize-operational-messages.md
+++ b/docs/plans/completed/20260728-pr-115-localize-operational-messages.md
@@ -1,0 +1,181 @@
+# PR-115: Localize operational and error messages
+
+## Overview
+
+Issue #115 — the resx pipeline exists (`Localization/Resources.resx` + `Resources.ru.resx`, a hand-maintained
+`Resources.Designer.cs` accessor per key) and menus/dialog AXAML use it, but a class of UI-composed
+user-facing strings is hardcoded English. A Russian-locale operator gets a mixed-language UI exactly on the
+error and status paths where clarity matters.
+
+This PR moves the UI-composed strings into resx. **Out of scope:** Core error *content*. Since #151
+(merged), typed Core errors already localize on type via `ReasonLocalizer` at the panel seams; the
+free-text `Result.Fail("...")` sites and exception `.Message` detail that remain stay English until their
+per-subsystem waves (see the roadmap). #115 localizes the UI-composed CONTEXT strings around them — the
+report+log context, panel-only literals, file-picker titles — a disjoint seam from #151's error-content
+localization (they meet only at `ReportFailure(result, context)`, where the context is a pre-localized
+plain string and the errors localize separately; no overlap).
+
+### Settled decision: logs stay English, panel is localized
+
+F1/F3 restructured most command-error strings into the report+log path, where a single `context` argument is
+BOTH logged AND shown in the panel (`ExceptionReporter.ReportAndLog`: `logger.LogError(ex, "{Context}", context)`
+then `panel.ReportError($"{context}: {ex.Message}")`). Localizing that context naively would localize the log
+too. Decision (confirmed): **the log keeps the invariant/English value; the panel shows the current-culture
+value.** A resx key yields both — `ResourceManager.GetString(key, CultureInfo.InvariantCulture)` for the log,
+`ResourceManager.GetString(key, Resources.Culture)` for the panel.
+
+## Mechanism (primary proposal — Fable to refine ergonomics)
+
+- Add a small `LocalizedText` type (in `SemiStep.UI.Localization`) that carries a resx key and exposes
+  `Invariant` and `Localized`:
+  ```csharp
+  public readonly record struct LocalizedText(string ResourceKey)
+  {
+      public string Localized  => Resources.ResourceManager.GetString(ResourceKey, Resources.Culture)          ?? ResourceKey;
+      public string Invariant  => Resources.ResourceManager.GetString(ResourceKey, CultureInfo.InvariantCulture) ?? ResourceKey;
+  }
+  ```
+  Call sites build it compile-safely with `nameof` against the designer accessor, e.g.
+  `new LocalizedText(nameof(Resources.CopyStepFailed))` — a typo fails the build because the accessor must exist.
+  `nameof(Resources.X)` is the chosen form (static per-key fields duplicate the key list; a `Resources.Text(...)`
+  factory is the same call renamed). Two constraints: **no implicit conversion from `string`** (a raw literal must
+  never silently masquerade as a key), and `.Localized` must tolerate `Resources.Culture == null` (it then falls
+  through to `CurrentUICulture`, matching the designer accessors' behavior).
+- Change the report+log seams to take `LocalizedText` instead of a bare `string context`:
+  - `ReportThrownExceptions(this ReactiveCommand<,>, MessagePanelViewModel, ILogger, LocalizedText)`
+  - `ExceptionReporter.ReportAndLog(MessagePanelViewModel, ILogger, LocalizedText, Exception)` — logs `.Invariant`, reports `$"{.Localized}: {ex.Message}"`
+  - `MainWindowViewModel.Guarded(LocalizedText, Action)` and `OnSubscriptionError(LocalizedText)`
+- Panel-only sites (no log) that pass a plain string get the localized accessor directly:
+  `ReportError(Resources.X)`, `ReportFailure(result, Resources.X)`, `ReportSuccess(string.Format(CultureInfo.CurrentCulture, Resources.XFormat, arg))`.
+
+## Context (grounded on current master, post F1/F2/F3/#114/#151)
+
+**Category A — report+log context strings (dual-use: logged + panel prefix → `LocalizedText`):**
+- `Clipboard/ClipboardViewModel.cs:61,64,67` — "Copy failed", "Cut failed", "Paste failed".
+- `RecipeFile/RecipeFileViewModel.cs:42,45,48` — "Save failed", "Save As failed", "Load failed".
+- `MainWindow/MainWindowViewModel.cs:73,76,79,82` — "Sync toggle failed", "Style editor failed", "Exit failed", "Orientation toggle failed" (`ReportThrownExceptions`); `:90,91,96,97,103,104,243` — "PLC state update", "PLC conflict handling", "Sync time refresh", "PLC conflict resolution failed" (`Guarded`/`OnSubscriptionError`). **The three bare-topic contexts** ("PLC state update", "PLC conflict handling", "Sync time refresh") read as neutral status lines, not errors — reword them to failure phrasing ("PLC state update failed", etc.) as part of this task, so the panel entry reads as a fault in both English and Russian.
+- `RecipeGrid/RecipeCommandsViewModel.cs:56,59,62,65` — "Add step failed", "Delete step failed", "Undo failed", "Redo failed".
+
+**Category B — panel-only literals / formats:**
+- `MainWindow/MainWindowViewModel.cs:231` — `ReportError("Failed to show PLC conflict dialog")`.
+- `MainWindow/MainWindow.axaml.cs:160` — `ReportError($"Exit failed: {ex.Message}")` in `ShowExitChoiceAsync` (a SECOND "Exit failed", view-side — reuse the same key as the `ExitCommand` context).
+- `Clipboard/ClipboardViewModel.cs:141` — currently `ReportError($"Paste failed: {errorMessages}")`, a raw sink with a manual `.Message` join. **Route it now** through the localized seam: `ReportFailure(recipeResult, Resources.PasteStepFailed)` (reuse the Category-A key), dropping the manual join. Satisfies #115's context localization AND removes a raw sink the clipboard/CSV wave would otherwise route later — mark that wave ROUTE item done-early in the roadmap. The paste-rejection errors are Core free-text today, so their *content* still renders English via the seam until their wave types them; the context prefix localizes now.
+- `StyleEditor/GridStyleEditorViewModel.cs:308` — `ErrorMessage = $"Save failed: {ex.Message}"` on the editor's own error surface (the log at `:307` is already correctly separate English; `:290` already uses `Resources.EditorCannotSave`).
+- `RecipeFile/RecipeFileViewModel.cs:103` — `ReportFailure(result, "Failed to save recipe")`; `:109,131` — `ReportSuccess($"Saved: {name}")` / `($"Loaded: {name}")` (→ resx format strings).
+- `Coordinator/RecipeCoordinator.cs:420` — `ReportFailure(applyResult, "PLC reconnect")`.
+- `RecipeGrid/RecipeGridSurfaceBase.cs:317,346` — `ReportFailure(result, $"Step {n}")` (→ resx format prefix). `:372` — currently `ReportError($"Step {n}: Failed to change action - {result.FormatErrors()}")`, a raw sink; **route it now** to `ReportFailure(result, string.Format(CultureInfo.CurrentCulture, Resources.StepActionChangeFailedFormat, n))` (a Step-{n} "change action failed" format key), matching its siblings at `:317/:346` and dropping the manual `FormatErrors()` join. Removes a raw sink the recipe wave would otherwise route later — mark that wave ROUTE item done-early. Error *content* renders English via the seam until the recipe wave types those errors.
+- `Logging/GlobalExceptionBackstop.cs:21,107` — `RecoverableUserMessage = "An unexpected error occurred; see the log for details."` (panel; the log stays English separately).
+
+**Category C — dialogs (file pickers only):**
+- `MainWindow/MainWindow.axaml.cs:234,238-239,251,256-257` — file-picker `Title` "Open Recipe"/"Save Recipe" and the `FilePickerFileType` display names ("Recipe Files", "All Files", "CSV Files"). (Anchors match Task 3.)
+- The window title (`MainWindowViewModel.BuildWindowTitle`, `$"SemiStep - {fileName}{dirtyIndicator}"`) is NOT in scope: "SemiStep" is the product name, `fileName` is user data, the dirty indicator is `" *"`, and the only natural-language part (the new-recipe placeholder) is already `Resources.WindowTitleNewRecipe`. No English remains to localize.
+
+**Explicitly EXCLUDED (Core-owned / wave-owned — whitelist for the Task 4 straggler grep):** `RecipeGridSurfaceBase.cs:191` (`exception.Message`), `RecipeCoordinator.cs:522` (`error.Message`, the Core PLC-fault bridge — PLC wave routes it; see `error-reporting.md` "Localizing failures on type"), the pre-config `ErrorWindow` (`Program.cs`), and the Core `Result` texts joined at `GridStyleEditorViewModel.cs:193,297` (style-editor surface, wave-owned).
+
+**Infra:** each new string = a `<data name="X">` in `Resources.resx` + the Russian in `Resources.ru.resx` + a `public static string X => ResourceManager.GetString("X", resourceCulture) ?? string.Empty;` accessor in `Resources.Designer.cs`. The two resx files currently hold 132 entries each (post-#151) and MUST stay matched. `MapSyncStatus`/`FormatLastSyncTime`/`PlcConflictDialogViewModel` show the established `Resources.X` / `string.Format(culture, Resources.XFormat, …)` pattern.
+
+## Development Approach
+
+- Regular (code, then tests). Warnings are errors; build stays clean after each task.
+- Add English (`Resources.resx`) and Russian (`Resources.ru.resx`) for every key, plus the designer accessor. Keep the two resx entry counts equal (a test or grep asserts parity).
+- Russian translations are added by this PR and flagged for a native-speaker pass in the PR body (not blocking).
+- Tests set `Resources.Culture` to `ru` and assert representative panel messages are the Russian value, while the LOG uses the invariant/English value. Restore culture in a finally / use a serialized collection so parallel tests do not see a mutated static `Resources.Culture`.
+- `dotnet build SemiStep.slnx` (0 warnings) + `dotnet test` after each task.
+
+## Acceptance Evidence
+
+**Automatable:**
+1. Report+log localization: under `Resources.Culture = ru`, a command fault reports the Russian prefix to the panel AND logs the invariant English context (assert both via a real panel + `RecordingLogger`). `--filter "FullyQualifiedName~Localiz"` (or the relevant filter).
+2. Panel-only sites: under ru, `ReportSuccess`/`ReportError`/`ReportFailure(context)` representative sites produce the Russian string.
+3. resx parity: `Resources.resx` and `Resources.ru.resx` have the same set of `data name` keys (a test or a grep count check).
+4. No stragglers: grep confirms no UI-composed user-facing literal remains at the enumerated sites (the report+log contexts, file-picker titles, window title, backstop message, ReportSuccess/ReportError/ReportFailure-context literals).
+
+**Manual smoke:** run with `ui.locale=ru`; trigger a copy failure, a save success, a PLC conflict-dialog show failure, open the file pickers — the panel/titles are Russian; the log file shows English.
+
+Full suite green + `dotnet build SemiStep.slnx` (0 warnings) is the gate.
+
+## Progress Tracking
+
+Mark `[x]` on completion; `➕` new tasks; `⚠️` blockers.
+
+## Implementation Steps
+
+### Task 1: Localization mechanism + migrate the report+log contexts (Category A)
+
+**Files:**
+- Create: `SemiStep/SemiStep.UI/Localization/LocalizedText.cs`
+- Modify: `SemiStep/SemiStep.UI/MessageService/ReactiveCommandReportingExtensions.cs`, `SemiStep/SemiStep.UI/MessageService/ExceptionReporter.cs`
+- Modify: `SemiStep/SemiStep.UI/MainWindow/MainWindowViewModel.cs` (`Guarded`/`OnSubscriptionError` + its 4 ReportThrownExceptions + 4 Guarded/OnSubscriptionError contexts)
+- Modify: `Clipboard/ClipboardViewModel.cs`, `RecipeFile/RecipeFileViewModel.cs`, `RecipeGrid/RecipeCommandsViewModel.cs`
+- Modify: `Localization/Resources.resx`, `Localization/Resources.ru.resx`, `Localization/Resources.Designer.cs`
+- Modify (existing tests that call the changed seams — WILL NOT COMPILE otherwise): `SemiStep.Tests/UI/MessageService/ReactiveCommandReportingExtensionsTests.cs`, `SemiStep.Tests/UI/MainWindow/MainWindowViewModelReportingTests.cs`; and `SemiStep.Tests/UI/Localization/ResourceSyncTests.cs` (parity leg)
+- Create/Modify: new localization tests
+
+- [x] add `LocalizedText` (Invariant/Localized from a resx key); add the resx keys + English + Russian + designer accessors for every Category-A context.
+- [x] change `ReportThrownExceptions`, `ExceptionReporter.ReportAndLog`, `Guarded`, `OnSubscriptionError` to take `LocalizedText`; log `.Invariant`, report `$"{.Localized}: {ex.Message}"`. Remove the now-dead `ArgumentNullException.ThrowIfNull(context)` on the (struct) context arg in `ReactiveCommandReportingExtensions.cs:20`.
+- [x] migrate all Category-A call sites to `new LocalizedText(nameof(Resources.X))`; reword the three bare-topic contexts to failure phrasing ("PLC state update failed", "PLC conflict handling failed", "Sync time refresh failed").
+- [x] migrate the two existing seam-caller tests: `ReactiveCommandReportingExtensionsTests.cs:33,61` (string arg → `LocalizedText`, update the `"Copy failed: boom"` assertion to the resolved value); `MainWindowViewModelReportingTests.cs:53,68,116` — its `[AvaloniaTheory]`/`[InlineData("PLC state update")]` CANNOT hold a `LocalizedText` (not a compile-time constant), so restructure it (pass the key name as a string and build `LocalizedText` inside the test, or `[MemberData]`), and update every exact-message assertion for the reworded contexts + the default-culture resolved value.
+- [x] parity: the three-way check is ALREADY mostly in `ResourceSyncTests.cs` (`RussianSatellite_ContainsEveryNeutralKey_AndNoOrphans` = en-keys == ru-keys; `Key_ResolvesToNonEmptyValue_UnderEnglishAndRussian` reflects the designer `string` props ⊆ resx). Add ONLY the missing leg there: every resx `data name` has a matching `public static string` accessor (resx ⊆ designer). Mirror its `PropertyType == typeof(string)` filter (excludes `Culture`/`ResourceManager`). Do not add a parallel parity test.
+- [x] tests: under a `ru` culture set via the existing `ResourcesCultureScope` (`SemiStep.Tests/UI/Localization/ResourcesCultureScope.cs`, used via `WithCulture` in `ViewModelLocalizationTests.cs`), a throwing command reports the Russian prefix to the panel AND logs the invariant English context (RecordingLogger). Parallelization is already disabled assembly-wide, so no per-test serialization is needed beyond the scope's save/restore.
+- [x] `dotnet build SemiStep.slnx` (0 warnings) + `--filter` green — before next task.
+
+### Task 2: Localize the panel-only literals (Category B)
+
+**Files:**
+- Modify: `MainWindow/MainWindowViewModel.cs` (`:231`), `MainWindow/MainWindow.axaml.cs` (`:160`), `Clipboard/ClipboardViewModel.cs` (`:141`), `StyleEditor/GridStyleEditorViewModel.cs` (`:308`), `RecipeFile/RecipeFileViewModel.cs` (`:103,109,131`), `Coordinator/RecipeCoordinator.cs` (`:420`), `RecipeGrid/RecipeGridSurfaceBase.cs` (`:317,346,372`), `Logging/GlobalExceptionBackstop.cs` (`:21`)
+- Modify: `Localization/Resources.resx`, `Resources.ru.resx`, `Resources.Designer.cs`
+- Modify/Create: tests
+
+- [x] add resx keys + EN + RU + accessors for: PLC-conflict-dialog-show-failed, save-recipe-failed context, Saved/Loaded formats, PLC-reconnect context, Step-{n} format prefix, the RecipeGridSurfaceBase `:372` message, and the backstop generic message. **Reuse existing keys** where the string repeats: the `MainWindow.axaml.cs:160` "Exit failed" reuses the Category-A Exit key; `ClipboardViewModel.cs:141` reuses `PasteStepFailed`; `GridStyleEditorViewModel.cs:308` reuses (or shares) the save-failed key.
+- [x] replace the literals: `ReportError(Resources.X)`, `ReportFailure(result, Resources.X)`, `ReportSuccess(string.Format(CultureInfo.CurrentCulture, Resources.SavedFormat, name))`, the two `$"...: {ex.Message}"` view/editor sites → `$"{Resources.X}: {ex.Message}"`, `RecoverableUserMessage` → a resx accessor at the report site (keep each already-separate English log line English).
+- [x] **route-now (two sites the waves would otherwise own):** `ClipboardViewModel.cs:141` `ReportError($"Paste failed: {join}")` → `ReportFailure(recipeResult, Resources.PasteStepFailed)` (drop the manual `.Message` join); `RecipeGridSurfaceBase.cs:372` `ReportError($"...{FormatErrors()}")` → `ReportFailure(result, string.Format(CultureInfo.CurrentCulture, Resources.StepActionChangeFailedFormat, n))` (matching siblings `:317/:346`). After this, update the roadmap: mark the clipboard/CSV and recipe wave ROUTE items for these two sinks done-early. (Roadmap already reflects both sinks as done-early.)
+- [x] tests: under ru (`ResourcesCultureScope`), representative Category-B sites produce the Russian string.
+- [x] build + `--filter` green.
+
+### Task 3: Localize the file-picker titles and filters (Category C)
+
+**Files:**
+- Modify: `MainWindow/MainWindow.axaml.cs` — "Open Recipe" title `:234`, filters `:238-239`; "Save Recipe" title `:251`, filters `:256-257`
+- Modify: `Localization/Resources.resx`, `Resources.ru.resx`, `Resources.Designer.cs`
+- Modify/Create: tests
+
+- [x] add resx keys + EN + RU + accessors for the file-picker titles ("Open Recipe"/"Save Recipe") and the filter display names ("Recipe Files", "All Files", "CSV Files").
+- [x] replace the literals with the accessors. (The window title is NOT touched — see Context; no English remains in it.)
+- [x] tests: the file-picker `Title`/filter strings resolve to the resx accessors; these are view glue, so assert the accessor values under ru (or a smoke note if the picker itself is not headless-drivable).
+- [x] build + `--filter` green.
+
+### Task 4: Verify + document
+
+**Files:**
+- Modify: `Docs/architecture/ui-localization.md` (the existing localization doc)
+
+- [x] full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1557 passed, 0 failed.
+- [x] `dotnet build SemiStep.slnx` — 0 warnings, 0 errors.
+- [x] `dotnet format SemiStep.slnx` — no files re-formatted; build stays clean.
+- [x] confirm the three-way parity test from Task 1 is green (resx == ru.resx == designer accessors). `--filter "FullyQualifiedName~ResourceSync"` = 167 passed, 0 failed.
+- [x] grep for stragglers: no UI-composed user-facing literal remains at a report/title site. The whitelist of by-design English (do NOT flag): `RecipeGridSurfaceBase.cs:191`, `RecipeCoordinator.cs:522`, `ErrorWindow`, and the Core `Result` joins at `GridStyleEditorViewModel.cs:193,297`. List what was checked. — Checked every `ReportError`/`ReportFailure`/`ReportSuccess`/`Title =`/`FilePickerFileType`/`RecoverableUserMessage` site plus a broad "English literal at a report/title site" grep across `SemiStep.UI`. All migrated to `Resources.X`/`LocalizedText`/`string.Format(Resources.XFormat…)`. Remaining English literals are the whitelist (now at `RecipeGridSurfaceBase.cs:192` `exception.Message`, `RecipeCoordinator.cs:523` `error.Message`, `GridStyleEditorViewModel.cs:193,297` Core `Result` joins, `ErrorWindow`), the window title (product name + user data, per Context), exception `.Message` suffixes, and `logger.Log*`/`Log.*` English templates. No straggler found.
+- [x] update `ui-localization.md`: operational/error/status strings go through resx; the report+log path logs the invariant English and reports the current-culture value via `LocalizedText`; Core `Result`/exception text stays English by design.
+- [x] mark this plan for archival at delivery (do NOT move it mid-run).
+
+## Post-Completion
+
+**Manual verification:** run with `ui.locale=ru` and walk the smoke scenarios; confirm the panel/titles are Russian and the log file is English.
+
+**Translations:** the Russian strings this PR adds are a first pass — flag in the PR body for a native-speaker review; they are not build-blocking.
+
+**Executed by exec:**
+- branch: pr-115-localize-operational-messages
+
+## Verify it yourself
+
+Note: this machine's ambient UI culture is Russian, so the panel already renders Russian by default with
+`Resources.Culture` unset — the meaningful proof is the log-stays-English split, plus the migration completeness.
+
+1. **Automated, the load-bearing proof** — `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName~Localiz|FullyQualifiedName~ResourceSync|FullyQualifiedName~Reporting"`.
+   - `CommandErrorLocalizationTests` is the split proof: under `ru`, the panel entry is the Russian sentence (`"Не удалось скопировать: boom"`) while the RecordingLogger record is the English invariant (`"Copy failed"`). On `master` (before this branch) `LocalizedText` does not exist and the context was a plain string logged and shown identically.
+   - `ResourceSyncTests` proves resx en == ru == designer accessors (163 each), including the new resx⊆designer leg.
+   - The two `[AvaloniaFact]` route-now sink tests in `CategoryBLocalizationTests` prove `ClipboardViewModel` paste and `RecipeGridSurfaceBase` change-action now route through `ReportFailure` with a localized prefix.
+2. **Log-English can't regress silently** — in `ExceptionReporter.ReportAndLog` swap `context.Invariant` for `context.Localized` on the log line and re-run: `CommandErrorLocalizationTests` goes red (log would become Russian). Restore it.
+3. **Manual smoke** — run with `ui.locale=ru`; trigger a copy/save/paste failure, a save success, a PLC conflict-dialog show failure, open the file pickers; the panel + picker titles are Russian and the log file lines are English.
+
+Full gate: `dotnet build SemiStep.slnx` (0 warnings) + `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` (1547 passed).


### PR DESCRIPTION
Closes #115.

## Problem

The resx pipeline and menu/dialog AXAML were already localized, but a class of UI-composed strings —
command-failure contexts, panel-only literals, and file-picker titles/filters — was hardcoded English.
A Russian-locale operator got a mixed-language UI on exactly the error and status paths where clarity
matters.

## What changed

- **`LocalizedText`** (`SemiStep.UI/Localization`) — a `readonly record struct` carrying a resx key with
  two forms: `.Invariant` (English, for the log) and `.Localized` (current culture, for the panel). No
  implicit conversion from `string` (a raw literal can't masquerade as a key). Built compile-safely with
  `new LocalizedText(nameof(Resources.X))`.
- **Report+log seam** — `ReportThrownExceptions` / `ExceptionReporter.ReportAndLog` / `Guarded` /
  `OnSubscriptionError` now take `LocalizedText`: the log records `.Invariant` (English), the panel shows
  `$"{.Localized}: {ex.Message}"`. **Logs stay English; the panel localizes.**
- **Panel-only literals** and **file-picker titles/filters** moved to resx accessors.
- **Two raw sinks routed** — `ClipboardViewModel` paste and `RecipeGridSurfaceBase` change-action now go
  through `ReportFailure` with a localized context (manual `.Message`/`FormatErrors()` joins dropped),
  removing two raw sinks the later error-typing waves would otherwise have had to route.
- 31 new resx keys (EN + first-pass RU + designer accessors), parity enforced at 163/163/163.

**Out of scope, English by design:** Core error *content* localizes on type via `ReasonLocalizer` (prior
mechanism PR); free-text `Result` and exception `.Message` detail stay English pending the per-subsystem
waves; and the pre-config `ErrorWindow` stays English because the locale (`ui.locale`) is only known
*after* config loads (`Program.cs:96-98`) — a load-failure message can't localize to a locale it failed
to load.

## Verification

- `dotnet build SemiStep.slnx` — 0 warnings (warnings are errors).
- `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1547 passed, 0 failed. resx parity 163/163/163.
- `CommandErrorLocalizationTests` is the load-bearing proof: under `ru`, the panel shows the Russian
  sentence while the RecordingLogger record is the English invariant.
- Two `[AvaloniaFact]` tests prove the route-now sinks report through `ReportFailure` with a localized prefix.
- Full multi-agent review chain (comprehensive + critical re-check + smells + comment audit + final
  critical), plus a pre-exec Fable pass reconciling the plan against the merged mechanism PR.
- **Manual smoke (operator):** ran under `ui.locale=ru`; command failures, save/load, and file pickers are
  Russian; the log file stays English.

## Note

The Russian strings are a first pass — flagged for a native-speaker review, not build-blocking. A machine
note surfaced during exec: unit tests run without `Program.Main`, so with `Resources.Culture` unset the
accessors fall through to the OS UI culture; tests assert through accessors / explicit culture scopes
rather than hardcoded English (production sets a deterministic default culture at startup).

<details>
<summary>Per-task commits before collapse</summary>

```
444cc6f docs(plans): record exec branch and verification steps
ad587f1 docs(architecture): align panel-format culture example with code
2955f61 test(ui): drop changelog framing in localization test comments
4ae7091 refactor(ui): align panel-format culture and using groups
17efe76 docs+test: fix seam-signature doc drift, trim brittle accessor tests
87b3e50 docs(architecture): document operational-message localization
73c2b65 feat(ui): localize file-picker titles and filters
ef92c43 feat(ui): localize panel literals and route two raw sinks
d6e8778 feat(ui): localize command-error contexts via LocalizedText
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
