### PR TITLE
feat(l10n): localize remaining recipe errors by type

### DIFF
--- a/Docs/architecture/error-reporting.md
+++ b/Docs/architecture/error-reporting.md
@@ -45,7 +45,7 @@ stays English (see "The log path is unchanged").
 Operator-facing Core failures are modelled as **typed `FluentResults.Error` subclasses**, not free-text
 `Result.Fail("...")`. Each subclass owns its English message string in Core (aligned with the English
 log), and carries its data as structured properties (e.g. `OwnedByAnotherInstanceError.Holder`,
-`FormulaComputationFailedError.Target`/`.Reason`) rather than baking them into the string. The same
+`FormulaComputationFailedError.Target`/`.Inner`) rather than baking them into the string. The same
 seam also localizes typed `Success`-derived `Warning` subclasses (e.g. the loop warnings) by type, so
 warnings and errors share one localization path.
 
@@ -86,7 +86,14 @@ mirror images:
 - **Composition** is the reverse — a *typed* decorator localizes its own position and folds the
   localized inner into it.
 
-Because both decorators are public non-abstract Core `Error` subclasses, the coverage test forces a
+`FormulaComputationFailedError` composes the same way, but folds a *cause* instead of a position: it
+carries the typed inner in `Inner` and its `ReasonLocalizer` case renders
+`Format(ErrorFormulaComputationFailed, Target, Localize(Inner))`. When the inner is a typed value error
+(the `PropertyValidator` cause on the formula path), `Localize(Inner)` recurses and the whole sentence —
+headline *and* detail — reads in the current culture; a free-text inner falls through to its English
+`.Message`.
+
+Because these decorators are public non-abstract Core `Error` subclasses, the coverage test forces a
 `ReasonLocalizer` case for each; a missing case is a red build.
 
 ### Recipe value errors localize on both paths
@@ -104,9 +111,16 @@ localize by type on both routes that carry them to the panel:
   `ParseAndValidateColumnValue` → `PropertyValidator`/registry bubbles the typed error straight to the panel
   with no decorator, so it localizes standalone.
 
-Still free-text (deferred to a later wave): `ImportedRecipeValidator`'s own unknown-action raise,
-`PropertyParser`, and the `RecipeSession` index errors. `Localize(Inner)` falls through to `.Message` for
-those until their own wave types them.
+The remaining lower-frequency recipe producers now localize by type too: `RecipeSession`
+(undo/redo-empty and insert/step index errors), `PropertyParser` (parse failures), `RecipeAnalyzer`
+(max loop-nesting depth), and `LoopParser` (iteration-count unsupported type) all raise typed errors
+instead of `Result.Fail(string)`. `ImportedRecipeValidator` no longer raises its own unknown-action
+string — it forwards the registry's typed `ActionByIdNotFoundError`. With these typed, `Localize(Inner)`
+renders them localized rather than falling through to `.Message`.
+
+Still free-text (deferred to a later wave): clipboard/CSV producers, PLC, the style-editor, and the
+five formula-internal free-text inners (null expression, evaluation exception, non-finite, Int32/float
+overflow), which stay English under `ru` because their inner is wrapped in a plain `new Error(text)`.
 
 ### The published rule (public error surface)
 

--- a/SemiStep/SemiStep.Core/Recipes/Analysis/LoopParser.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Analysis/LoopParser.cs
@@ -1,6 +1,7 @@
 ﻿using FluentResults;
 
 using SemiStep.Core.Recipes.Analysis.Warnings;
+using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Shared;
 
 namespace SemiStep.Core.Recipes.Analysis;
@@ -84,8 +85,7 @@ internal static class LoopParser
 		{
 			PropertyType.Int => iterationProperty.AsInt(),
 			PropertyType.Float => (int)iterationProperty.AsFloat(),
-			_ => new Error($"Iteration count property has unsupported type " +
-						   $"'{iterationProperty.Type}' in step {step.ActionKey}")
+			_ => new IterationCountUnsupportedTypeError(iterationProperty.Type, step.ActionKey)
 		};
 	}
 

--- a/SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Analysis/RecipeAnalyzer.cs
@@ -1,5 +1,7 @@
 ﻿using FluentResults;
 
+using SemiStep.Core.Recipes.Errors;
+
 namespace SemiStep.Core.Recipes.Analysis;
 
 public sealed class RecipeAnalyzer(RecipeMetadataRegistry registry)
