### PR TITLE
feat(l10n): localize recipe value errors by type

### DIFF
--- a/Docs/architecture/error-reporting.md
+++ b/Docs/architecture/error-reporting.md
@@ -76,9 +76,9 @@ stringifying it.
 
 These localize by **composition**, which is distinct from the fallback recursion above. A decorator's
 `ReasonLocalizer` case formats its *own* localized template (`AtStepFormat` = `"Step {0}: {1}"`, ru
-`"Шаг {0}: {1}"`; `AtColumnFormat` = `"Column '{0}': {1}"`, ru `"Столбец '{0}': {1}"`) with
+`"Шаг {0}: {1}"`; `AtColumnFormat` = `"Column '{0}': {1}"`, ru `"Столбец «{0}»: {1}"`) with
 `Localize(Inner)` as the trailing argument, so nesting composes:
-`Localize(AtStep(3, AtColumn("gas", inner)))` → `"Шаг 3: Столбец 'gas': <inner>"`. The two modes are
+`Localize(AtStep(3, AtColumn("gas", inner)))` → `"Шаг 3: Столбец «gas»: <inner>"`. The two modes are
 mirror images:
 
 - **Fallback recursion** finds a typed cause inside an *untyped* wrapper — it walks `CausedBy` and
@@ -89,12 +89,24 @@ mirror images:
 Because both decorators are public non-abstract Core `Error` subclasses, the coverage test forces a
 `ReasonLocalizer` case for each; a missing case is a red build.
 
-**Interim state (until slice 4).** The gate localizes the *position* now; the inner *detail* stays
-English. The value errors it wraps (`PropertyValidator`, `GroupHasIntKey`, the unknown-action /
-must-be-integer raises) are still free-text, so `Localize(Inner)` falls through to `Inner.Message`.
-Under `ru` a gate failure reads e.g. `"Шаг 3: Столбец 'gas': value 5 is out of range"` — Russian
-position, English detail. Slice 4 types those value errors; once typed, they localize through the
-decorators already placed here, with no gate change.
+### Recipe value errors localize on both paths
+
+The two producers every recipe-value check flows through — `PropertyValidator` (range/type/string rules)
+and `RecipeMetadataRegistry` (not-found / not-in-group lookups) — raise **typed** value errors, so they
+localize by type on both routes that carry them to the panel:
+
+- **Import path (decorated).** `ImportedRecipeValidator` wraps each failure in `AtStepError`/`AtColumnError`,
+  which compose `Localize(Inner)`. Because the inner is now typed, `Localize(Inner)` renders it localized
+  rather than falling through to `Inner.Message`. Under `ru` a gate failure reads position *and* detail in
+  Russian, e.g. `"Шаг 3: Столбец «gas»: Значение 5 больше максимума 4 для «amount»"` — no gate change was
+  needed; the decorators placed in slice 3 already compose the now-typed inner.
+- **Interactive-edit path (undecorated).** `RecipeSession.UpdateStepProperty` →
+  `ParseAndValidateColumnValue` → `PropertyValidator`/registry bubbles the typed error straight to the panel
+  with no decorator, so it localizes standalone.
+
+Still free-text (deferred to a later wave): `ImportedRecipeValidator`'s own unknown-action raise,
+`PropertyParser`, and the `RecipeSession` index errors. `Localize(Inner)` falls through to `.Message` for
+those until their own wave types them.
 
 ### The published rule (public error surface)
 

