### PR TITLE
feat(l10n): localize recipe validation errors by type

### DIFF
--- a/Docs/architecture/error-reporting.md
+++ b/Docs/architecture/error-reporting.md
@@ -64,6 +64,36 @@ Localization is applied at exactly **two panel seams**, both of which route thei
 Every other surface that reads `.Message`/`FormatErrors` directly stays English until its own wave
 routes it. This uses the same resx pipeline as the rest of the UI chrome — see `ui-localization.md`.
 
+### Positional decorators (compose, not discriminate)
+
+`AtStepError`/`AtColumnError` (`SemiStep.Core/Recipes/Errors/`) are typed *positional* decorators: each
+adds a position (`StepNumber` / `ColumnKey`) and delegates the sentence to an inner reason held in
+`Inner`. `ImportedRecipeValidator` — the shared recipe-value gate — wraps each step's failures in
+`AtStepError` and each column's in `AtColumnError`, **preserving the typed inner** rather than
+stringifying it.
+
+These localize by **composition**, which is distinct from the fallback recursion above. A decorator's
+`ReasonLocalizer` case formats its *own* localized template (`AtStepFormat` = `"Step {0}: {1}"`, ru
+`"Шаг {0}: {1}"`; `AtColumnFormat` = `"Column '{0}': {1}"`, ru `"Столбец '{0}': {1}"`) with
+`Localize(Inner)` as the trailing argument, so nesting composes:
+`Localize(AtStep(3, AtColumn("gas", inner)))` → `"Шаг 3: Столбец 'gas': <inner>"`. The two modes are
+mirror images:
+
+- **Fallback recursion** finds a typed cause inside an *untyped* wrapper — it walks `CausedBy` and
+  localizes the first typed reason it reaches.
+- **Composition** is the reverse — a *typed* decorator localizes its own position and folds the
+  localized inner into it.
+
+Because both decorators are public non-abstract Core `Error` subclasses, the coverage test forces a
+`ReasonLocalizer` case for each; a missing case is a red build.
+
+**Interim state (until slice 4).** The gate localizes the *position* now; the inner *detail* stays
+English. The value errors it wraps (`PropertyValidator`, `GroupHasIntKey`, the unknown-action /
+must-be-integer raises) are still free-text, so `Localize(Inner)` falls through to `Inner.Message`.
+Under `ru` a gate failure reads e.g. `"Шаг 3: Столбец 'gas': value 5 is out of range"` — Russian
+position, English detail. Slice 4 types those value errors; once typed, they localize through the
+decorators already placed here, with no gate change.
+
 ### The published rule (public error surface)
 
 > A public `Error` type exists **iff** a distinct localized operator sentence exists. Everything else