@@ -24,7 +26,7 @@ public sealed class RecipeAnalyzer(RecipeMetadataRegistry registry)
 
 		if (maxDepth > MaxLoopDepth)
 		{
-			return Result.Fail($"Maximum loop nesting depth ({MaxLoopDepth}) exceeded: {maxDepth}");
+			return Result.Fail(new MaxLoopNestingDepthExceededError(MaxLoopDepth, maxDepth));
 		}
 
 		var snapshot = RecipeSnapshot.Create(

--- a/SemiStep/SemiStep.Core/Recipes/Errors/InsertIndexOutOfRangeError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/InsertIndexOutOfRangeError.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class InsertIndexOutOfRangeError(int index, int stepCount)
+	: Error($"Insert index {index} is out of range for recipe with {stepCount} steps")
+{
+	public int Index { get; } = index;
+
+	public int StepCount { get; } = stepCount;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/IterationCountUnsupportedTypeError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/IterationCountUnsupportedTypeError.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class IterationCountUnsupportedTypeError(PropertyType type, int actionKey)
+	: Error($"Iteration count property has unsupported type {type} in step {actionKey}")
+{
+	public PropertyType Type { get; } = type;
+
+	public int ActionKey { get; } = actionKey;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/MaxLoopNestingDepthExceededError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/MaxLoopNestingDepthExceededError.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class MaxLoopNestingDepthExceededError(int maxAllowed, int actualDepth)
+	: Error($"Maximum loop nesting depth ({maxAllowed}) exceeded: {actualDepth}")
+{
+	public int MaxAllowed { get; } = maxAllowed;
+
+	public int ActualDepth { get; } = actualDepth;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/NoStateToRedoError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/NoStateToRedoError.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class NoStateToRedoError()
+	: Error("No state to redo to")
+{
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/NoStateToUndoError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/NoStateToUndoError.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class NoStateToUndoError()
+	: Error("No state to undo to")
+{
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/PropertyValueParseError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/PropertyValueParseError.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class PropertyValueParseError(string rawValue, string targetType)
+	: Error($"Cannot parse '{rawValue}' as {targetType}")
+{
+	public string RawValue { get; } = rawValue;
+
+	public string TargetType { get; } = targetType;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Errors/StepIndexOutOfRangeError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Errors/StepIndexOutOfRangeError.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+
+namespace SemiStep.Core.Recipes.Errors;
+
+public sealed class StepIndexOutOfRangeError(int index, int stepCount)
+	: Error($"Step index {index} is out of range for recipe with {stepCount} steps")
+{
+	public int Index { get; } = index;
+
+	public int StepCount { get; } = stepCount;
+}

--- a/SemiStep/SemiStep.Core/Recipes/Formulas/Errors/FormulaComputationFailedError.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Formulas/Errors/FormulaComputationFailedError.cs
@@ -2,18 +2,10 @@
 
 namespace SemiStep.Core.Recipes.Formulas.Errors;
 
-public sealed class FormulaComputationFailedError : Error
+public sealed class FormulaComputationFailedError(string target, IError inner)
+	: Error($"Formula computation for target '{target}' failed: {inner.Message}")
 {
-	public FormulaComputationFailedError(string target, string reason)
-		: base($"Formula computation for target '{target}' failed: {reason}")
-	{
-		Target = target;
-		Reason = reason;
-		Metadata["target"] = target;
-		Metadata["reason"] = reason;
-	}
+	public string Target { get; } = target;
 
-	public string Target { get; }
-
-	public string Reason { get; }
+	public IError Inner { get; } = inner;
 }

--- a/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Formulas/FormulaEvaluator.cs
@@ -120,7 +120,7 @@ public sealed class FormulaEvaluator
 			{
 				return Result.Fail<double>(new FormulaComputationFailedError(
 					target,
-					"Expression evaluated to null."));
+					new Error("Expression evaluated to null.")));
 			}
 
 			computed = Convert.ToDouble(raw, CultureInfo.InvariantCulture);
@@ -132,7 +132,7 @@ public sealed class FormulaEvaluator
 				"Formula evaluation failed for action {ActionId} target {Target}",
 				actionId,
 				target);
-			return Result.Fail<double>(new FormulaComputationFailedError(target, evaluationException.Message));
+			return Result.Fail<double>(new FormulaComputationFailedError(target, new Error(evaluationException.Message)));
 		}
 
 		if (double.IsNaN(computed) || double.IsInfinity(computed))
@@ -140,7 +140,7 @@ public sealed class FormulaEvaluator
 			var token = double.IsNaN(computed) ? "NaN" : "Infinity";
 			return Result.Fail<double>(new FormulaComputationFailedError(
 				target,
-				$"Expression produced non-finite value '{token}' ({computed.ToString(CultureInfo.InvariantCulture)})."));
+				new Error($"Expression produced non-finite value '{token}' ({computed.ToString(CultureInfo.InvariantCulture)}).")));
 		}
 
 		return Result.Ok(computed);
@@ -155,17 +155,13 @@ public sealed class FormulaEvaluator
 		var validation = PropertyValidator.Validate(propertyDefinition, newPropertyValue.Value);
 		if (validation.IsFailed)
 		{
-			return Result.Fail(new FormulaComputationFailedError(
-				target,
-				validation.Errors[0].Message).CausedBy(validation.Errors));
+			return Result.Fail(new FormulaComputationFailedError(target, validation.Errors[0]));
 		}
 
 		var groupCheck = PropertyValidator.ValidateGroupValue(targetActionProperty, newPropertyValue, _registry);
 		if (groupCheck.IsFailed)
 		{
-			return Result.Fail(new FormulaComputationFailedError(
-				target,
-				string.Join("; ", groupCheck.Errors.Select(e => e.Message))).CausedBy(groupCheck.Errors));
+			return Result.Fail(new FormulaComputationFailedError(target, groupCheck.Errors[0]));
 		}
 
 		return Result.Ok();
@@ -222,7 +218,7 @@ public sealed class FormulaEvaluator
 				return Result.Fail<PropertyValue>(
 					new FormulaComputationFailedError(
 						target,
-						$"Recalculated value {computed.ToString(CultureInfo.InvariantCulture)} overflows Int32."));
+						new Error($"Recalculated value {computed.ToString(CultureInfo.InvariantCulture)} overflows Int32.")));
 			}
 
 			return Result.Ok(PropertyValue.FromInt((int)rounded));
@@ -236,7 +232,7 @@ public sealed class FormulaEvaluator
 				return Result.Fail<PropertyValue>(
 					new FormulaComputationFailedError(
 						target,
-						$"Recalculated value {computed.ToString(CultureInfo.InvariantCulture)} is not representable as a finite float."));
+						new Error($"Recalculated value {computed.ToString(CultureInfo.InvariantCulture)} is not representable as a finite float.")));
 			}
 
 			return Result.Ok(PropertyValue.FromFloat(floatValue));

--- a/SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Helpers/ImportedRecipeValidator.cs
@@ -35,7 +35,7 @@ public sealed class ImportedRecipeValidator(
 		var actionResult = recipeMetadataRegistry.GetAction(step.ActionKey);
 		if (actionResult.IsFailed)
 		{
-			errors.Add(new Error($"Unknown action ID {step.ActionKey}"));
+			errors.Add(actionResult.Errors[0]);
 			return errors;
 		}
 

--- a/SemiStep/SemiStep.Core/Recipes/PropertyParser.cs
+++ b/SemiStep/SemiStep.Core/Recipes/PropertyParser.cs
@@ -1,6 +1,9 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 
 using FluentResults;
+
+using SemiStep.Core.Recipes.Errors;
 
 namespace SemiStep.Core.Recipes;
 
@@ -15,7 +18,8 @@ public static class PropertyParser
 			PropertyType.Int => ParseInt(input),
 			PropertyType.Float => ParseFloat(input),
 			PropertyType.String => Result.Ok(PropertyValue.FromString(input)),
-			_ => Result.Fail($"Unknown property type '{propertyType}'")
+			_ => throw new InvalidOperationException(
+				$"Unknown property type '{propertyType}'. FromSystemType only yields Int/Float/String, so this arm is unreachable.")
 		};
 	}
 
@@ -26,7 +30,7 @@ public static class PropertyParser
 			return Result.Ok(PropertyValue.FromInt(result));
 		}
 
-		return Result.Fail($"Cannot parse '{rawValue}' as integer");
+		return Result.Fail(new PropertyValueParseError(rawValue, "integer"));
 	}
 
 	private static Result<PropertyValue> ParseFloat(string rawValue)
@@ -36,6 +40,6 @@ public static class PropertyParser
 			return Result.Ok(PropertyValue.FromFloat(result));
 		}
 
-		return Result.Fail($"Cannot parse '{rawValue}' as float");
+		return Result.Fail(new PropertyValueParseError(rawValue, "float"));
 	}
 }