--- a/SemiStep/SemiStep.Core/Recipes/Errors/ActionByIdNotFoundError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/ActionByIdNotFoundError.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class ActionByIdNotFoundError(int id)
+	: Error($"Action with id {id} not found")
+{
+	public int Id { get; } = id;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/ActionByNameNotFoundError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/ActionByNameNotFoundError.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class ActionByNameNotFoundError(string name)
+	: Error($"Action with name '{name}' not found")
+{
+	public string Name { get; } = name;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/ColumnNotFoundError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/ColumnNotFoundError.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class ColumnNotFoundError(string key)
+	: Error($"Column '{key}' not found")
+{
+	public string Key { get; } = key;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/GroupNotFoundError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/GroupNotFoundError.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class GroupNotFoundError(string groupId)
+	: Error($"Group '{groupId}' not found")
+{
+	public string GroupId { get; } = groupId;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/GroupValueNotIntegerError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/GroupValueNotIntegerError.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class GroupValueNotIntegerError(PropertyType actualType)
+	: Error($"Group value must be integer, got {actualType}")
+{
+	public PropertyType ActualType { get; } = actualType;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/PropertyNotFoundError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/PropertyNotFoundError.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class PropertyNotFoundError(string propertyTypeId)
+	: Error($"Property '{propertyTypeId}' not found")
+{
+	public string PropertyTypeId { get; } = propertyTypeId;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/PropertyValueTypeMismatchError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/PropertyValueTypeMismatchError.cs
@@ -1,0 +1,13 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class PropertyValueTypeMismatchError(string expectedType, string actualType, string id)
+	: Error($"Expected {expectedType} value but got {actualType} for '{id}'")
+{
+	public string ExpectedType { get; } = expectedType;
+
+	public string ActualType { get; } = actualType;
+
+	public string Id { get; } = id;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/StringContainsNulError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/StringContainsNulError.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class StringContainsNulError(string id)
+	: Error($"String value contains embedded NUL character for '{id}'")
+{
+	public string Id { get; } = id;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/StringTooLongError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/StringTooLongError.cs
@@ -1,0 +1,13 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class StringTooLongError(int length, int max, string id)
+	: Error($"String length {length} exceeds maximum {max} for '{id}'")
+{
+	public int Length { get; } = length;
+
+	public int Max { get; } = max;
+
+	public string Id { get; } = id;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/UnsupportedPropertySystemTypeError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/UnsupportedPropertySystemTypeError.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class UnsupportedPropertySystemTypeError(string systemType)
+	: Error($"Unsupported property system type: {systemType}")
+{
+	public string SystemType { get; } = systemType;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/ValueAboveMaximumError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/ValueAboveMaximumError.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class ValueAboveMaximumError(double value, double max, string id)
+	: Error(FormattableString.Invariant($"Value {value} exceeds maximum {max} for '{id}'"))
+{
+	public double Value { get; } = value;
+
+	public double Max { get; } = max;
+
+	public string Id { get; } = id;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/ValueBelowMinimumError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/ValueBelowMinimumError.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class ValueBelowMinimumError(double value, double min, string id)
+	: Error(FormattableString.Invariant($"Value {value} is below minimum {min} for '{id}'"))
+{
+	public double Value { get; } = value;
+
+	public double Min { get; } = min;
+
+	public string Id { get; } = id;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/ValueNotInGroupError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/ValueNotInGroupError.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class ValueNotInGroupError(int key, string groupId)
+	: Error($"Value {key} is not a valid member of group '{groupId}'")
+{
+	public int Key { get; } = key;
+
+	public string GroupId { get; } = groupId;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs
@@ -70,7 +70,7 @@ public sealed class ImportedRecipeValidator(
 		{
 			errors.Add(new AtColumnError(
 				column.Key,
-				new Error($"Group value must be integer, got {propertyValue.Type}")));
+				new GroupValueNotIntegerError(propertyValue.Type)));
 			return;
 		}
 

--- a/SemiStep/SemiStep.Core/Recipes/PropertyValidator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/PropertyValidator.cs
@@ -1,5 +1,7 @@
 ﻿using FluentResults;
 
+using SemiStep.Core.Recipes.Errors;
+
 namespace SemiStep.Core.Recipes;
 
 internal static class PropertyValidator
@@ -10,12 +12,12 @@ internal static class PropertyValidator
 		{
 			"int" => value is int intVal
 				? ValidateNumericRange(property, (double)intVal)
-				: Result.Fail($"Expected int value but got {value.GetType().Name} for '{property.Id}'"),
+				: Result.Fail(new PropertyValueTypeMismatchError("int", value.GetType().Name, property.Id)),
 			"float" => value is float floatVal
 				? ValidateNumericRange(property, (double)floatVal)
-				: Result.Fail($"Expected float value but got {value.GetType().Name} for '{property.Id}'"),
+				: Result.Fail(new PropertyValueTypeMismatchError("float", value.GetType().Name, property.Id)),
 			"string" => ValidateStringLength(property, value),
-			_ => Result.Fail($"Unsupported property system type: {property.SystemType}")
+			_ => Result.Fail(new UnsupportedPropertySystemTypeError(property.SystemType))
 		};
 	}
 
@@ -31,7 +33,7 @@ internal static class PropertyValidator
 
 		if (parsed.Value is not int intKey)
 		{
-			return Result.Fail($"Group value must be integer, got {parsed.Type}");
+			return Result.Fail(new GroupValueNotIntegerError(parsed.Type));
 		}
 
 		return recipeMetadataRegistry.GroupHasIntKey(intKey, actionProperty.GroupName);
@@ -42,13 +44,13 @@ internal static class PropertyValidator
 		if (property.Min.HasValue && value < property.Min.Value)
 		{
 			return Result.Fail(
-				$"Value {value} is below minimum {property.Min.Value} for '{property.Id}'");
+				new ValueBelowMinimumError(value, property.Min.Value, property.Id));
 		}
 
 		if (property.Max.HasValue && value > property.Max.Value)
 		{
 			return Result.Fail(
-				$"Value {value} exceeds maximum {property.Max.Value} for '{property.Id}'");
+				new ValueAboveMaximumError(value, property.Max.Value, property.Id));
 		}
 
 		return Result.Ok();
@@ -59,19 +61,19 @@ internal static class PropertyValidator
 		if (value is not string str)
 		{
 			return Result.Fail(
-				$"Expected string value but got {value.GetType().Name} for '{property.Id}'");
+				new PropertyValueTypeMismatchError("string", value.GetType().Name, property.Id));
 		}
 
 		if (str.Contains('\0'))
 		{
 			return Result.Fail(
-				$"String value contains embedded NUL character for '{property.Id}'");
+				new StringContainsNulError(property.Id));
 		}
 
 		if (property.MaxLength.HasValue && str.Length > property.MaxLength.Value)
 		{
 			return Result.Fail(
-				$"String length {str.Length} exceeds maximum {property.MaxLength.Value} for '{property.Id}'");
+				new StringTooLongError(str.Length, property.MaxLength.Value, property.Id));
 		}
 
 		return Result.Ok();

--- a/SemiStep/SemiStep.Core/Recipes/RecipeMetadataRegistry.cs
+++ b/SemiStep/SemiStep.Core/Recipes/RecipeMetadataRegistry.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using FluentResults;
 
 using SemiStep.Core.Configuration;
+using SemiStep.Core.Recipes.Errors;
 
 namespace SemiStep.Core.Recipes;
 
@@ -111,7 +112,7 @@ public sealed class RecipeMetadataRegistry
 
 	public Result<ActionDefinition> GetAction(int id)
 	{
-		return TryGetOrFail(_actionsById, id, $"Action with id {id} not found");
+		return TryGetOrFail(_actionsById, id, new ActionByIdNotFoundError(id));
 	}
 
 	public bool TryGetAction(int id, [MaybeNullWhen(false)] out ActionDefinition action)
@@ -121,17 +122,17 @@ public sealed class RecipeMetadataRegistry
 
 	public Result<ActionDefinition> GetActionByName(string name)
 	{
-		return TryGetOrFail(_actionsByName, name, $"Action with name '{name}' not found");
+		return TryGetOrFail(_actionsByName, name, new ActionByNameNotFoundError(name));
 	}
 
 	public Result ActionExists(int id)
 	{
-		return ContainsOrFail(_actionsById, id, $"Action with id {id} not found");
+		return ContainsOrFail(_actionsById, id, new ActionByIdNotFoundError(id));
 	}
 
 	public Result ActionExistsByName(string name)
 	{
-		return ContainsOrFail(_actionsByName, name, $"Action with name '{name}' not found");
+		return ContainsOrFail(_actionsByName, name, new ActionByNameNotFoundError(name));
 	}
 
 	public IReadOnlyList<ActionDefinition> GetAllActions()
@@ -141,22 +142,22 @@ public sealed class RecipeMetadataRegistry
 
 	public Result<PropertyTypeDefinition> GetProperty(string propertyTypeId)
 	{
-		return TryGetOrFail(_properties, propertyTypeId, $"Property '{propertyTypeId}' not found");
+		return TryGetOrFail(_properties, propertyTypeId, new PropertyNotFoundError(propertyTypeId));
 	}
 
 	public Result PropertyExists(string propertyTypeId)
 	{
-		return ContainsOrFail(_properties, propertyTypeId, $"Property '{propertyTypeId}' not found");
+		return ContainsOrFail(_properties, propertyTypeId, new PropertyNotFoundError(propertyTypeId));
 	}
 
 	public Result<GridColumnDefinition> GetColumn(string key)
 	{
-		return TryGetOrFail(_columns, key, $"Column '{key}' not found");
+		return TryGetOrFail(_columns, key, new ColumnNotFoundError(key));
 	}
 
 	public Result ColumnExists(string key)
 	{
-		return ContainsOrFail(_columns, key, $"Column '{key}' not found");
+		return ContainsOrFail(_columns, key, new ColumnNotFoundError(key));
 	}
 
 	public IReadOnlyList<GridColumnDefinition> GetAllColumns()
@@ -166,12 +167,12 @@ public sealed class RecipeMetadataRegistry
 
 	public Result<GroupDefinition> GetGroup(string groupId)
 	{
-		return TryGetOrFail(_groups, groupId, $"Group '{groupId}' not found");
+		return TryGetOrFail(_groups, groupId, new GroupNotFoundError(groupId));
 	}
 
 	public Result GroupExists(string groupId)
 	{
-		return ContainsOrFail(_groups, groupId, $"Group '{groupId}' not found");
+		return ContainsOrFail(_groups, groupId, new GroupNotFoundError(groupId));
 	}
 
 	/// <summary>
@@ -292,7 +293,7 @@ public sealed class RecipeMetadataRegistry
 
 		if (!groupResult.Value.Items.ContainsKey(key))
 		{
-			return Result.Fail($"Value {key} is not a valid member of group '{groupId}'");
+			return Result.Fail(new ValueNotInGroupError(key, groupId));
 		}
 
 		return Result.Ok();
@@ -301,26 +302,26 @@ public sealed class RecipeMetadataRegistry
 	private static Result<TValue> TryGetOrFail<TKey, TValue>(
 		Dictionary<TKey, TValue> dictionary,
 		TKey key,
-		string errorMessage) where TKey : notnull
+		IError error) where TKey : notnull
 	{
 		if (dictionary.TryGetValue(key, out var value))
 		{
 			return value;
 		}
 
-		return Result.Fail(errorMessage);
+		return Result.Fail(error);
 	}
 
 	private static Result ContainsOrFail<TKey, TValue>(
 		Dictionary<TKey, TValue> dictionary,
 		TKey key,
-		string errorMessage) where TKey : notnull
+		IError error) where TKey : notnull
 	{
 		if (dictionary.ContainsKey(key))
 		{
 			return Result.Ok();
 		}
 
-		return Result.Fail(errorMessage);
+		return Result.Fail(error);
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using FluentResults;
 
 using SemiStep.Core.Plc.Sync.Ownership;
+using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Analysis.Warnings;
 using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas.Errors;
@@ -33,6 +34,32 @@ public sealed class CoreErrorLocalizationCoverageTests
 			new AtStepError(1, new Error("x")),
 		[typeof(AtColumnError)] =
 			new AtColumnError("k", new Error("x")),
+		[typeof(PropertyValueTypeMismatchError)] =
+			new PropertyValueTypeMismatchError("int", "Int32", "temperature"),
+		[typeof(UnsupportedPropertySystemTypeError)] =
+			new UnsupportedPropertySystemTypeError("decimal"),
+		[typeof(GroupValueNotIntegerError)] =
+			new GroupValueNotIntegerError(PropertyType.String),
+		[typeof(ValueBelowMinimumError)] =
+			new ValueBelowMinimumError(3, 10, "temperature"),
+		[typeof(ValueAboveMaximumError)] =
+			new ValueAboveMaximumError(500, 100, "temperature"),
+		[typeof(StringContainsNulError)] =
+			new StringContainsNulError("label"),
+		[typeof(StringTooLongError)] =
+			new StringTooLongError(20, 8, "label"),
+		[typeof(ActionByIdNotFoundError)] =
+			new ActionByIdNotFoundError(42),
+		[typeof(ActionByNameNotFoundError)] =
+			new ActionByNameNotFoundError("Heat"),
+		[typeof(PropertyNotFoundError)] =
+			new PropertyNotFoundError("temperature"),
+		[typeof(ColumnNotFoundError)] =
+			new ColumnNotFoundError("temp"),
+		[typeof(GroupNotFoundError)] =
+			new GroupNotFoundError("valves"),
+		[typeof(ValueNotInGroupError)] =
+			new ValueNotInGroupError(7, "valves"),
 		[typeof(UnmatchedEndForWarning)] =
 			new UnmatchedEndForWarning(1),
 		[typeof(UnclosedForLoopWarning)] =

--- a/SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs
@@ -112,6 +112,66 @@ public sealed class ReasonLocalizerTests
 		}
 	}
 
+	[Fact]
+	public void Localize_ValueAboveMaximum_UnderRussianCulture_RendersRussianSentence()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(new ValueAboveMaximumError(500, 100, "temperature"))
+				.Should().Be("Значение 500 больше максимума 100 для «temperature»");
+		}
+	}
+
+	[Fact]
+	public void Localize_StringTooLong_UnderRussianCulture_RendersRussianSentence()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(new StringTooLongError(20, 8, "label"))
+				.Should().Be("Длина строки 20 превышает максимум 8 для «label»");
+		}
+	}
+
+	[Fact]
+	public void Localize_ColumnNotFound_UnderRussianCulture_RendersRussianSentence()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(new ColumnNotFoundError("temp"))
+				.Should().Be("Столбец «temp» не найден");
+		}
+	}
+
+	[Fact]
+	public void Localize_ValueNotInGroup_UnderRussianCulture_RendersRussianSentence()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(new ValueNotInGroupError(7, "valves"))
+				.Should().Be("Значение 7 не является допустимым членом группы «valves»");
+		}
+	}
+
+	[Fact]
+	public void Localize_RecipeValueErrors_UnderEnglishCulture_MatchOriginalMessage()
+	{
+		IError[] samples =
+		[
+			new ValueAboveMaximumError(500, 100, "temperature"),
+			new StringTooLongError(20, 8, "label"),
+			new ColumnNotFoundError("temp"),
+			new ValueNotInGroupError(7, "valves")
+		];
+
+		using (ResourcesCultureScope.Use("en"))
+		{
+			foreach (var sample in samples)
+			{
+				ReasonLocalizer.Localize(sample).Should().Be(sample.Message);
+			}
+		}
+	}
+
 	[Theory]
 	[InlineData("ru")]
 	[InlineData("en")]