--- a/SemiStep/SemiStep.Core/Recipes/Errors/AtColumnError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/AtColumnError.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class AtColumnError(string columnKey, IError inner)
+	: Error($"Column '{columnKey}': {inner.Message}")
+{
+	public string ColumnKey { get; } = columnKey;
+
+	public IError Inner { get; } = inner;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/AtStepError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/AtStepError.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class AtStepError(int stepNumber, IError inner)
+	: Error($"Step {stepNumber}: {inner.Message}")
+{
+	public int StepNumber { get; } = stepNumber;
+
+	public IError Inner { get; } = inner;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs
@@ -1,5 +1,7 @@
 ﻿using FluentResults;
 
+using SemiStep.Core.Recipes.Errors;
+
 namespace SemiStep.Core.Recipes.Helpers;
 
 public sealed class ImportedRecipeValidator(
@@ -7,7 +9,7 @@ public sealed class ImportedRecipeValidator(
 {
 	public Result Validate(Recipe recipe)
 	{
-		var errors = new List<string>();
+		var errors = new List<IError>();
 
 		for (var stepIndex = 0; stepIndex < recipe.Steps.Count; stepIndex++)
 		{
@@ -17,7 +19,7 @@ public sealed class ImportedRecipeValidator(
 
 			foreach (var error in stepErrors)
 			{
-				errors.Add($"Step {stepNumber}: {error}");
+				errors.Add(new AtStepError(stepNumber, error));
 			}
 		}
 
@@ -26,14 +28,14 @@ public sealed class ImportedRecipeValidator(
 			: Result.Fail(errors);
 	}
 
-	private List<string> ValidateStep(Step step)
+	private List<IError> ValidateStep(Step step)
 	{
-		var errors = new List<string>();
+		var errors = new List<IError>();
 
 		var actionResult = recipeMetadataRegistry.GetAction(step.ActionKey);
 		if (actionResult.IsFailed)
 		{
-			errors.Add($"Unknown action ID {step.ActionKey}");
+			errors.Add(new Error($"Unknown action ID {step.ActionKey}"));
 			return errors;
 		}
 
@@ -62,30 +64,32 @@ public sealed class ImportedRecipeValidator(
 	private void ValidateGroupColumn(
 		ActionPropertyDefinition column,
 		PropertyValue propertyValue,
-		List<string> errors)
+		List<IError> errors)
 	{
 		if (propertyValue.Value is not int intKey)
 		{
-			errors.Add($"Group property '{column.Key}' must be integer, got {propertyValue.Type}");
+			errors.Add(new AtColumnError(
+				column.Key,
+				new Error($"Group value must be integer, got {propertyValue.Type}")));
 			return;
 		}
 
-		if (recipeMetadataRegistry.GroupHasIntKey(intKey, column.GroupName!).IsFailed)
+		var groupResult = recipeMetadataRegistry.GroupHasIntKey(intKey, column.GroupName!);
+		if (groupResult.IsFailed)
 		{
-			errors.Add(
-				$"Value {intKey} is not a valid member of group '{column.GroupName}' for column '{column.Key}'");
+			errors.Add(new AtColumnError(column.Key, groupResult.Errors[0]));
 		}
 	}
 
 	private void ValidatePropertyColumn(
 		ActionPropertyDefinition column,
 		PropertyValue propertyValue,
-		List<string> errors)
+		List<IError> errors)
 	{
 		var propertyDefResult = recipeMetadataRegistry.GetProperty(column.PropertyTypeId);
 		if (propertyDefResult.IsFailed)
 		{
-			errors.Add($"Property '{column.Key}': {string.Join("; ", propertyDefResult.Errors.Select(e => e.Message))}");
+			errors.Add(new AtColumnError(column.Key, propertyDefResult.Errors[0]));
 			return;
 		}
 
@@ -94,7 +98,7 @@ public sealed class ImportedRecipeValidator(
 		{
 			foreach (var error in validationResult.Errors)
 			{
-				errors.Add($"Property '{column.Key}': {error.Message}");
+				errors.Add(new AtColumnError(column.Key, error));
 			}
 		}
 	}

--- a/SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs
@@ -2,7 +2,10 @@
 
 using FluentAssertions;
 
+using FluentResults;
+
 using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Tests.Helpers;
 
@@ -43,7 +46,7 @@ public sealed class ImportedRecipeValidatorTests
 		};
 	}
 
-	private static ImportedRecipeValidator BuildValidator()
+	private static RecipeMetadataRegistry BuildValveRegistry()
 	{
 		var actions = new Dictionary<int, ActionDefinition>
 		{
@@ -72,8 +75,12 @@ public sealed class ImportedRecipeValidatorTests
 				})
 		};
 
-		var registry = BuildRecipeMetadataRegistry(actions, groups);
-		return new ImportedRecipeValidator(registry);
+		return BuildRecipeMetadataRegistry(actions, groups);
+	}
+
+	private static ImportedRecipeValidator BuildValidator()
+	{
+		return new ImportedRecipeValidator(BuildValveRegistry());
 	}
 
 	private static Recipe BuildRecipeWithStep(int actionId, string columnKey, PropertyValue value)
@@ -248,7 +255,7 @@ public sealed class ImportedRecipeValidatorTests
 	private const string CommentColumnKey = "comment";
 	private const string IntColumnKey = "amount";
 
-	private static ImportedRecipeValidator BuildPropertyAwareValidator()
+	private static RecipeMetadataRegistry BuildPropertyAwareRegistry()
 	{
 		var actions = new Dictionary<int, ActionDefinition>
 		{
@@ -271,8 +278,12 @@ public sealed class ImportedRecipeValidatorTests
 				})
 		};
 
-		var registry = BuildRecipeMetadataRegistry(actions);
-		return new ImportedRecipeValidator(registry);
+		return BuildRecipeMetadataRegistry(actions);
+	}
+
+	private static ImportedRecipeValidator BuildPropertyAwareValidator()
+	{
+		return new ImportedRecipeValidator(BuildPropertyAwareRegistry());
 	}
 
 	[Fact]
@@ -332,5 +343,126 @@ public sealed class ImportedRecipeValidatorTests
 		result.Errors.Should().HaveCount(2);
 		result.Errors.Should().Contain(error => error.Message.Contains("Step 1"));
 		result.Errors.Should().Contain(error => error.Message.Contains("Step 2"));
+	}
+
+	[Fact]
+	public void Validate_InvalidGroupKey_ForwardsTypedGroupErrorThroughDecorators()
+	{
+		var registry = BuildValveRegistry();
+		var validator = new ImportedRecipeValidator(registry);
+		var recipe = BuildRecipeWithStep(ValveActionId, TargetColumnKey, PropertyValue.FromInt(InvalidGroupKey));
+
+		var result = validator.Validate(recipe);
+
+		var stepError = result.Errors.Should().ContainSingle().Which.Should().BeOfType<AtStepError>().Subject;
+		stepError.StepNumber.Should().Be(1);
+
+		var columnError = stepError.Inner.Should().BeOfType<AtColumnError>().Subject;
+		columnError.ColumnKey.Should().Be(TargetColumnKey);
+
+		var expectedInner = registry.GroupHasIntKey(InvalidGroupKey, ValveGroupId).Errors[0];
+		columnError.Inner.Message.Should().Be(expectedInner.Message,
+			"the GroupHasIntKey typed error is forwarded verbatim, not rebuilt into a fabricated string");
+		columnError.Inner.Should().NotBeOfType<AtColumnError>().And.NotBeOfType<AtStepError>();
+	}
+
+	[Fact]
+	public void Validate_PropertyValidationFailure_ForwardsTypedInnerThroughDecorators()
+	{
+		var registry = BuildPropertyAwareRegistry();
+		var validator = new ImportedRecipeValidator(registry);
+		var step = new Step(
+			CommentActionId,
+			ImmutableDictionary<PropertyId, PropertyValue>.Empty
+				.Add(new PropertyId(IntColumnKey), PropertyValue.FromInt(500)));
+		var recipe = new Recipe(ImmutableList.Create(step));
+
+		var result = validator.Validate(recipe);
+
+		var stepError = result.Errors.Should().ContainSingle().Which.Should().BeOfType<AtStepError>().Subject;
+		stepError.StepNumber.Should().Be(1);
+
+		var columnError = stepError.Inner.Should().BeOfType<AtColumnError>().Subject;
+		columnError.ColumnKey.Should().Be(IntColumnKey);
+
+		columnError.Inner.Message.Should().Contain("exceeds maximum").And.Contain("int_bounded");
+		columnError.Inner.Message.Should().NotContain(IntColumnKey,
+			"the column key is carried by the AtColumnError decorator, not baked into the forwarded inner");
+	}
+
+	[Fact]
+	public void Validate_MissingPropertyDefinition_ForwardsTypedGetPropertyErrorThroughDecorators()
+	{
+		const int GhostActionId = 300;
+		const string GhostColumnKey = "ghost";
+		const string MissingPropertyTypeId = "nonexistent_type";
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[GhostActionId] = new ActionDefinition(
+				id: GhostActionId,
+				uiName: "Ghost",
+				deployDuration: DeployDuration.Immediate,
+				properties: new[]
+				{
+					new ActionPropertyDefinition(
+						Key: GhostColumnKey,
+						GroupName: null,
+						PropertyTypeId: MissingPropertyTypeId,
+						DefaultValue: null)
+				})
+		};
+		var registry = BuildRecipeMetadataRegistry(actions);
+		var validator = new ImportedRecipeValidator(registry);
+		var step = new Step(
+			GhostActionId,
+			ImmutableDictionary<PropertyId, PropertyValue>.Empty
+				.Add(new PropertyId(GhostColumnKey), PropertyValue.FromInt(1)));
+		var recipe = new Recipe(ImmutableList.Create(step));
+
+		var result = validator.Validate(recipe);
+
+		var stepError = result.Errors.Should().ContainSingle().Which.Should().BeOfType<AtStepError>().Subject;
+		var columnError = stepError.Inner.Should().BeOfType<AtColumnError>().Subject;
+		columnError.ColumnKey.Should().Be(GhostColumnKey);
+
+		var expectedInner = registry.GetProperty(MissingPropertyTypeId).Errors[0];
+		columnError.Inner.Message.Should().Be(expectedInner.Message,
+			"the GetProperty typed error is forwarded verbatim, not string-joined into a new message");
+	}
+
+	[Fact]
+	public void Validate_GroupColumnWithNonIntValue_RaisesFreeTextInnerWithoutColumnKey()
+	{
+		var validator = BuildValidator();
+		var recipe = BuildRecipeWithStep(ValveActionId, TargetColumnKey, PropertyValue.FromString("Open"));
+
+		var result = validator.Validate(recipe);
+
+		var stepError = result.Errors.Should().ContainSingle().Which.Should().BeOfType<AtStepError>().Subject;
+		stepError.StepNumber.Should().Be(1);
+
+		var columnError = stepError.Inner.Should().BeOfType<AtColumnError>().Subject;
+		columnError.ColumnKey.Should().Be(TargetColumnKey);
+
+		columnError.Inner.Message.Should().Be($"Group value must be integer, got {PropertyType.String}");
+		columnError.Inner.Message.Should().NotContain(TargetColumnKey,
+			"the column key is carried by the AtColumnError decorator, not baked into the raised group error");
+		columnError.Inner.Should().NotBeOfType<AtColumnError>().And.NotBeOfType<AtStepError>();
+	}
+
+	[Fact]
+	public void Validate_UnknownActionId_RaisesBareStepLevelErrorWithoutColumnDecorator()
+	{
+		const int UnknownActionId = 9999;
+		var validator = BuildValidator();
+		var recipe = BuildRecipeWithStep(UnknownActionId, TargetColumnKey, PropertyValue.FromInt(ValidGroupKey));
+
+		var result = validator.Validate(recipe);
+
+		var stepError = result.Errors.Should().ContainSingle().Which.Should().BeOfType<AtStepError>().Subject;
+		stepError.StepNumber.Should().Be(1);
+
+		stepError.Inner.Should().NotBeOfType<AtColumnError>();
+		stepError.Inner.Message.Should().Be($"Unknown action ID {UnknownActionId}");
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using FluentResults;
 
 using SemiStep.Core.Plc.Sync.Ownership;
+using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas.Errors;
 
 using SemiStep.UI.Localization;
@@ -25,7 +26,11 @@ public sealed class CoreErrorLocalizationCoverageTests
 		[typeof(OwnedByAnotherInstanceError)] =
 			new OwnedByAnotherInstanceError(new OwnerInfo(1, "MACHINE", "alice", DateTimeOffset.UnixEpoch)),
 		[typeof(FormulaComputationFailedError)] =
-			new FormulaComputationFailedError("temp", "min > max")
+			new FormulaComputationFailedError("temp", "min > max"),
+		[typeof(AtStepError)] =
+			new AtStepError(1, new Error("x")),
+		[typeof(AtColumnError)] =
+			new AtColumnError("k", new Error("x"))
 	};
 
 	[Fact]