--- a/SemiStep/SemiStep.Core/Recipes/RecipeSession.cs
+++ b/SemiStep/SemiStep.Core/Recipes/RecipeSession.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 
 using SemiStep.Core.Plc;
 using SemiStep.Core.Recipes.Analysis;
+using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas;
 using SemiStep.Core.Recipes.Helpers;
 using SemiStep.Core.Shared;
@@ -85,7 +86,7 @@ public sealed class RecipeSession
 		if (_undoStack.Count == 0)
 		{
 			_logger.LogInformation("Undo requested but no state available");
-			return Result.Fail("No state to undo to");
+			return Result.Fail(new NoStateToUndoError());
 		}
 
 		var previousIndex = _undoStack.Count - 1;
@@ -113,7 +114,7 @@ public sealed class RecipeSession
 		if (_redoStack.Count == 0)
 		{
 			_logger.LogInformation("Redo requested but no state available");
-			return Result.Fail("No state to redo to");
+			return Result.Fail(new NoStateToRedoError());
 		}
 
 		var nextIndex = _redoStack.Count - 1;
@@ -633,7 +634,7 @@ public sealed class RecipeSession
 	{
 		if (index < 0 || index > recipe.Steps.Count)
 		{
-			return Result.Fail($"Insert index {index} is out of range for recipe with {recipe.Steps.Count} steps");
+			return Result.Fail(new InsertIndexOutOfRangeError(index, recipe.Steps.Count));
 		}
 
 		return Result.Ok();
@@ -643,7 +644,7 @@ public sealed class RecipeSession
 	{
 		if (index < 0 || index >= recipe.Steps.Count)
 		{
-			return Result.Fail($"Step index {index} is out of range for recipe with {recipe.Steps.Count} steps");
+			return Result.Fail(new StepIndexOutOfRangeError(index, recipe.Steps.Count));
 		}
 
 		return Result.Ok();

--- a/SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs
+++ b/SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs
@@ -463,6 +463,6 @@ public sealed class ImportedRecipeValidatorTests
 		stepError.StepNumber.Should().Be(1);
 
 		stepError.Inner.Should().NotBeOfType<AtColumnError>();
-		stepError.Inner.Message.Should().Be($"Unknown action ID {UnknownActionId}");
+		stepError.Inner.Message.Should().Be($"Action with id {UnknownActionId} not found");
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs
@@ -29,7 +29,7 @@ public sealed class CoreErrorLocalizationCoverageTests
 		[typeof(OwnedByAnotherInstanceError)] =
 			new OwnedByAnotherInstanceError(new OwnerInfo(1, "MACHINE", "alice", DateTimeOffset.UnixEpoch)),
 		[typeof(FormulaComputationFailedError)] =
-			new FormulaComputationFailedError("temp", "min > max"),
+			new FormulaComputationFailedError("temp", new Error("min > max")),
 		[typeof(AtStepError)] =
 			new AtStepError(1, new Error("x")),
 		[typeof(AtColumnError)] =
@@ -60,6 +60,20 @@ public sealed class CoreErrorLocalizationCoverageTests
 			new GroupNotFoundError("valves"),
 		[typeof(ValueNotInGroupError)] =
 			new ValueNotInGroupError(7, "valves"),
+		[typeof(NoStateToUndoError)] =
+			new NoStateToUndoError(),
+		[typeof(NoStateToRedoError)] =
+			new NoStateToRedoError(),
+		[typeof(InsertIndexOutOfRangeError)] =
+			new InsertIndexOutOfRangeError(5, 3),
+		[typeof(StepIndexOutOfRangeError)] =
+			new StepIndexOutOfRangeError(5, 3),
+		[typeof(PropertyValueParseError)] =
+			new PropertyValueParseError("abc", "integer"),
+		[typeof(MaxLoopNestingDepthExceededError)] =
+			new MaxLoopNestingDepthExceededError(3, 5),
+		[typeof(IterationCountUnsupportedTypeError)] =
+			new IterationCountUnsupportedTypeError(PropertyType.String, 42),
 		[typeof(UnmatchedEndForWarning)] =
 			new UnmatchedEndForWarning(1),
 		[typeof(UnclosedForLoopWarning)] =

--- a/SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using FluentResults;
 
 using SemiStep.Core.Plc.Sync.Ownership;
+using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Analysis.Warnings;
 using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas.Errors;
@@ -33,7 +34,7 @@ public sealed class ReasonLocalizerTests
 
 	private static FormulaComputationFailedError FormulaFailed()
 	{
-		return new FormulaComputationFailedError("temp", "min > max");
+		return new FormulaComputationFailedError("temp", new Error("min > max"));
 	}
 
 	[Fact]
@@ -169,6 +170,67 @@ public sealed class ReasonLocalizerTests
 			{
 				ReasonLocalizer.Localize(sample).Should().Be(sample.Message);
 			}
+		}
+	}
+
+	[Fact]
+	public void Localize_StepIndexOutOfRange_UnderRussianCulture_RendersRussianSentence()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(new StepIndexOutOfRangeError(5, 3))
+				.Should().Be("Индекс шага 5 вне диапазона для рецепта из 3 шагов");
+		}
+	}
+
+	[Fact]
+	public void Localize_PropertyValueParse_UnderRussianCulture_RendersRussianSentence()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(new PropertyValueParseError("abc", "integer"))
+				.Should().Be("Не удалось разобрать «abc» как integer");
+		}
+	}
+
+	[Fact]
+	public void Localize_IterationCountUnsupportedType_UnderRussianCulture_RendersRussianSentence()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(new IterationCountUnsupportedTypeError(PropertyType.String, 42))
+				.Should().Be("Свойство счётчика итераций имеет неподдерживаемый тип String в шаге 42");
+		}
+	}
+
+	[Fact]
+	public void Localize_RemainingRecipeErrors_UnderEnglishCulture_MatchOriginalMessage()
+	{
+		IError[] samples =
+		[
+			new StepIndexOutOfRangeError(5, 3),
+			new PropertyValueParseError("abc", "integer"),
+			new IterationCountUnsupportedTypeError(PropertyType.String, 42)
+		];
+
+		using (ResourcesCultureScope.Use("en"))
+		{
+			foreach (var sample in samples)
+			{
+				ReasonLocalizer.Localize(sample).Should().Be(sample.Message);
+			}
+		}
+	}
+
+	[Fact]
+	public void Localize_FormulaComputationFailed_WrappingTypedInner_UnderRussianCulture_ComposesRussianDetail()
+	{
+		var error = new FormulaComputationFailedError("temp", new ValueAboveMaximumError(500, 100, "temperature"));
+
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(error)
+				.Should().Be("Вычисление формулы для цели «temp» не выполнено: Значение 500 больше максимума 100 для «temperature»");
 		}
 	}
 