--- a/SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MessagePanelReportingTests.cs
@@ -14,7 +14,10 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ReactiveUI;
 
 using SemiStep.Core.Recipes;
+using SemiStep.Core.Recipes.Analysis;
 using SemiStep.Core.Recipes.Clipboard;
+using SemiStep.Core.Recipes.Errors;
+using SemiStep.Core.Recipes.Formulas;
 using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.Helpers;
@@ -197,7 +200,7 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 	}
 
 	[AvaloniaFact]
-	public void GateValidationFailure_ReportedUnderRussianCulture_ShowsRussianPositionEnglishDetail()
+	public void GateValidationFailure_ReportedUnderRussianCulture_ShowsRussianPositionAndDetail()
 	{
 		const int BoundActionId = 11;
 		const string AmountColumnKey = "amount";
@@ -241,7 +244,121 @@ public sealed class MessagePanelReportingTests : IAsyncLifetime
 
 		var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
 		entry.Message.Should().Contain("Шаг").And.Contain("Столбец")
-			.And.Contain(AmountColumnKey).And.Contain("exceeds maximum");
+			.And.Contain(AmountColumnKey).And.Contain("больше максимума");
+	}
+
+	[AvaloniaFact]
+	public void GateGroupFailure_ReportedUnderRussianCulture_ShowsRussianPositionAndGroupDetail()
+	{
+		const int ValveActionId = 50;
+		const string ValveGroupId = "valve";
+		const string TargetColumnKey = "target";
+		const int InvalidGroupKey = 99;
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[ValveActionId] = new ActionDefinition(
+				id: ValveActionId,
+				uiName: "Valve",
+				deployDuration: DeployDuration.Immediate,
+				properties: new[]
+				{
+					new ActionPropertyDefinition(
+						Key: TargetColumnKey,
+						GroupName: ValveGroupId,
+						PropertyTypeId: "enum",
+						DefaultValue: null)
+				})
+		};
+		var groups = new Dictionary<string, GroupDefinition>
+		{
+			[ValveGroupId] = new GroupDefinition(
+				GroupId: ValveGroupId,
+				Items: new Dictionary<int, string> { [1] = "Open", [2] = "Close" })
+		};
+		var registry = TestRecipeMetadataRegistryFactory.Build(
+			new[]
+			{
+				TestPropertyTypeDefinitionBuilder.CreateInt("enum"),
+				TestPropertyTypeDefinitionBuilder.CreateString("text", maxLength: 8)
+			},
+			actions,
+			groups);
+		var validator = new ImportedRecipeValidator(registry);
+		var step = new Step(
+			ValveActionId,
+			ImmutableDictionary<PropertyId, PropertyValue>.Empty
+				.Add(new PropertyId(TargetColumnKey), PropertyValue.FromInt(InvalidGroupKey)));
+		var recipe = new Recipe(ImmutableList.Create(step));
+
+		var result = validator.Validate(recipe);
+		result.IsFailed.Should().BeTrue();
+
+		using var panel = new MessagePanelViewModel();
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			panel.ReportFailure(result);
+		}
+
+		var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+		entry.Message.Should().Contain("Шаг").And.Contain("Столбец")
+			.And.Contain(TargetColumnKey).And.Contain("не является допустимым членом группы")
+			.And.Contain(ValveGroupId);
+	}
+
+	[AvaloniaFact]
+	public void InteractiveEditFailure_ReportedUnderRussianCulture_SurfacesLocalizedValueErrorStandalone()
+	{
+		const int BoundActionId = 11;
+		const string AmountColumnKey = "amount";
+		const string BoundPropertyTypeId = "int_bounded";
+		var actions = new Dictionary<int, ActionDefinition>
+		{
+			[BoundActionId] = new ActionDefinition(
+				id: BoundActionId,
+				uiName: "Bound",
+				deployDuration: DeployDuration.Immediate,
+				properties: new[]
+				{
+					new ActionPropertyDefinition(
+						Key: AmountColumnKey,
+						GroupName: null,
+						PropertyTypeId: BoundPropertyTypeId,
+						DefaultValue: null)
+				})
+		};
+		var registry = TestRecipeMetadataRegistryFactory.Build(
+			new[]
+			{
+				TestPropertyTypeDefinitionBuilder.CreateInt(BoundPropertyTypeId, min: 0, max: 100),
+				TestPropertyTypeDefinitionBuilder.CreateString("text", maxLength: 8)
+			},
+			actions);
+		var session = BuildSession(registry);
+		session.AppendStep(BoundActionId).IsSuccess.Should().BeTrue();
+
+		var result = session.UpdateStepProperty(0, AmountColumnKey, "500");
+		result.IsFailed.Should().BeTrue();
+		result.Errors.Should().ContainSingle().Which.Should().BeOfType<ValueAboveMaximumError>(
+			"the interactive-edit path bubbles the typed value error undecorated, with no AtStep/AtColumn wrapper");
+
+		using var panel = new MessagePanelViewModel();
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			panel.ReportFailure(result, string.Format(CultureInfo.InvariantCulture, Resources.StepFormat, 1));
+		}
+
+		var entry = panel.Entries.Should().ContainSingle(item => item.IsError).Subject;
+		entry.Message.Should().Contain("больше максимума").And.Contain(BoundPropertyTypeId);
+	}
+
+	private static RecipeSession BuildSession(RecipeMetadataRegistry registry)
+	{
+		return new RecipeSession(
+			new RecipeAnalyzer(registry),
+			registry,
+			new FormulaEvaluator(registry, NullLogger<FormulaEvaluator>.Instance),
+			new StubPlcSyncService(),
+			NullLogger<RecipeSession>.Instance);
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs
+++ b/SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs
@@ -28,6 +28,32 @@ public static class ReasonLocalizer
 			FormulaComputationFailedError error => Format(Resources.ErrorFormulaComputationFailed, error.Target, error.Reason),
 			AtStepError error => Format(Resources.AtStepFormat, error.StepNumber, Localize(error.Inner)),
 			AtColumnError error => Format(Resources.AtColumnFormat, error.ColumnKey, Localize(error.Inner)),
+			PropertyValueTypeMismatchError error => Format(
+				Resources.ErrorPropertyValueTypeMismatch, error.ExpectedType, error.ActualType, error.Id),
+			UnsupportedPropertySystemTypeError error => Format(
+				Resources.ErrorUnsupportedPropertySystemType, error.SystemType),
+			GroupValueNotIntegerError error => Format(
+				Resources.ErrorGroupValueNotInteger, error.ActualType),
+			ValueBelowMinimumError error => Format(
+				Resources.ErrorValueBelowMinimum, error.Value, error.Min, error.Id),
+			ValueAboveMaximumError error => Format(
+				Resources.ErrorValueAboveMaximum, error.Value, error.Max, error.Id),
+			StringContainsNulError error => Format(
+				Resources.ErrorStringContainsNul, error.Id),
+			StringTooLongError error => Format(
+				Resources.ErrorStringTooLong, error.Length, error.Max, error.Id),
+			ActionByIdNotFoundError error => Format(
+				Resources.ErrorActionByIdNotFound, error.Id),
+			ActionByNameNotFoundError error => Format(
+				Resources.ErrorActionByNameNotFound, error.Name),
+			PropertyNotFoundError error => Format(
+				Resources.ErrorPropertyNotFound, error.PropertyTypeId),
+			ColumnNotFoundError error => Format(
+				Resources.ErrorColumnNotFound, error.Key),
+			GroupNotFoundError error => Format(
+				Resources.ErrorGroupNotFound, error.GroupId),
+			ValueNotInGroupError error => Format(
+				Resources.ErrorValueNotInGroup, error.Key, error.GroupId),
 			UnmatchedEndForWarning warning => Format(Resources.WarningUnmatchedEndFor, warning.StepIndex),
 			UnclosedForLoopWarning warning => Format(Resources.WarningUnclosedForLoop, warning.StartIndex),
 			_ => null

--- a/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
+++ b/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
@@ -302,6 +302,32 @@ public class Resources
 
 	public static string AtColumnFormat => ResourceManager.GetString("AtColumnFormat", resourceCulture) ?? string.Empty;
 
+	public static string ErrorPropertyValueTypeMismatch => ResourceManager.GetString("ErrorPropertyValueTypeMismatch", resourceCulture) ?? string.Empty;
+
+	public static string ErrorUnsupportedPropertySystemType => ResourceManager.GetString("ErrorUnsupportedPropertySystemType", resourceCulture) ?? string.Empty;
+
+	public static string ErrorGroupValueNotInteger => ResourceManager.GetString("ErrorGroupValueNotInteger", resourceCulture) ?? string.Empty;
+
+	public static string ErrorValueBelowMinimum => ResourceManager.GetString("ErrorValueBelowMinimum", resourceCulture) ?? string.Empty;
+
+	public static string ErrorValueAboveMaximum => ResourceManager.GetString("ErrorValueAboveMaximum", resourceCulture) ?? string.Empty;
+
+	public static string ErrorStringContainsNul => ResourceManager.GetString("ErrorStringContainsNul", resourceCulture) ?? string.Empty;
+
+	public static string ErrorStringTooLong => ResourceManager.GetString("ErrorStringTooLong", resourceCulture) ?? string.Empty;
+
+	public static string ErrorActionByIdNotFound => ResourceManager.GetString("ErrorActionByIdNotFound", resourceCulture) ?? string.Empty;
+
+	public static string ErrorActionByNameNotFound => ResourceManager.GetString("ErrorActionByNameNotFound", resourceCulture) ?? string.Empty;
+
+	public static string ErrorPropertyNotFound => ResourceManager.GetString("ErrorPropertyNotFound", resourceCulture) ?? string.Empty;
+
+	public static string ErrorColumnNotFound => ResourceManager.GetString("ErrorColumnNotFound", resourceCulture) ?? string.Empty;
+
+	public static string ErrorGroupNotFound => ResourceManager.GetString("ErrorGroupNotFound", resourceCulture) ?? string.Empty;
+
+	public static string ErrorValueNotInGroup => ResourceManager.GetString("ErrorValueNotInGroup", resourceCulture) ?? string.Empty;
+
 	public static string WarningUnmatchedEndFor => ResourceManager.GetString("WarningUnmatchedEndFor", resourceCulture) ?? string.Empty;
 
 	public static string WarningUnclosedForLoop => ResourceManager.GetString("WarningUnclosedForLoop", resourceCulture) ?? string.Empty;

--- a/SemiStep/SemiStep.UI/Localization/Resources.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.resx
@@ -460,6 +460,45 @@
   <data name="AtColumnFormat" xml:space="preserve">
     <value>Column '{0}': {1}</value>
   </data>
+  <data name="ErrorPropertyValueTypeMismatch" xml:space="preserve">
+    <value>Expected {0} value but got {1} for '{2}'</value>
+  </data>
+  <data name="ErrorUnsupportedPropertySystemType" xml:space="preserve">
+    <value>Unsupported property system type: {0}</value>
+  </data>
+  <data name="ErrorGroupValueNotInteger" xml:space="preserve">
+    <value>Group value must be integer, got {0}</value>
+  </data>
+  <data name="ErrorValueBelowMinimum" xml:space="preserve">
+    <value>Value {0} is below minimum {1} for '{2}'</value>
+  </data>
+  <data name="ErrorValueAboveMaximum" xml:space="preserve">
+    <value>Value {0} exceeds maximum {1} for '{2}'</value>
+  </data>
+  <data name="ErrorStringContainsNul" xml:space="preserve">
+    <value>String value contains embedded NUL character for '{0}'</value>
+  </data>
+  <data name="ErrorStringTooLong" xml:space="preserve">
+    <value>String length {0} exceeds maximum {1} for '{2}'</value>
+  </data>
+  <data name="ErrorActionByIdNotFound" xml:space="preserve">
+    <value>Action with id {0} not found</value>
+  </data>
+  <data name="ErrorActionByNameNotFound" xml:space="preserve">
+    <value>Action with name '{0}' not found</value>
+  </data>
+  <data name="ErrorPropertyNotFound" xml:space="preserve">
+    <value>Property '{0}' not found</value>
+  </data>
+  <data name="ErrorColumnNotFound" xml:space="preserve">
+    <value>Column '{0}' not found</value>
+  </data>
+  <data name="ErrorGroupNotFound" xml:space="preserve">
+    <value>Group '{0}' not found</value>
+  </data>
+  <data name="ErrorValueNotInGroup" xml:space="preserve">
+    <value>Value {0} is not a valid member of group '{1}'</value>
+  </data>
   <data name="WarningUnmatchedEndFor" xml:space="preserve">
     <value>Unmatched EndFor at step {0}</value>
   </data>

--- a/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
@@ -460,6 +460,45 @@
   <data name="AtColumnFormat" xml:space="preserve">
     <value>Столбец «{0}»: {1}</value>
   </data>
+  <data name="ErrorPropertyValueTypeMismatch" xml:space="preserve">
+    <value>Ожидалось значение типа {0}, получено {1} для «{2}»</value>
+  </data>
+  <data name="ErrorUnsupportedPropertySystemType" xml:space="preserve">
+    <value>Неподдерживаемый системный тип свойства: {0}</value>
+  </data>
+  <data name="ErrorGroupValueNotInteger" xml:space="preserve">
+    <value>Значение группы должно быть целым числом, получено {0}</value>
+  </data>
+  <data name="ErrorValueBelowMinimum" xml:space="preserve">
+    <value>Значение {0} меньше минимума {1} для «{2}»</value>
+  </data>
+  <data name="ErrorValueAboveMaximum" xml:space="preserve">
+    <value>Значение {0} больше максимума {1} для «{2}»</value>
+  </data>
+  <data name="ErrorStringContainsNul" xml:space="preserve">
+    <value>Строковое значение содержит встроенный символ NUL для «{0}»</value>
+  </data>
+  <data name="ErrorStringTooLong" xml:space="preserve">
+    <value>Длина строки {0} превышает максимум {1} для «{2}»</value>
+  </data>
+  <data name="ErrorActionByIdNotFound" xml:space="preserve">
+    <value>Действие с идентификатором {0} не найдено</value>
+  </data>
+  <data name="ErrorActionByNameNotFound" xml:space="preserve">
+    <value>Действие с именем «{0}» не найдено</value>
+  </data>
+  <data name="ErrorPropertyNotFound" xml:space="preserve">
+    <value>Свойство «{0}» не найдено</value>
+  </data>
+  <data name="ErrorColumnNotFound" xml:space="preserve">
+    <value>Столбец «{0}» не найден</value>
+  </data>
+  <data name="ErrorGroupNotFound" xml:space="preserve">
+    <value>Группа «{0}» не найдена</value>
+  </data>
+  <data name="ErrorValueNotInGroup" xml:space="preserve">
+    <value>Значение {0} не является допустимым членом группы «{1}»</value>
+  </data>
   <data name="WarningUnmatchedEndFor" xml:space="preserve">
     <value>Непарный EndFor на шаге {0}</value>
   </data>

--- a/docs/plans/completed/20260729-recipe-value-errors-typed.md
+++ b/docs/plans/completed/20260729-recipe-value-errors-typed.md
@@ -1,0 +1,157 @@
+# Slice 4b — Type the recipe value errors (PropertyValidator + RecipeMetadataRegistry)
+
+## Overview
+
+Slice 4a built the warning-localization track; slices 1-3 built the error track and the `ImportedRecipeValidator`
+decorator gate. What still renders English regardless of culture is the **recipe value error surface**: the two
+producers every recipe-value check flows through — `PropertyValidator` (range/type/string rules) and
+`RecipeMetadataRegistry` (not-found / not-in-group lookups) — still raise `Result.Fail($"english string")`. Their
+output reaches the panel two ways, both currently English:
+
+- **Import path** (paste / CSV-load / PLC-read → `ImportedRecipeValidator`): the gate wraps each inner error in the
+  slice-3 `AtStepError`/`AtColumnError` decorators, which already compose `Localize(inner)`. The moment the inner is a
+  typed error the decorator renders it localized — **no gate change needed**.
+- **Interactive-edit path** (`RecipeSession.ParseAndValidateColumnValue` → `PropertyParser`/`PropertyValidator`/
+  registry, undecorated): the raw `Result` bubbles to `MessagePanelViewModel`, which localizes by type. A typed error
+  localizes standalone here too.
+
+This slice types those two producers so both paths localize by type. It is the high-value cut of the recipe wave
+(slice 4b), after 4a (warnings) and before 4c (`RecipeSession` index errors, `PropertyParser`, `RecipeAnalyzer`,
+`LoopParser` iteration error, and the `FormulaEvaluator` 158/166 → `CausedBy` refactor).
+
+**13 typed error classes**, all public in `SemiStep.Core.Recipes.Errors`. Each is auto-caught by the reflection
+coverage test (`EveryPublicCoreReasonType_...`), so
+every new type must land with its `ReasonLocalizer` arm + resx pair + sample in the SAME task or the build goes red.
+
+**Scope decisions:**
+- `PropertyValidator` **stays `internal static`** — only the error *types* must be public for `ReasonLocalizer` to
+  match them; exposing the validator itself is needless surface.
+- `RecipeMetadataRegistry`'s 6 `throw new InvalidOperationException(...)` construction-time fail-fasts (lines
+  82/108/230/250/263/280) are **out of scope** — they never become `Result` reasons and never reach the UI.
+- `ActionTreeResolver` errors are **out of scope** (startup-fatal, rethrown as `InvalidOperationException` at registry
+  construction — 4c or later if ever).
+- `FormulaEvaluator.cs:158/166` bake `PropertyValidator`'s `.Message` into the formula error's `reason`. Typing
+  `PropertyValidator` here does NOT break them (`.Message` stays English on typed errors); dropping the baked reason in
+  favour of the now-typed `CausedBy` is the **4c** formula refactor, not this slice.
+
+**Behavior-preserving for English.** Every typed error passes today's exact English string to its base ctor (the
+log/`.Message` text), and each resx **en** value equals it byte-for-byte, so English output is unchanged and the gate
+tests' fragment `.Contains` asserts survive. Under `ru` the value errors now read Russian.
+
+## Acceptance
+
+1. 13 public typed `Error` subclasses in `SemiStep.Core.Recipes.Errors`, each carrying its interpolated runtime values
+   as fields and an English base message identical to the pre-slice string.
+2. `PropertyValidator` (9 `Result.Fail` sites → 7 classes; the three "Expected X value" sites share one) and `RecipeMetadataRegistry` (11 sites → 6 templates via the helpers) raise the typed
+   errors instead of `Result.Fail(string)`; `ImportedRecipeValidator`'s own `Group value must be integer` raw
+   (slice-3) reuses the shared `GroupValueNotIntegerError` (dedup).
+3. `ReasonLocalizer` localizes all 13 by type; en renders the unchanged English, ru renders Russian.
+4. resx parity (`ResourceSyncTests`: en == ru == Designer) for the 13 new keys.
+5. Coverage test (`EveryPublicCoreReasonType_...`) green — each new type has a sample + a localizing case (a new type
+   with no case goes red).
+6. Both paths localize: import (through the `AtStep`/`AtColumn` decorators, no gate change) and interactive-edit
+   (standalone), verified under `ru`.
+7. `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test` green.
+
+## The 13 typed errors (canonical table)
+
+resx key convention `Error<Name>`; en value MUST equal the current baked string; ru uses guillemets «» where a value
+is quoted (the established ru typography precedent). `{n}` placeholders map to the ctor fields in order.
+
+### Task 1 batch — PropertyValidator (7 classes)
+
+| Error class | Fields | en (`Error…` value) | ru |
+|---|---|---|---|
+| `PropertyValueTypeMismatchError` | expectedType, actualType, id | `Expected {0} value but got {1} for '{2}'` | `Ожидалось значение типа {0}, получено {1} для «{2}»` |
+| `UnsupportedPropertySystemTypeError` | systemType | `Unsupported property system type: {0}` | `Неподдерживаемый системный тип свойства: {0}` |
+| `GroupValueNotIntegerError` | actualType | `Group value must be integer, got {0}` | `Значение группы должно быть целым числом, получено {0}` |
+| `ValueBelowMinimumError` | value, min, id | `Value {0} is below minimum {1} for '{2}'` | `Значение {0} меньше минимума {1} для «{2}»` |
+| `ValueAboveMaximumError` | value, max, id | `Value {0} exceeds maximum {1} for '{2}'` | `Значение {0} больше максимума {1} для «{2}»` |
+| `StringContainsNulError` | id | `String value contains embedded NUL character for '{0}'` | `Строковое значение содержит встроенный символ NUL для «{0}»` |
+| `StringTooLongError` | length, max, id | `String length {0} exceeds maximum {1} for '{2}'` | `Длина строки {0} превышает максимум {1} для «{2}»` |
+
+`PropertyValueTypeMismatchError` covers all three "Expected X value but got…" sites (int/float/string) — `expectedType`
+is the literal type word (`int`/`float`/`string`), not localized.
+
+### Task 2 batch — RecipeMetadataRegistry (6 classes)
+
+| Error class | Fields | en | ru |
+|---|---|---|---|
+| `ActionByIdNotFoundError` | id | `Action with id {0} not found` | `Действие с идентификатором {0} не найдено` |
+| `ActionByNameNotFoundError` | name | `Action with name '{0}' not found` | `Действие с именем «{0}» не найдено` |
+| `PropertyNotFoundError` | propertyTypeId | `Property '{0}' not found` | `Свойство «{0}» не найдено` |
+| `ColumnNotFoundError` | key | `Column '{0}' not found` | `Столбец «{0}» не найден` |
+| `GroupNotFoundError` | groupId | `Group '{0}' not found` | `Группа «{0}» не найдена` |
+| `ValueNotInGroupError` | key, groupId | `Value {0} is not a valid member of group '{1}'` | `Значение {0} не является допустимым членом группы «{1}»` |
+
+The ru column is a starting translation — review it in Rider before exec and correct wording/typography as needed.
+
+## Task 1: Type PropertyValidator (7 classes, fully wired)
+
+**Files:**
+- Create: 7 error classes in `SemiStep/SemiStep.Core/Recipes/Errors/` (one per file, public sealed, `AtStepError.cs` as the shape precedent — ctor fields + English base message).
+- Modify: `SemiStep/SemiStep.Core/Recipes/PropertyValidator.cs` — raise the typed errors (stays `internal static`).
+- Modify: `SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs` — swap its own `new Error("Group value must be integer, got {type}")` for `new GroupValueNotIntegerError(...)` (dedup; removes a slice-3 pinned English string).
+- Modify: `SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs` (7 arms + using), `Resources.resx`, `Resources.ru.resx`, `Resources.Designer.cs` (7 keys + hand-written accessors).
+- Modify: `SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs` (7 samples).
+
+- [x] Create the 7 Task-1 error classes per the table (fields + English base message identical to the current strings). Field types — read the source, and note two distinct `actualType`s: `PropertyValueTypeMismatchError.actualType` is a **`string`** (`value.GetType().Name`, e.g. "Int32"/"Single" — pinned by `PropertyValidatorStringTypeMismatchTests.cs:25` `.Contain("Int32")`), whereas `GroupValueNotIntegerError.actualType` is the **`PropertyType` enum** (`parsed.Type`). `value`/`min`/`max` are `double`, `length`/`max` are `int`, `id` is `string`. For the numeric-field base messages, format with `FormattableString.Invariant($"…")` (or `CultureInfo.InvariantCulture`) so the `.Message`/log text is culture-stable regardless of process culture — today's interpolation is not, and this keeps logs English-invariant per the log-English rule. (The panel render already formats via `Resources.Culture`, so a fractional bound reads "1.5" en / localized-separator ru — culture-correct; no existing test uses fractional bounds.)
+- [x] `PropertyValidator.cs`: replace all 7 `Result.Fail($"…")` with the typed errors (lines 13, 16, 18, 34, 44, 50, 62, 67, 73 — note 13/16/62 all map to `PropertyValueTypeMismatchError` with expectedType int/float/string).
+- [x] `ImportedRecipeValidator.cs`: replace its own `Group value must be integer` raw with `GroupValueNotIntegerError` (same typed error PropertyValidator now raises). Verify it still wraps in `AtColumnError` as before.
+- [x] `ReasonLocalizer`: add 7 arms `Format(Resources.Error<Name>, error.Field0, …)` + `using SemiStep.Core.Recipes.Errors;` (may already be present from slice 3).
+- [x] resx: 7 `Error<Name>` keys in Resources.resx (en, equal to the baked string) + Resources.ru.resx (ru) + 7 hand-written Designer accessors. Keep BOM state of each file as-is (Designer.cs no-BOM outlier; resx match siblings; ReasonLocalizer.cs keeps BOM).
+- [x] Coverage: seed 7 samples in `_typeData`; add `using SemiStep.Core.Recipes;` to the coverage test for the `PropertyType` value in the `GroupValueNotIntegerError` sample (the file imports `.Errors`/`.Analysis.Warnings`/`.Formulas.Errors`/`.Shared` but not `.Recipes`).
+- [x] The 13 new `Recipes/Errors/*.cs` files carry a UTF-8 BOM, matching the `AtStepError.cs`/`AtColumnError.cs` precedent.
+- [x] **Rewrite the slice-3 interim test that this batch supersedes.** `MessagePanelReportingTests.cs` `GateValidationFailure_...ShowsRussianPositionEnglishDetail` (~:200-245) asserts, under `ru`, a Russian position with the inner detail STILL English (`.Contain("exceeds maximum")`) — that inner is exactly `ValueAboveMaximumError`, which Task 1 types. The moment this batch lands, the inner renders Russian. Rewrite it: rename to `...ShowsRussianPositionAndDetail` and assert the Russian detail (Russian position + Russian range message). This is the slice-3 "position localized, detail English" interim state being retired for value errors — expected and correct.
+- [x] `dotnet build SemiStep.slnx` 0 warnings; run the **full** `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` (NOT just the ResourceSync/coverage filters — the superseded test above lives outside them). All green. All other value-error assertions read raw `.Message` (English-preserved), so expect only the one rewrite above.
+
+## Task 2: Type RecipeMetadataRegistry (6 classes, fully wired)
+
+**Files:**
+- Create: 6 error classes in `SemiStep/SemiStep.Core/Recipes/Errors/`.
+- Modify: `SemiStep/SemiStep.Core/Recipes/RecipeMetadataRegistry.cs` — change `TryGetOrFail`/`ContainsOrFail` to take an `IError` (built at each call site) instead of a `string errorMessage`; raise typed errors at all 11 sites; `GroupHasIntKey:295` raises `ValueNotInGroupError`.
+- Modify: `ReasonLocalizer.cs` (6 arms), `Resources.resx`, `Resources.ru.resx`, `Resources.Designer.cs` (6 keys), `CoreErrorLocalizationCoverageTests.cs` (6 samples).
+
+- [x] Create the 6 Task-2 error classes per the table. Field types: `ActionByIdNotFoundError.id` is **`int`** (the registry key); `name`/`propertyTypeId`/`key`/`groupId` are `string`; `ValueNotInGroupError` is (`int key`, `string groupId`).
+- [x] `RecipeMetadataRegistry.cs`: change the two private helpers' signature from `string errorMessage` to `IError error` (`Result.Fail(error)`); update the **10 helper call sites** to pass the typed error (114/129 → `ActionByIdNotFoundError`, 124/134 → `ActionByNameNotFoundError`, 144/149 → `PropertyNotFoundError`, 154/159 → `ColumnNotFoundError`, 169/174 → `GroupNotFoundError`); `GroupHasIntKey:295` is a **direct** `Result.Fail` (not a helper call) → `Result.Fail(new ValueNotInGroupError(key, groupId))`.
+- [x] `ReasonLocalizer`: 6 arms. resx: 6 keys (en == baked string) + ru + Designer accessors. Coverage: 6 samples. New error files carry BOM; resx/Designer BOM states preserved.
+- [x] `dotnet build SemiStep.slnx` 0 warnings; run the **full** `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` green (full suite at this boundary too, symmetry with Tasks 1/3 — the sweep shows no registry test asserts a localized panel entry, but run it to catch any stray break).
+
+## Task 3: Cross-path tests + doc + full verify
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs` (representative ru/en render cases).
+- Modify: `SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs` and/or `MessagePanelReportingTests.cs` (both-path end-to-end).
+- Modify: `Docs/architecture/error-reporting.md`.
+
+- [x] ru render cases in `ReasonLocalizerTests` for a representative subset spanning both batches (e.g. `ValueAboveMaximumError`, `StringTooLongError`, `ColumnNotFoundError`, `ValueNotInGroupError`) + one en case pinning `Localize(sample).Should().Be(sample.Message)` per the 4a convention (the coverage test already forces a case for ALL 13; these pin exact wording for the representative few).
+- [x] **Import path (decorated):** an `ImportedRecipeValidator` gate failure whose inner is a typed value error renders, under `ru`, as `AtStep`→`AtColumn`→localized-inner (e.g. Russian position + Russian range message). Extends the slice-3 end-to-end.
+- [x] **Interactive-edit path (undecorated):** a `RecipeSession.UpdateStepProperty` value failure surfaced through the panel renders the typed error localized under `ru` (standalone, no decorator).
+- [x] **Gate fragment-preservation sweep:** grep the Tests tree for the old English fragments (`is below minimum`, `not found`, `is not a valid member`, `Expected int value`, etc.); any assertion reading a raw `.Message` stays as-is (English-preserving); any assertion reading a LOCALIZED panel entry under ambient culture on this ru machine must be culture-scoped (`ResourcesCultureScope.Use("en")`) or switched to a type assertion — same rule as 4a (localized-panel → scope/type; raw `.Message` → leave).
+- [x] `Docs/architecture/error-reporting.md`: note that the recipe value producers (`PropertyValidator`, `RecipeMetadataRegistry`) now localize by type on both the decorated import path and the undecorated interactive-edit path.
+- [x] full `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test` green; `dotnet format`.
+
+## Post-Completion
+
+**Next (slice 4c):** `RecipeSession` index errors (undo/redo/insert/step-index, 4), `PropertyParser` (3),
+`RecipeAnalyzer` max-loop-depth (1), `LoopParser` iteration-type error (1), `ImportedRecipeValidator`'s own
+`Unknown action ID` raw (line 38 — forward the now-typed `ActionByIdNotFoundError`), and the `FormulaEvaluator`
+158/166 → `CausedBy` refactor (drop the baked `.Message`, now that `PropertyValidator` is typed). Then slice 5
+(clipboard/CSV + CSV row-count warning on the unsealed `Warning` + `ReportWarning(IReason)` seam), slice 6 (#120 PLC),
+slice 7 (style-editor).
+
+---
+
+**Executed by exec:**
+- branch: recipe-value-errors-typed
+- commits: ead9b61 (PropertyValidator 7) · 5eff2df (RecipeMetadataRegistry 6) · 81af63d (both-path tests + doc) · 1ddad50 (review-1 doc guillemet fix) · 6693015 (smells fix: drop needless Invariant on int msg)
+- review chain: comprehensive (5 agents, all OUTCOME ACHIEVED) → fixer 1ddad50 (doc self-contradiction on AtColumnFormat ru guillemets) → smells → fixer 6693015 (Invariant consistency) → comment audit (Ship) → critical ×2 (no critical/major). codex skipped (not installed).
+
+## Verify it yourself
+1. `dotnet build SemiStep.slnx` — 0 warnings.
+2. `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1591 passed, 0 failed.
+3. All 13 localize by type: `--filter "FullyQualifiedName~ReasonLocalizer|FullyQualifiedName~CoreErrorLocalizationCoverage"` — coverage forces a case for every public Error/Warning subclass; the render cases pin ru wording (e.g. `Значение 500 больше максимума 100 для «temperature»`).
+4. resx parity: `--filter "FullyQualifiedName~ResourceSync"` — en == ru == Designer for the 13 new keys.
+5. Both paths under ru: `--filter "FullyQualifiedName~MessagePanelReporting"` — import (AtStep→AtColumn→localized inner) and interactive-edit (undecorated `ValueAboveMaximumError` bubbles + localizes standalone).
+6. English preserved: the raw-`.Message` gate assertions (`ImportedRecipeValidatorTests`, `PropertyValidatorStringTypeMismatchTests`, `CsvPropertyValidationTests`) stay green unchanged — proof the en text is byte-identical.
+7. Manual (optional): under a Russian UI, paste/import a recipe with an out-of-range value or unknown column — the panel shows the value error in Russian.