--- a/SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using FluentResults;
 
 using SemiStep.Core.Plc.Sync.Ownership;
+using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas.Errors;
 using SemiStep.Core.Shared;
 
@@ -99,6 +100,39 @@ public sealed class ReasonLocalizerTests
 		using (ResourcesCultureScope.Use(culture))
 		{
 			ReasonLocalizer.Localize(warning).Should().Be("unmatched EndFor at step 3");
+		}
+	}
+
+	[Fact]
+	public void Localize_NestedStepColumnDecorators_UnderRussianCulture_ComposesLocalizedPositions()
+	{
+		var error = new AtStepError(3, new AtColumnError("gas", new Error("bad")));
+
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(error).Should().Be("Шаг 3: Столбец «gas»: bad");
+		}
+	}
+
+	[Fact]
+	public void Localize_NestedStepColumnDecorators_UnderEnglishCulture_ComposesEnglishPositions()
+	{
+		var error = new AtStepError(3, new AtColumnError("gas", new Error("bad")));
+
+		using (ResourcesCultureScope.Use("en"))
+		{
+			ReasonLocalizer.Localize(error).Should().Be("Step 3: Column 'gas': bad");
+		}
+	}
+
+	[Fact]
+	public void Localize_ColumnDecorator_UnderRussianCulture_ComposesLocalizedPosition()
+	{
+		var error = new AtColumnError("gas", new Error("bad"));
+
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(error).Should().Be("Столбец «gas»: bad");
 		}
 	}
 