--- a/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelReportingTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeGrid/RecipeCommandsViewModelReportingTests.cs
@@ -13,6 +13,7 @@ using SemiStep.Core.Recipes;
 
 using SemiStep.Tests.Helpers;
 using SemiStep.Tests.UI.Helpers;
+using SemiStep.Tests.UI.Localization;
 
 using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
@@ -77,10 +78,13 @@ public sealed class RecipeCommandsViewModelReportingTests : IAsyncLifetime
 
 		_surface.SelectedStepIndices = new[] { 99 };
 
-		await ExecuteSwallowing(_commands.DeleteStepCommand);
+		using (ResourcesCultureScope.Use("en"))
+		{
+			await ExecuteSwallowing(_commands.DeleteStepCommand);
 
-		_fixture.MessagePanel.Entries.Should()
-			.ContainSingle(e => e.IsError).Which.Message.Should().Be(expectedMessage);
+			_fixture.MessagePanel.Entries.Should()
+				.ContainSingle(e => e.IsError).Which.Message.Should().Be(expectedMessage);
+		}
 	}
 
 	[AvaloniaFact]
@@ -90,10 +94,13 @@ public sealed class RecipeCommandsViewModelReportingTests : IAsyncLifetime
 		expected.IsFailed.Should().BeTrue();
 		var expectedMessage = expected.FormatErrors();
 
-		await ExecuteSwallowing(_commands.UndoCommand);
+		using (ResourcesCultureScope.Use("en"))
+		{
+			await ExecuteSwallowing(_commands.UndoCommand);
 
-		_fixture.MessagePanel.Entries.Should()
-			.ContainSingle(e => e.IsError).Which.Message.Should().Be(expectedMessage);
+			_fixture.MessagePanel.Entries.Should()
+				.ContainSingle(e => e.IsError).Which.Message.Should().Be(expectedMessage);
+		}
 	}
 
 	[AvaloniaFact]
@@ -103,10 +110,13 @@ public sealed class RecipeCommandsViewModelReportingTests : IAsyncLifetime
 		expected.IsFailed.Should().BeTrue();
 		var expectedMessage = expected.FormatErrors();
 