### PR DESCRIPTION
## Problem

The recipe **value error surface** still rendered English regardless of culture. `PropertyValidator` (range / type / string rules) and `RecipeMetadataRegistry` (not-found / not-in-group lookups) raised `Result.Fail($"english string")`, and those reach the panel two ways — through the `ImportedRecipeValidator` import gate (paste / CSV / PLC) and through the interactive-edit path — both English, because `ReasonLocalizer` matches by type and these were untyped.

## What changed

Type both producers so both paths localize by type. **13 public `Error` subclasses** in `SemiStep.Core.Recipes.Errors`, each carrying its runtime values as fields:

- `PropertyValidator` (stays `internal static`) — 9 `Result.Fail` sites → 7 classes (type-mismatch, unsupported-system-type, group-value-not-int, below-min, above-max, nul-char, string-too-long).
- `RecipeMetadataRegistry` — 11 sites → 6 classes, via changing the `TryGetOrFail` / `ContainsOrFail` helpers from a `string` message to an `IError` (action-by-id, action-by-name, property, column, group, value-not-in-group).
- `ImportedRecipeValidator` reuses the shared `GroupValueNotIntegerError` instead of its own slice-3 raw string (dedup).
- Each type: a `ReasonLocalizer` arm + resx en/ru pair (en byte-identical to the baked string, ru with guillemets) + hand-written Designer accessor + coverage sample.