--- a/SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections.Immutable;
+using System.Globalization;
 using System.Reactive.Linq;
 
 using Avalonia.Controls;
@@ -12,10 +13,13 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using ReactiveUI;
 
+using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Clipboard;
 using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Tests.Core.Helpers;
+using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
+using SemiStep.Tests.UI.Localization;
 
 using SemiStep.UI.Clipboard;
 using SemiStep.UI.Localization;
@@ -190,6 +194,54 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 			clipboardViewModel.Dispose();
 			window.Close();
 		}
+	}
+
+	[AvaloniaFact]
+	public void GateValidationFailure_ReportedUnderRussianCulture_ShowsRussianPositionEnglishDetail()
+	{
+		const int BoundActionId = 11;
+		const string AmountColumnKey = "amount";
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[BoundActionId] = new ActionDefinition(
+				id: BoundActionId,
+				uiName: "Bound",
+				deployDuration: DeployDuration.Immediate,
+				properties: new[]
+				{
+					new ActionPropertyDefinition(
+						Key: AmountColumnKey,
+						GroupName: null,
+						PropertyTypeId: "int_bounded",
+						DefaultValue: null)
+				})
+		};
+		var registry = TestRecipeMetadataRegistryFactory.Build(
+			new[]
+			{
+				TestPropertyTypeDefinitionBuilder.CreateInt("int_bounded", min: 0, max: 100),
+				TestPropertyTypeDefinitionBuilder.CreateString("text", maxLength: 8)
+			},
+			actions);
+		var validator = new ImportedRecipeValidator(registry);
+		var step = new Step(
+			BoundActionId,
+			ImmutableDictionary<PropertyId, PropertyValue>.Empty
+				.Add(new PropertyId(AmountColumnKey), PropertyValue.FromInt(500)));
+		var recipe = new Recipe(ImmutableList.Create(step));
+
+		var result = validator.Validate(recipe);
+		result.IsFailed.Should().BeTrue();
+
+		using var panel = new MessagePanelViewModel();
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			panel.ReportFailure(result);
+		}
+
+		var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+		entry.Message.Should().Contain("Шаг").And.Contain("Столбец")
+			.And.Contain(AmountColumnKey).And.Contain("exceeds maximum");
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs
+++ b/SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FluentResults;
 
 using SemiStep.Core.Plc.Sync.Ownership;
+using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas.Errors;
 
 namespace SemiStep.UI.Localization;
@@ -24,6 +25,8 @@ public static class ReasonLocalizer
 				error.Holder.UserName,
 				error.Holder.AcquiredUtc),
 			FormulaComputationFailedError error => Format(Resources.ErrorFormulaComputationFailed, error.Target, error.Reason),
+			AtStepError error => Format(Resources.AtStepFormat, error.StepNumber, Localize(error.Inner)),
+			AtColumnError error => Format(Resources.AtColumnFormat, error.ColumnKey, Localize(error.Inner)),
 			_ => null
 		};
 

--- a/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
+++ b/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
@@ -298,6 +298,10 @@ public class Resources
 
 	public static string ErrorFormulaComputationFailed => ResourceManager.GetString("ErrorFormulaComputationFailed", resourceCulture) ?? string.Empty;
 