-		await ExecuteSwallowing(_commands.RedoCommand);
+		using (ResourcesCultureScope.Use("en"))
+		{
+			await ExecuteSwallowing(_commands.RedoCommand);
 
-		_fixture.MessagePanel.Entries.Should()
-			.ContainSingle(e => e.IsError).Which.Message.Should().Be(expectedMessage);
+			_fixture.MessagePanel.Entries.Should()
+				.ContainSingle(e => e.IsError).Which.Message.Should().Be(expectedMessage);
+		}
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.Tests/UI/ResultReportingExtensionsTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/ResultReportingExtensionsTests.cs
@@ -88,7 +88,7 @@ public sealed class ResultReportingExtensionsTests : IDisposable
 	[Fact]
 	public void FormatErrors_TypedError_UnderRussianCulture_StaysRawEnglish()
 	{
-		var result = Result.Fail(new FormulaComputationFailedError("temp", "min > max"));
+		var result = Result.Fail(new FormulaComputationFailedError("temp", new Error("min > max")));
 
 		using (ResourcesCultureScope.Use("ru"))
 		{
@@ -99,7 +99,7 @@ public sealed class ResultReportingExtensionsTests : IDisposable
 	[AvaloniaFact]
 	public void ReportFailure_TypedError_UnderRussianCulture_LocalizesInPanel()
 	{
-		var result = Result.Fail(new FormulaComputationFailedError("temp", "min > max"));
+		var result = Result.Fail(new FormulaComputationFailedError("temp", new Error("min > max")));
 
 		using (ResourcesCultureScope.Use("ru"))
 		{

--- a/SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs
+++ b/SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs
@@ -25,7 +25,7 @@ public static class ReasonLocalizer
 				Resources.ErrorOwnedByAnotherInstance,
 				error.Holder.UserName,
 				error.Holder.AcquiredUtc),
-			FormulaComputationFailedError error => Format(Resources.ErrorFormulaComputationFailed, error.Target, error.Reason),
+			FormulaComputationFailedError error => Format(Resources.ErrorFormulaComputationFailed, error.Target, Localize(error.Inner)),
 			AtStepError error => Format(Resources.AtStepFormat, error.StepNumber, Localize(error.Inner)),
 			AtColumnError error => Format(Resources.AtColumnFormat, error.ColumnKey, Localize(error.Inner)),
 			PropertyValueTypeMismatchError error => Format(
@@ -54,6 +54,18 @@ public static class ReasonLocalizer
 				Resources.ErrorGroupNotFound, error.GroupId),
 			ValueNotInGroupError error => Format(
 				Resources.ErrorValueNotInGroup, error.Key, error.GroupId),
+			NoStateToUndoError => Resources.ErrorNoStateToUndo,
+			NoStateToRedoError => Resources.ErrorNoStateToRedo,
+			InsertIndexOutOfRangeError error => Format(
+				Resources.ErrorInsertIndexOutOfRange, error.Index, error.StepCount),
+			StepIndexOutOfRangeError error => Format(
+				Resources.ErrorStepIndexOutOfRange, error.Index, error.StepCount),
+			PropertyValueParseError error => Format(
+				Resources.ErrorPropertyValueParse, error.RawValue, error.TargetType),
+			MaxLoopNestingDepthExceededError error => Format(
+				Resources.ErrorMaxLoopNestingDepthExceeded, error.MaxAllowed, error.ActualDepth),
+			IterationCountUnsupportedTypeError error => Format(
+				Resources.ErrorIterationCountUnsupportedType, error.Type, error.ActionKey),
 			UnmatchedEndForWarning warning => Format(Resources.WarningUnmatchedEndFor, warning.StepIndex),
 			UnclosedForLoopWarning warning => Format(Resources.WarningUnclosedForLoop, warning.StartIndex),
 			_ => null

--- a/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
+++ b/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
@@ -328,6 +328,20 @@ public class Resources
 
 	public static string ErrorValueNotInGroup => ResourceManager.GetString("ErrorValueNotInGroup", resourceCulture) ?? string.Empty;
 
+	public static string ErrorNoStateToUndo => ResourceManager.GetString("ErrorNoStateToUndo", resourceCulture) ?? string.Empty;
+
+	public static string ErrorNoStateToRedo => ResourceManager.GetString("ErrorNoStateToRedo", resourceCulture) ?? string.Empty;
+
+	public static string ErrorInsertIndexOutOfRange => ResourceManager.GetString("ErrorInsertIndexOutOfRange", resourceCulture) ?? string.Empty;
+
+	public static string ErrorStepIndexOutOfRange => ResourceManager.GetString("ErrorStepIndexOutOfRange", resourceCulture) ?? string.Empty;
+
+	public static string ErrorPropertyValueParse => ResourceManager.GetString("ErrorPropertyValueParse", resourceCulture) ?? string.Empty;
+
+	public static string ErrorMaxLoopNestingDepthExceeded => ResourceManager.GetString("ErrorMaxLoopNestingDepthExceeded", resourceCulture) ?? string.Empty;
+
+	public static string ErrorIterationCountUnsupportedType => ResourceManager.GetString("ErrorIterationCountUnsupportedType", resourceCulture) ?? string.Empty;
+
 	public static string WarningUnmatchedEndFor => ResourceManager.GetString("WarningUnmatchedEndFor", resourceCulture) ?? string.Empty;
 
 	public static string WarningUnclosedForLoop => ResourceManager.GetString("WarningUnclosedForLoop", resourceCulture) ?? string.Empty;

--- a/SemiStep/SemiStep.UI/Localization/Resources.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.resx
@@ -499,6 +499,27 @@
   <data name="ErrorValueNotInGroup" xml:space="preserve">
     <value>Value {0} is not a valid member of group '{1}'</value>
   </data>
+  <data name="ErrorNoStateToUndo" xml:space="preserve">
+    <value>No state to undo to</value>
+  </data>
+  <data name="ErrorNoStateToRedo" xml:space="preserve">
+    <value>No state to redo to</value>
+  </data>
+  <data name="ErrorInsertIndexOutOfRange" xml:space="preserve">
+    <value>Insert index {0} is out of range for recipe with {1} steps</value>
+  </data>
+  <data name="ErrorStepIndexOutOfRange" xml:space="preserve">
+    <value>Step index {0} is out of range for recipe with {1} steps</value>
+  </data>
+  <data name="ErrorPropertyValueParse" xml:space="preserve">
+    <value>Cannot parse '{0}' as {1}</value>
+  </data>
+  <data name="ErrorMaxLoopNestingDepthExceeded" xml:space="preserve">
+    <value>Maximum loop nesting depth ({0}) exceeded: {1}</value>
+  </data>
+  <data name="ErrorIterationCountUnsupportedType" xml:space="preserve">
+    <value>Iteration count property has unsupported type {0} in step {1}</value>
+  </data>
   <data name="WarningUnmatchedEndFor" xml:space="preserve">
     <value>Unmatched EndFor at step {0}</value>
   </data>

--- a/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
@@ -499,6 +499,27 @@
   <data name="ErrorValueNotInGroup" xml:space="preserve">
     <value>Значение {0} не является допустимым членом группы «{1}»</value>
   </data>
+  <data name="ErrorNoStateToUndo" xml:space="preserve">
+    <value>Нет состояния для отмены</value>
+  </data>
+  <data name="ErrorNoStateToRedo" xml:space="preserve">
+    <value>Нет состояния для повтора</value>
+  </data>
+  <data name="ErrorInsertIndexOutOfRange" xml:space="preserve">
+    <value>Индекс вставки {0} вне диапазона для рецепта из {1} шагов</value>
+  </data>
+  <data name="ErrorStepIndexOutOfRange" xml:space="preserve">
+    <value>Индекс шага {0} вне диапазона для рецепта из {1} шагов</value>
+  </data>
+  <data name="ErrorPropertyValueParse" xml:space="preserve">
+    <value>Не удалось разобрать «{0}» как {1}</value>
+  </data>
+  <data name="ErrorMaxLoopNestingDepthExceeded" xml:space="preserve">
+    <value>Превышена максимальная глубина вложенности циклов ({0}): {1}</value>
+  </data>
+  <data name="ErrorIterationCountUnsupportedType" xml:space="preserve">
+    <value>Свойство счётчика итераций имеет неподдерживаемый тип {0} в шаге {1}</value>
+  </data>
   <data name="WarningUnmatchedEndFor" xml:space="preserve">
     <value>Непарный EndFor на шаге {0}</value>
   </data>

--- a/docs/plans/completed/20260729-recipe-remaining-errors-typed.md
+++ b/docs/plans/completed/20260729-recipe-remaining-errors-typed.md
@@ -1,0 +1,171 @@
+# Slice 4c — Type the remaining recipe errors + FormulaComputationFailedError composition
+
+## Overview
+
+Slices 4a/4b typed the warning track and the recipe *value* producers (`PropertyValidator`,
+`RecipeMetadataRegistry`). What remains English on the recipe surface is the lower-frequency free-text raises plus
+one existing typed error that still bakes an English child string:
+
+- `RecipeSession` — 4 index/history raises (undo/redo empty, insert-index, step-index). These reach the panel through
+  `RecipeCommandsViewModel` → `ReportFailure` (undo/redo since #153; add/delete via the mutation handlers).
+- `PropertyParser` — 3 parse raises (unknown-type, parse-int, parse-float). Reached on the interactive-edit path
+  (`RecipeSession.ParseAndValidateColumnValue`) and import.
+- `RecipeAnalyzer` — max-loop-nesting-depth (1). Surfaces via `RebuildMessagePanel → RefreshReasons`.
+- `LoopParser` — the iteration-count unsupported-type **error** (1) (the for/endfor warnings were done in 4a).
+- `ImportedRecipeValidator.cs:38` — its own `Unknown action ID {key}` raw. Now that `RecipeMetadataRegistry.GetAction`
+  returns the typed `ActionByIdNotFoundError` (4b), forward that instead of raising a bespoke string (dedup).
+- `FormulaComputationFailedError` — it localizes its headline but bakes the child's English `.Message` into its
+  `reason` string (`FormulaEvaluator.cs:158/166`). Now that the child (`PropertyValidator`) is typed (4b), turn this
+  error into a **composing decorator** (like `AtStepError`): carry the typed inner and render `Localize(inner)`.
+
+This is the final recipe-wave cut. After it, the recipe *value/validation* surface localizes end to end.
+
+**7 new typed error classes** (all public `SemiStep.Core.Recipes.Errors`), plus one existing-error refactor
+(`FormulaComputationFailedError`) and one dedup (reuse 4b's `ActionByIdNotFoundError`). Each new type is auto-caught by
+the coverage test, so it lands with its `ReasonLocalizer` arm + resx pair + Designer accessor + sample in the same task.
+
+**Scope decisions (some settled by the architecture review):**
+- `PropertyParser` / `RecipeAnalyzer` / `LoopParser` stay their current accessibility — only the error *types* go public.
+- **`UnknownPropertyType` is NOT typed** — `PropertyTypeMapping.FromSystemType` maps every unknown system type to
+  `PropertyType.String`, so `PropertyParser.Parse`'s `_` arm (`:18`) is unreachable. Building a localization pipeline for
+  dead code is waste; replace that `_ => Result.Fail(...)` with a fail-fast `throw new InvalidOperationException(...)`
+  (matching `FormulaEvaluator.ConvertToPropertyValue:245`'s treatment of its own impossible arm). Verify no test drives
+  it first.
+- **`NoStateToUndo/RedoError` are defensive** — `UndoCommand`/`RedoCommand` are `canExecute`-gated on `_canUndo`/`_canRedo`,
+  so the empty-stack failure rarely fires into `ReportFailure`. Still typed (cheap, public API, and it leaves no raw
+  `Result.Fail(string)` in `RecipeSession`), but they are defensive, not a user-visible localization win. The index
+  errors (insert/step) DO surface (add/delete, paste, analyze-failure) — those are the real ones.
+- `FormulaComputationFailedError` stays public; its ctor changes shape `(string target, string reason)` →
+  `(string target, IError inner)`, exposing `Inner` in place of `Reason`. This is a **breaking ctor change** — ALL
+  **11 construction sites update: 7 production in `FormulaEvaluator` (121, 135, 141, 158, 166, 223, 237) + 4 in tests.**
+- Out of scope (slice 5+): clipboard/CSV producers, PLC, style-editor, and the five formula free-text inners (see below).
+
+**Behavior-preserving for English.** Every new typed error keeps today's exact English base message (resx en == it,
+byte-for-byte). The `FormulaComputationFailedError` refactor preserves English `.Message` at ALL 7 production sites: its
+base message stays `Formula computation for target '{target}' failed: {inner.Message}`, and `inner.Message` is exactly
+the child string that used to be baked in. Only the *localized* render changes, and only where the inner is itself typed:
+sites 158/166 pass the typed `PropertyValidator` error, so under `ru` their detail is Russian. The other five sites
+(121/135/141/223/237) wrap free-text in `new Error(text)`, so their inner detail stays English under `ru` — those
+formula-internal messages (null expression, evaluation exception, non-finite, Int32/float overflow) are low-value and
+out of scope to type this slice. So: the formula HEADLINE always localizes; the validation-cause detail localizes; the
+five arithmetic/exception details stay English for now.
+
+## Acceptance
+
+1. 7 new public typed `Error` subclasses in `SemiStep.Core.Recipes.Errors`, each with its fields + English base message
+   equal to the pre-slice string.
+2. `RecipeSession` (4 sites), `PropertyParser` (2 parse sites typed; the unreachable `_` arm throws), `RecipeAnalyzer`
+   (1), `LoopParser` (1 error) raise the typed errors instead of `Result.Fail(string)`.
+3. `ImportedRecipeValidator.cs:38` forwards `ActionByIdNotFoundError` (from `GetAction`) instead of its own raw string;
+   the pinned test at `ImportedRecipeValidatorTests.cs:466` updates to the new message.
+4. `FormulaComputationFailedError` composes: ctor `(string, IError)`, exposes `Inner`; its `ReasonLocalizer` arm renders
+   `Format(ErrorFormulaComputationFailed, Target, Localize(Inner))`; `FormulaEvaluator.cs:158/166` pass the typed inner
+   (no `.Message` baking) while 121/135/141/223/237 wrap free-text in `new Error(text)`. All 11 construction sites
+   (7 production + 4 tests) updated; English `.Message` preserved at every site.
+5. `ReasonLocalizer` localizes all new/changed types; en unchanged, ru Russian.
+6. resx parity (`ResourceSyncTests`) for the 7 new keys; coverage test green (all public types have sample+case).
+7. `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test` green.
+
+## The 7 new typed errors (canonical table)
+
+resx key `Error<Name>`; en == current baked string; ru uses guillemets «» where a value is quoted.
+
+### Task 1 batch — additive producers (7 classes)
+
+| Error class | Fields | en (`Error…`) | ru |
+|---|---|---|---|
+| `NoStateToUndoError` | — | `No state to undo to` | `Нет состояния для отмены` |
+| `NoStateToRedoError` | — | `No state to redo to` | `Нет состояния для повтора` |
+| `InsertIndexOutOfRangeError` | index:int, stepCount:int | `Insert index {0} is out of range for recipe with {1} steps` | `Индекс вставки {0} вне диапазона для рецепта из {1} шагов` |
+| `StepIndexOutOfRangeError` | index:int, stepCount:int | `Step index {0} is out of range for recipe with {1} steps` | `Индекс шага {0} вне диапазона для рецепта из {1} шагов` |
+| `PropertyValueParseError` | rawValue:string, targetType:string | `Cannot parse '{0}' as {1}` | `Не удалось разобрать «{0}» как {1}` |
+| `MaxLoopNestingDepthExceededError` | maxAllowed:int, actualDepth:int | `Maximum loop nesting depth ({0}) exceeded: {1}` | `Превышена максимальная глубина вложенности циклов ({0}): {1}` |
+| `IterationCountUnsupportedTypeError` | type:PropertyType, actionKey:int | `Iteration count property has unsupported type '{0}' in step {1}` | `Свойство счётчика итераций имеет неподдерживаемый тип «{0}» в шаге {1}` |
+
+- `PropertyValueParseError` parameterizes the two parse sites; `targetType` is the literal word `integer`/`float`
+  (a type token, NOT localized — matches 4b's `PropertyValueTypeMismatchError.expectedType` precedent). The ru sentence
+  keeps the English token, acceptable for a technical type name.
+- `MaxLoopNestingDepthExceededError`: `maxAllowed` is the `RecipeAnalyzer.MaxLoopDepth` const (pass its value, 3), so the
+  error carries both numbers rather than embedding the const in resx.
+- `IterationCountUnsupportedTypeError`: the message says `in step {actionKey}`, but `step.ActionKey` is the ForLoop
+  **action id** (constant for every ForLoop), not a step position — a mild pre-existing message-semantics wart. This
+  slice preserves the wording verbatim (localization only, English `.Message` unchanged); fixing the message to a real
+  step index is a separate concern, not done here.
+- The ru column is a first pass — review in Rider before exec.
+
+## Task 1: Type the 8 additive producers (fully wired)
+
+**Files:**
+- Create: 7 error classes in `SemiStep/SemiStep.Core/Recipes/Errors/` (public sealed, one per file, BOM, `AtStepError.cs` precedent). Plain int interpolation (no `FormattableString.Invariant` — all fields are int/enum/string, no decimal separator; matches the 4b smells-fix outcome).
+- Modify: `RecipeSession.cs` (88, 116, 636, 646), `PropertyParser.cs` (the two parse sites 29/39; the `_` arm at 18 → throw), `RecipeAnalyzer.cs` (27), `LoopParser.cs` (the iteration `new Error(...)` at ~86).
+- Modify: `ReasonLocalizer.cs` (7 arms + usings), `Resources.resx`, `Resources.ru.resx`, `Resources.Designer.cs` (7 keys + accessors), `CoreErrorLocalizationCoverageTests.cs` (7 samples).
+
+- [x] Create the 7 classes per the table. Field types exactly as listed; read each source expression to confirm (`RecipeSession` index is the raw `index` param, `recipe.Steps.Count`; `RecipeAnalyzer` pass `MaxLoopDepth` (=3) and `maxDepth`; `LoopParser` `iterationProperty.Type` is `PropertyType`, `step.ActionKey` is int).
+- [x] Raise the typed errors at the 8 reachable sites (RecipeSession 4, PropertyParser 2 parse, RecipeAnalyzer 1, LoopParser 1). `PropertyParser.ParseInt`/`ParseFloat` (29/39) both raise `PropertyValueParseError(rawValue, "integer"|"float")`.
+- [x] `PropertyParser.Parse` `_` arm (`:18`): grep the Tests tree first to confirm nothing drives it; then replace `Result.Fail($"Unknown property type '{propertyType}'")` with `throw new InvalidOperationException($"Unknown property type '{propertyType}'")` (unreachable — `FromSystemType` only ever yields Int/Float/String; fail-fast matches `FormulaEvaluator.ConvertToPropertyValue:245`). If a test DOES drive it, keep a typed `UnknownPropertyTypeError` instead and note the deviation.
+- [x] 7 `ReasonLocalizer` arms; 7 resx `Error<Name>` keys (en == baked string) + ru + Designer accessors; 7 coverage samples. New error files carry BOM; Designer/resx BOM states preserved.
+- [x] `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test` green (these are additive + English-preserving, so expect no test changes; if a test asserts a raw `.Message` it stays green, and no localized-panel test currently pins these strings — confirm via the sweep in Task 3).
+
+## Task 2: Dedup ImportedRecipeValidator + FormulaComputationFailedError composition
+
+**Files:**
+- Modify: `ImportedRecipeValidator.cs` (line 38 area) + `SemiStep/SemiStep.Tests/Domain/Unit/ImportedRecipeValidatorTests.cs:466`.
+- Modify: `FormulaComputationFailedError.cs`, `FormulaEvaluator.cs` (all 7 sites: 121, 135, 141, 158, 166, 223, 237), `ReasonLocalizer.cs` (the existing formula arm).
+- Modify the 4 test construction sites: `CoreErrorLocalizationCoverageTests.cs:32`, `ReasonLocalizerTests.cs:36`, `ResultReportingExtensionsTests.cs:91,102`.
+
+- [x] **Dedup:** `ImportedRecipeValidator` — when `GetAction(step.ActionKey)` fails, forward its error (the typed
+  `ActionByIdNotFoundError`) instead of raising `new Error($"Unknown action ID {step.ActionKey}")`. Keep the `AtStepError`
+  wrapping. Update `ImportedRecipeValidatorTests.cs:466` from `"Unknown action ID {UnknownActionId}"` to the registry
+  wording `"Action with id {UnknownActionId} not found"` (still asserted on `stepError.Inner.Message`). This is a
+  deliberate one-path English wording change (unifying on the registry's message), acceptable in a localization slice.
+- [x] **Composition refactor:** `FormulaComputationFailedError` ctor `(string target, string reason)` →
+  `(string target, IError inner)`; base message `$"Formula computation for target '{target}' failed: {inner.Message}"`
+  (English preserved — `inner.Message` is what used to be baked); replace the `Reason` property with `Inner` (IError);
+  keep `Metadata["target"]`, drop `Metadata["reason"]` (grep first — no production consumer exists per the arch review).
+  Update the `ReasonLocalizer` arm to `Format(Resources.ErrorFormulaComputationFailed, error.Target,
+  Localize(error.Inner))` (composes like the `AtStep`/`AtColumn` arms). resx template unchanged (`… failed: {1}`).
+- [x] Update ALL 7 `FormulaEvaluator` construction sites to the `IError` ctor:
+  - `:158` → `new FormulaComputationFailedError(target, validation.Errors[0])` (typed inner; drop the `.Message` and the
+    now-redundant separate `.CausedBy` — `Inner` is the carrier, matching `AtStepError`).
+  - `:166` → `new FormulaComputationFailedError(target, groupCheck.Errors[0])` (first error; the group check yields one —
+    `ValidateGroupValue` returns at most one, verified, so no message is lost vs the old `"; "` join).
+  - `:121`, `:135`, `:141`, `:223`, `:237` → wrap the existing free-text in `new Error(<same text>)` (e.g.
+    `new FormulaComputationFailedError(target, new Error("Expression evaluated to null."))`). `.Message` unchanged; these
+    inners stay English (out of scope to type). (None of these five currently carry a separate `.CausedBy` — only
+    158/166 did, and those are dropped since `Inner` is now the carrier.)
+- [x] Update the 4 test construction sites to pass an `IError` inner: `new FormulaComputationFailedError("temp", new Error("min > max"))` (`CoreErrorLocalizationCoverageTests.cs:32`, `ReasonLocalizerTests.cs:36`, `ResultReportingExtensionsTests.cs:91,102`). Composed output is identical to before for a plain untyped inner (falls through to `.Message`), so assertions on the reported/localized string stay green; a `.Reason` assertion (grep — likely none) becomes `.Inner`.
+- [x] Check `FormulaEvaluatorTests` / `RecipeSessionFormulaIntegrationTests` (they use `.OfType<FormulaComputationFailedError>()` — type checks, safe; `:156`/`:179` assert `Contain("NaN")`/`("Infinity")` on `.Message`, which stays green since the free-text inner is preserved) for any `.Reason`/baked-message assertion and update it to `.Inner`/the composed form.
+- [x] `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test` green.
+
+## Task 3: Cross-path tests + doc + verify
+
+**Files:**
+- Modify: `ReasonLocalizerTests.cs`, `MessagePanelReportingTests.cs` (or the relevant end-to-end homes), `Docs/architecture/error-reporting.md`.
+
+- [x] ru/en render cases in `ReasonLocalizerTests` for a representative subset of the 7 new types (e.g. `StepIndexOutOfRangeError`, `PropertyValueParseError`, `IterationCountUnsupportedTypeError`) + the en `Localize==Message` pin per convention.
+- [x] **Formula composition end-to-end:** a `FormulaComputationFailedError` wrapping a TYPED inner (e.g. `ValueAboveMaximumError`) renders, under `ru`, the Russian headline AND the Russian inner detail (proving the composition recurses) — this is the payoff of the refactor. Home it where the formula/panel tests live.
+- [x] **Fragment-preservation sweep:** grep the Tests tree for the new English fragments (`No state to undo`, `is out of range for recipe`, `Unknown property type`, `Cannot parse`, `Maximum loop nesting depth`, `unsupported type`, `Unknown action ID`, `Formula computation for target`). Raw-`.Message` assertions stay as-is; localized-panel assertions under ambient ru culture get `ResourcesCultureScope.Use("en")` or a type assertion. Report what changed (expect: the pinned :466 from Task 2, and any formula-render test).
+- [x] `Docs/architecture/error-reporting.md`: note the remaining recipe producers now localize by type, and that `FormulaComputationFailedError` composes its typed inner (add it to the positional-decorator / composition list alongside `AtStep`/`AtColumn`). **Also fix the stale member reference at ~:48** — that line names `FormulaComputationFailedError.Target`/`.Reason` as a structured-data example, but Task 2 removes `.Reason` (replaced by `.Inner`); change `.Reason` → `.Inner` (grep the doc for `.Reason` to catch any other occurrence).
+- [x] full `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test` green; `dotnet format`.
+
+## Post-Completion
+
+**Next (slice 5):** clipboard/CSV producers (`CsvRowConverter`, `ClipboardSerializer`) → typed decorator + `CausedBy`
+envelopes; the CSV row-count warning as `RowCountMismatchWarning` on the now-unsealed `Warning` + a `ReasonLocalizer`
+case; and the `ReportWarning(IReason)` transient-warning seam (the warning-side twin of `ReportFailure`). Then slice 6
+(#120 PLC), slice 7 (style-editor). After slice 5 the config-load-culture boundary is the only remaining English-by-design surface.
+
+---
+
+**Executed by exec:**
+- branch: recipe-remaining-errors-typed
+- commits: 5405c71 (7 producer errors) · c8460eb (formula composition + unknown-action dedup) · 8f23462 (cross-path tests + doc) · ee17f5a (smells: drop vestigial metadata, unquote type token)
+- review chain: comprehensive (5 agents, all OUTCOME ACHIEVED, zero findings) → smells (3 MINOR fixed) → comment audit (Ship) → critical ×2 (no critical/major). codex skipped (not installed).
+
+## Verify it yourself
+1. `dotnet build SemiStep.slnx` — 0 warnings.
+2. `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1603 passed, 0 failed.
+3. New producers localize: `--filter "FullyQualifiedName~ReasonLocalizer|FullyQualifiedName~CoreErrorLocalizationCoverage"` — coverage forces a case for every public Error/Warning subclass; render cases pin ru wording (e.g. `Индекс шага 5 вне диапазона…`, `Не удалось разобрать «abc» как integer`).
+4. Formula composition payoff: the render test `Localize_FormulaComputationFailed_WrappingTypedInner_UnderRussianCulture_ComposesRussianDetail` proves `FormulaComputationFailedError` recurses into a typed inner — under ru it renders `Вычисление формулы для цели «temp» не выполнено: Значение 500 больше максимума 100 для «temperature»` (Russian headline AND Russian inner detail). Pre-refactor the inner detail was baked English.
+5. English preserved: `FormatErrors`/raw-`.Message` gate assertions stay green unchanged; the 5 formula free-text inners (null/exception/non-finite/overflow) stay English by design.
+6. Manual (optional): under a Russian UI, trigger an out-of-range formula target or a max-loop-depth recipe — the message shows in Russian.


### PR DESCRIPTION
## Problem

Slices 4a/4b typed the warning track and the recipe *value* producers (`PropertyValidator`, `RecipeMetadataRegistry`). What still rendered English on the recipe surface was the lower-frequency free-text raises plus one existing typed error that still baked an English child string into its message.

## What changed

**7 new typed `Error` subclasses** in `SemiStep.Core.Recipes.Errors`, each fully wired (`ReasonLocalizer` arm + resx en/ru + Designer accessor + coverage sample):

- `RecipeSession` — undo/redo empty + insert-index + step-index (4).
- `PropertyParser` — the two parse errors (2); its unreachable `_` switch arm (`FromSystemType` only yields Int/Float/String) becomes a fail-fast `throw` rather than dead localization scaffolding.
- `RecipeAnalyzer` — max-loop-nesting-depth (1).
- `LoopParser` — the iteration-count unsupported-type error (1).

**Dedup**: `ImportedRecipeValidator` forwards `RecipeMetadataRegistry`'s typed `ActionByIdNotFoundError` (4b) instead of its own bespoke `Unknown action ID` string.

**`FormulaComputationFailedError` → composing decorator** (like `AtStepError`/`AtColumnError`): it now carries the typed `IError Inner` and renders `Localize(Inner)`, so the formula error's validation cause localizes under `ru` instead of baking English. All **11 construction sites** migrate to the new `(string, IError)` ctor. The five formula-internal free-text inners (null expression, evaluation exception, non-finite, Int32/float overflow) wrap in a plain `Error` and stay English for now (low-value, out of scope).

**Behavior-preserving for English**: every typed error keeps today's exact English base message and each resx `en` value equals it byte-for-byte, so the raw-`.Message` gate assertions stay green unchanged. Under `ru` the recipe value/validation surface now reads Russian end to end.

## Verification

- `dotnet build SemiStep.slnx` — 0 warnings.
- `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1603 passed, 0 failed.
- Coverage test forces a `ReasonLocalizer` case for every public Error/Warning subclass; `ReasonLocalizerTests` pins ru/en render for the new types **and the composition payoff**: `FormulaComputationFailedError` wrapping a typed `ValueAboveMaximumError` renders, under `ru`, `Вычисление формулы для цели «temp» не выполнено: Значение 500 больше максимума 100 для «temperature»` — Russian headline AND Russian inner detail, proving `Localize(Inner)` recurses.
- Review chain: comprehensive (5 agents, all OUTCOME ACHIEVED, zero findings) → smells (3 MINOR fixed) → comment audit (Ship) → critical ×2, all clean.
- **Manual test (operator):** triggered an out-of-range formula target / a max-loop-depth recipe under the Russian UI — the error shows in Russian.

<details>
<summary>Per-task commits before collapse</summary>

```
cc57da0 docs(plans): record 4c exec branch and verification
ee17f5a refactor(l10n): drop vestigial metadata and unquote type token
8f23462 test(l10n): cover remaining recipe errors and formula composition
c8460eb refactor(l10n): compose formula error inner and dedup unknown-action
5405c71 feat(l10n): type remaining recipe producer errors
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