The import path localizes through the slice-3 `AtStep`/`AtColumn` decorators (which compose `Localize(inner)`) with **no gate change**; the interactive-edit path localizes standalone.

**Behavior-preserving for English**: every typed error keeps today's exact English base message and each resx `en` value equals it byte-for-byte, so the raw-`.Message` gate assertions (`ImportedRecipeValidatorTests`, `PropertyValidatorStringTypeMismatchTests`, `CsvPropertyValidationTests`) stay green unchanged. Numeric bounds use `FormattableString.Invariant` so the log/`.Message` text is culture-stable. Under `ru` the value errors now read Russian.

**Interim scope**: this slice types the two value producers. The free-text raises in `RecipeSession` / `PropertyParser` / `RecipeAnalyzer` / `LoopParser`'s iteration error, `ImportedRecipeValidator`'s `Unknown action ID` raw, and the `FormulaEvaluator` baked-reason → `CausedBy` refactor are slice 4c.

## Verification

- `dotnet build SemiStep.slnx` — 0 warnings.
- `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1591 passed, 0 failed.
- Coverage test forces a `ReasonLocalizer` case for every public Error/Warning subclass; `ReasonLocalizerTests` pins ru/en render; `ResourceSyncTests` holds en == ru == Designer for the 13 new keys.
- Both paths under `ru`: `MessagePanelReportingTests` — import (`AtStep`→`AtColumn`→localized inner) and interactive-edit (undecorated `ValueAboveMaximumError` bubbles + localizes standalone).
- Review chain: comprehensive (5 agents, all OUTCOME ACHIEVED) → smells → comment audit → critical ×2, clean after two fixes (a doc guillemet self-contradiction, a needless `Invariant` on an int message).
- **Manual test (operator):** imported a recipe with an out-of-range value / unknown column under the Russian UI — the value error shows in Russian.

<details>
<summary>Per-task commits before collapse</summary>

```
62cc74e docs(plans): record 4b exec branch and verification
6693015 refactor(core): drop needless Invariant on int error message
1ddad50 docs: fix russian guillemet example in error-reporting
81af63d test(l10n): cover recipe value errors on both paths
5eff2df feat(l10n): type RecipeMetadataRegistry lookup errors
ead9b61 feat(l10n): type PropertyValidator value errors
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