+	public static string AtStepFormat => ResourceManager.GetString("AtStepFormat", resourceCulture) ?? string.Empty;
+
+	public static string AtColumnFormat => ResourceManager.GetString("AtColumnFormat", resourceCulture) ?? string.Empty;
+
 	public static string CopyStepFailed => ResourceManager.GetString("CopyStepFailed", resourceCulture) ?? string.Empty;
 
 	public static string CutStepFailed => ResourceManager.GetString("CutStepFailed", resourceCulture) ?? string.Empty;

--- a/SemiStep/SemiStep.UI/Localization/Resources.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.resx
@@ -454,6 +454,12 @@
   <data name="ErrorFormulaComputationFailed" xml:space="preserve">
     <value>Formula computation for target '{0}' failed: {1}</value>
   </data>
+  <data name="AtStepFormat" xml:space="preserve">
+    <value>Step {0}: {1}</value>
+  </data>
+  <data name="AtColumnFormat" xml:space="preserve">
+    <value>Column '{0}': {1}</value>
+  </data>
   <data name="CopyStepFailed" xml:space="preserve">
     <value>Copy failed</value>
   </data>

--- a/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
@@ -454,6 +454,12 @@
   <data name="ErrorFormulaComputationFailed" xml:space="preserve">
     <value>Вычисление формулы для цели «{0}» не выполнено: {1}</value>
   </data>
+  <data name="AtStepFormat" xml:space="preserve">
+    <value>Шаг {0}: {1}</value>
+  </data>
+  <data name="AtColumnFormat" xml:space="preserve">
+    <value>Столбец «{0}»: {1}</value>
+  </data>
   <data name="CopyStepFailed" xml:space="preserve">
     <value>Не удалось скопировать</value>
   </data>

--- a/docs/plans/completed/20260729-recipe-validator-batch-typed.md
+++ b/docs/plans/completed/20260729-recipe-validator-batch-typed.md
@@ -1,0 +1,201 @@
+# Recipe-value validation gate — typed batch + positional decorators (localization slice 3)
+
+## Overview
+
+`ImportedRecipeValidator` is the shared validation gate every untrusted recipe passes through — paste,
+CSV file-load, and PLC-read all call it after deserialization. It accumulates a `List<string>`,
+stringifying every inner error under two positional prefixes (`"Step {n}: "` and `"Property/Group
+'{key}': "`), and at one point discards a typed error outright (reads only `.IsFailed`). That single
+class defeats localization for the entire recipe-value surface: its output reaches `ReportFailure`
+(routed through `ReasonLocalizer` since #151), but the reasons arrive as plain `Error` strings the
+type-switch can't match, so every path renders English regardless of culture.
+
+This slice de-launders the gate: `List<string>` → `List<IError>`, positions carried by **typed
+decorators** (`AtStep`/`AtColumn`) instead of baked prefixes, and inner errors **preserved** (via the
+decorator's `Inner`) instead of stringified. It also adds the decorator-**composition** mode to
+`ReasonLocalizer` — the half the mechanism PR deferred (the resolver shipped only the fallback
+recursion). It is the roadmap's slice-3 prerequisite, standalone, before the recipe/clipboard/CSV waves.
+
+**Interim result (honest):** positions localize now; the inner *detail* stays English until the recipe
+wave (slice 4) types the value errors (`PropertyValidator`, `GroupHasIntKey`, …). Under `ru` a gate error
+reads e.g. `"Шаг 3: Столбец 'gas': value 5 is out of range"` — Russian position, English detail. This is
+strictly better than today's all-English, and it's the stepping stone the roadmap names.
+
+**Not behavior-preserving for English** (unlike the mechanism PR): the positional wording becomes uniform
+(`"Property 'x'"` / `"Group property 'x'"` → `"Column 'x'"`), so a handful of existing gate-validation
+assertions update to the new English. The *inner detail* text is preserved verbatim.
+
+## Mechanism
+
+### Positional decorators (Core — `SemiStep.Core/Recipes/Errors/`)
+
+Typed `Error` subclasses that add positional context and delegate the sentence to an inner reason. Not
+discriminators — position is data, the sentence is the inner error.
+
+```csharp
+public sealed class AtStepError(int stepNumber, IError inner)
+    : Error($"Step {stepNumber}: {inner.Message}")           // English baked for the log
+{
+    public int StepNumber { get; } = stepNumber;             // 1-based, as displayed
+    public IError Inner { get; } = inner;
+}
+
+public sealed class AtColumnError(string columnKey, IError inner)
+    : Error($"Column '{columnKey}': {inner.Message}")
+{
+    public string ColumnKey { get; } = columnKey;
+    public IError Inner { get; } = inner;
+}
+```
+
+### `ReasonLocalizer` composition cases (UI)
+
+The mechanism PR's `TryLocalize` switch handles leaf types + a fallback recursion. Decorators **compose**
+— the case localizes its own template with the localized inner as an argument:
+
+```csharp
+AtStepError e   => Format(Resources.AtStepFormat,   e.StepNumber, Localize(e.Inner)),
+AtColumnError e => Format(Resources.AtColumnFormat,  e.ColumnKey,  Localize(e.Inner)),
+```
+
+Nesting composes naturally: `Localize(AtStep(3, AtColumn("gas", inner)))` →
+`Format(AtStepFormat, 3, Format(AtColumnFormat, "gas", Localize(inner)))`. `Localize(inner)` on a
+still-free-text inner falls through to `inner.Message` (English) — the interim detail.
+
+resx: `AtStepFormat` = `"Step {0}: {1}"` (ru `"Шаг {0}: {1}"`); `AtColumnFormat` = `"Column '{0}': {1}"`
+(ru `"Столбец '{0}': {1}"`). Designer accessors; parity held.
+
+`AtStepError`/`AtColumnError` are public Core `Error` subclasses, so the mechanism PR's reflection
+coverage test **forces** their `ReasonLocalizer` cases — a missing case is a red build. Seed the test's
+`TypeData` map with a constructed sample of each (inner = a plain `Error`).
+
+### The gate rework (`ImportedRecipeValidator`)
+
+`List<string>` → `List<IError>`. Wrap each step's errors in `AtStepError(stepNumber, inner)`; wrap each
+column error in `AtColumnError(column.Key, inner)`. **Preserve the typed inner** where a sub-result
+already carries one — do NOT stringify:
+- `PropertyValidator.Validate` failures: `foreach (var error in validationResult.Errors) errors.Add(new AtColumnError(column.Key, error));` (was `$"Property '{key}': {error.Message}"`).
+- `GetProperty` failure: `new AtColumnError(column.Key, propertyDefResult.Errors[0])` (was a `string.Join` of messages).
+- `GroupHasIntKey` failure: capture the result and forward its error — `var groupResult = registry.GroupHasIntKey(...); if (groupResult.IsFailed) errors.Add(new AtColumnError(column.Key, groupResult.Errors[0]));` (was `.IsFailed`-only + a fabricated string).
+- The validator's **own** directly-raised messages stay free-text `new Error(text)` (typed later), wrapped in the right decorator — and their text **drops the position the decorator now carries**, so nothing is duplicated: `new Error($"Unknown action ID {step.ActionKey}")` → `AtStepError` only (step-level, no column); `new Error($"Group value must be integer, got {type}")` (NOT `"Group property '{key}' must be integer…"`, since `AtColumnError` already prepends `"Column '{key}': "`) → `AtColumnError(column.Key, …)`.
+
+`Validate` returns `Result.Fail(errors)` (a `List<IError>`); the batch stays intact and each reason
+localizes independently at the sink.
+
+## Scope
+
+**In:** the two decorators; the `ReasonLocalizer` composition cases + resx + coverage samples; the
+`ImportedRecipeValidator` rework; tests.
+
+**Out (later slices):** typing the inner value errors — `PropertyValidator`, `PropertyParser`,
+`RecipeMetadataRegistry.GroupHasIntKey`, the unknown-action/must-be-integer raises (recipe wave, slice 4;
+once typed, they localize through the already-placed decorators with **no** gate change); the clipboard/CSV
+*deserialize-time* value errors at `ClipboardSerializer.cs:191` / `CsvRowConverter.cs:89` (slice 5 — a
+separate parse surface, not this post-deserialize gate); PLC/style-editor.
+
+Note: an invalid paste can interleave both surfaces in one failure — this gate's localized-position
+errors alongside the still-all-English deserialize errors (`ClipboardSerializer`/`CsvRowConverter`). That
+is the accepted interim until slice 5, not a defect.
+
+## Context (grounded on current master, post #151/#152/#153)
+
+- `SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs` — the full gate (read the file): `Validate`
+  (`:8-27`) `List<string>` + `$"Step {n}: {error}"`; `ValidateStep` (`:29-60`) `"Unknown action ID"`;
+  `ValidateGroupColumn` (`:62-78`) `"Group property '{key}' must be integer…"` + the discarded
+  `GroupHasIntKey` typed error (`:73`); `ValidatePropertyColumn` (`:80-100`) `$"Property '{key}': …"`.
+- Consumers (all reach `ReportFailure`, routed): `RecipeSession.LoadAsCurrentValidated` →
+  `RecipeCoordinator.LoadRecipeAsync` → `RecipeFileViewModel.LoadRecipeAsync` `ReportFailure`; the paste
+  path → `ClipboardViewModel` `ReportFailure(recipeResult, Resources.PasteStepFailed)` (routed as of #115);
+  the PLC-read path → `MainWindowViewModel:249` `ReportFailure`. Injected also at `PlcLifecycleManager.cs`.
+- `ReasonLocalizer.cs` (from #151) — `TryLocalize` switch + `is IError` fallback recursion; the mechanism
+  plan's forward note already anticipates these decorator composition cases.
+- Coverage test: `SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs` — reflects public
+  non-abstract Core `Error` subclasses; the two decorators join it (add samples).
+- resx parity enforced by `ResourceSyncTests`; the two new keys extend it. `Warning` is untouched here
+  (no warnings in this gate).
+
+## Development Approach
+
+- Regular (code, then tests). `dotnet build SemiStep.slnx` 0 warnings; `dotnet test` green after each task.
+- Two new resx keys with EN + first-pass RU + designer accessors; keep resx counts equal.
+- Tests set `ru` via `ResourcesCultureScope`. The existing gate tests mostly use fragment `Contains`
+  assertions that survive the new wording — run them and fix only real failures, not a blanket rewrite.
+
+## Acceptance Evidence
+
+**Automatable:**
+1. **Decorator composition:** under `ru`, `ReasonLocalizer.Localize(new AtStepError(3, new AtColumnError("gas", new Error("bad"))))` == `"Шаг 3: Столбец 'gas': bad"` (position localized, inner English via fallback); under en == `"Step 3: Column 'gas': bad"`.
+2. **Gate emits typed decorated reasons:** `ImportedRecipeValidator.Validate` on a recipe with a bad group value / failed property validation returns `Result.Fail` whose `Errors` are `AtStepError` wrapping `AtColumnError` wrapping the **preserved inner** (assert the inner is the original `IError`, not a fabricated string) — including the `GroupHasIntKey` path that previously discarded its error.
+3. **End-to-end (paste or load) under ru:** a recipe-value validation failure surfaces to a real
+   `MessagePanelViewModel` via `ReportFailure` with the Russian position + English detail.
+4. **Coverage:** the reflection coverage test is green with the two decorators mapped, and goes red if a
+   decorator case is removed.
+5. resx parity green.
+
+**Manual smoke:** under `ui.locale=ru`, paste / load a recipe with an out-of-range value — the panel shows
+`"Шаг N: Столбец '…': <english detail>"`.
+
+Full suite green + `dotnet build SemiStep.slnx` (0 warnings) is the gate.
+
+## Progress Tracking
+
+Mark `[x]` on completion; `➕` new tasks; `⚠️` blockers.
+
+## Implementation Steps
+
+### Task 1: Decorators + ReasonLocalizer composition cases + resx
+
+**Files:**
+- Create: `SemiStep/SemiStep.Core/Recipes/Errors/AtStepError.cs`, `AtColumnError.cs`
+- Modify: `SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs`, `Resources.resx`, `Resources.ru.resx`, `Resources.Designer.cs`
+- Modify: `SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs` (add a `TypeData` sample per decorator); `SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs` (composition unit tests — same `ResourcesCultureScope.Use(...)` + `.Should().Be(...)` pattern as its existing cases)
+
+- [x] add `AtStepError(int stepNumber, IError inner)` and `AtColumnError(string columnKey, IError inner)` (public sealed, `Inner`/`StepNumber`/`ColumnKey` props, English `.Message` baked).
+- [x] add `AtStepFormat`/`AtColumnFormat` resx keys (EN + RU) + a hand-written `Resources.Designer.cs` accessor for each (`public static string X => ResourceManager.GetString("X", resourceCulture) ?? string.Empty;` — the designer is hand-maintained, no regeneration step); keep the two resx counts equal.
+- [x] add the two composition cases to `ReasonLocalizer.TryLocalize` (`Format(template, position, Localize(Inner))`).
+- [x] seed `CoreErrorLocalizationCoverageTests` `TypeData` with a sample of each decorator (inner = plain `Error`); in `ReasonLocalizerTests.cs` add composition tests (acceptance #1): single, NESTED (`AtStep`→`AtColumn`→inner) under en/ru, and inner-fallback for a free-text inner.
+- [x] `dotnet build SemiStep.slnx` (0 warnings) + `--filter` green.
+
+### Task 2: Rework `ImportedRecipeValidator` to `List<IError>` + decorators
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs`
+- Modify: `SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs` (fragment asserts survive — run/fix only failures, then add the new assertions below)
+- Modify: `SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs` (or the recipe-load/paste test that already drives the gate) — the ru end-to-end
+
+- [x] `Validate`/`ValidateStep`/`ValidateGroupColumn`/`ValidatePropertyColumn`: `List<string>` → `List<IError>`; wrap steps in `AtStepError`, columns in `AtColumnError`; **preserve** the typed inner from `PropertyValidator`/`GetProperty`/`GroupHasIntKey` (do not stringify; forward the `IError`); keep the validator's own direct raises as free-text `new Error(text)` wrapped in the right decorator; `Result.Fail(errors)`.
+- [x] run the suite; the existing gate assertions use fragment `Contains` checks (step number, column key, detail fragments) that SURVIVE the new `"Step N: Column 'k': <detail>"` shape — fix ONLY actual failures (expect near-zero). The one repo-wide exact `"Step 1:"` match is `ResultReportingExtensionsTests.cs:85` (synthetic, not the gate — verify unaffected).
+- [x] add tests (acceptance #2, in `ImportedRecipeValidatorTests.cs`): the gate's reasons are `AtStepError`→`AtColumnError`→inner, and the inner is the ORIGINAL `IError` object (not a fabricated string) — for the `PropertyValidator`, `GetProperty`, AND `GroupHasIntKey` paths (the last previously discarded its error at the old `:73`).
+- [x] end-to-end (acceptance #3): under `ru` (`ResourcesCultureScope`), a gate failure surfaced via `ReportFailure` to a real `MessagePanelViewModel` shows the Russian position + English detail.
+- [x] build + `--filter` green.
+
+### Task 3: Verify + document
+
+**Files:**
+- Modify: `Docs/architecture/error-reporting.md` (or `ui-localization.md`) — the decorator composition mode
+
+- [x] full suite: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj`; `dotnet build` 0 warnings; `dotnet format`.
+- [x] confirm coverage + parity tests green.
+- [x] document the decorator composition mode (`AtStep`/`AtColumn` compose position + `Localize(inner)`; the fallback recursion is for untyped wrappers) and the interim "position localized, detail English until slice 4" state.
+- [x] mark this plan for archival at delivery (do NOT move it mid-run).
+
+## Post-Completion
+
+**Next (slice 4, recipe wave):** type the inner value errors (`PropertyValidator`, `PropertyParser`,
+`RecipeMetadataRegistry.GroupHasIntKey`, unknown-action/must-be-integer) — they then localize through the
+decorators placed here with no gate change — plus the recipe-edit/analysis errors and `LoopParser`
+warnings (unseal `Warning`). Then slice 5 (clipboard/CSV deserialize surface), slice 6 (#120 PLC).
+
+---
+
+**Executed by exec:**
+- branch: recipe-validator-batch-typed
+- commits: be2dc53 (decorators) · 6116f0d (validator rework) · 1a8d8d5 (doc) · b65f4ae (pin raises) · 44f313f (ru guillemets)
+- review chain: comprehensive (5 agents, ACHIEVED) → smells (guillemets fix) → comment audit (clean) → critical ×2 (no major/critical). codex phase skipped (not installed).
+
+## Verify it yourself
+1. `dotnet build SemiStep.slnx` — expect 0 warnings.
+2. `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — expect 1565 passed, 0 failed.
+3. Localization composition: `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj --filter "FullyQualifiedName~ReasonLocalizer"` — the ru cases render `Шаг {n}: Столбец «{key}»: {detail}`.
+4. Coverage guard: `--filter "FullyQualifiedName~CoreErrorLocalizationCoverage"` — AtStepError/AtColumnError each force a ReasonLocalizer case.
+5. Validator inner-preservation: `--filter "FullyQualifiedName~ImportedRecipeValidator"` — the PropertyValidator / GetProperty / GroupHasIntKey paths forward the original typed IError, wrapped in AtStep→AtColumn decorators.


### PR DESCRIPTION
## Problem

`ImportedRecipeValidator` is the shared gate every untrusted recipe passes through (paste, CSV file-load, PLC read). It accumulated a `List<string>`, stringifying every inner error under baked positional prefixes (`"Step {n}: "`, `"Property/Group '{key}': "`) and at one point discarded a typed error outright (read only `.IsFailed`). That single class defeated localization for the whole recipe-value surface: its output reaches `ReportFailure` (routed through `ReasonLocalizer` since #151), but the reasons arrived as plain `Error` strings the type-switch could not match, so every path rendered English regardless of culture.

## What changed

- **Typed positional decorators** — `AtStepError(stepNumber, inner)` and `AtColumnError(columnKey, inner)` carry position without baking it into the text; the inner `IError` is preserved via the decorator's `Inner`.
- **Validator rework** — `ImportedRecipeValidator` now returns `List<IError>`, forwarding the original typed inner from `PropertyValidator`, `GetProperty`, and `GroupHasIntKey` (the last previously discarded), wrapped `AtStep` → `AtColumn`.
- **ReasonLocalizer composition mode** — the half the mechanism PR (#151) deferred: a decorator formats its localized position around `Localize(inner)`, distinct from the fallback recursion used for untyped wrappers.
- resx `AtStepFormat` / `AtColumnFormat` (en + ru, Russian uses guillemets to match the existing typography precedent) + hand-maintained Designer accessor; architecture doc updated.

**Interim state (honest):** positions localize now; the inner *detail* stays English until the recipe wave (slice 4) types the value errors. Under `ru` a gate error reads `"Шаг 3: Столбец «gas»: value 5 is out of range"` — Russian position, English detail. Strictly better than today's all-English, and the stepping stone the roadmap names.

**Not behavior-preserving for English:** the positional wording is now uniform (`"Property 'x'"` / `"Group property 'x'"` → `"Column 'x'"`), so a handful of gate assertions move to the new English; the inner detail is preserved verbatim.

## Verification

- `dotnet build SemiStep.slnx` — 0 warnings.
- `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1565 passed, 0 failed.
- Coverage guard (`CoreErrorLocalizationCoverageTests`) forces a `ReasonLocalizer` case for both new decorator types via reflection over public Core `Error` subclasses.
- resx parity (`ResourceSyncTests`) green (en == ru == Designer).
- Review chain: comprehensive (5 agents) → smells → comment audit → critical ×2, all clean after fixes.
- **Manual test (operator):** imported/edited a recipe with a bad step/column under the Russian UI and confirmed the localized position + English detail surface in the message panel.

<details>
<summary>Per-task commits before collapse</summary>

```
571288d docs(plans): record slice-3 exec branch and verification
44f313f test+l10n(ui): use guillemets in russian column format
b65f4ae test: pin validator raises and drop duplicate localizer test
1a8d8d5 docs(architecture): document positional-decorator composition
6116f0d refactor(core): emit typed decorated reasons from recipe validator
be2dc53 feat(l10n): add AtStep/AtColumn positional error decorators
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
