### PR TITLE
feat(l10n): add transient-warning seam, localize row-count

### DIFF
--- a/Docs/architecture/error-reporting.md
+++ b/Docs/architecture/error-reporting.md
@@ -35,6 +35,13 @@ How a failed operation reaches the user. Read this before adding a new error-sur
   **localized** join of the result's errors (`ReasonLocalizer.Localize` over `result.Errors`) on the
   transient operation channel, optionally prefixed with `"{context}: "`. It no longer delegates to
   `FormatErrors`.
+- `void ReportWarnings(this MessagePanelViewModel, IResultBase)` — the warning-side twin of
+  `ReportFailure`. It surfaces the **localized** join of the result's warnings
+  (`ReasonLocalizer.Localize` over `result.Successes.OfType<Warning>()`) on the same transient operation
+  channel, and guards the empty case (no warning → no transient entry). This is the transient-warning
+  localizing path; it delegates to the raw `MessagePanelViewModel.ReportWarning(string)` member, which
+  stays as the internal sink that accepts an already-composed string. `RowCountMismatchWarning` (the CSV
+  row-count mismatch on file load) is the first typed warning to flow through it.
 
 A failed operation surfaces **all** of its error messages, not just `Errors[0]`. The message *set* is
 the same one the log records; under `Resources.Culture = ru` the panel text is localized while the log
@@ -56,10 +63,13 @@ template, formatting the structured data into it. An unmapped type falls through
 recurses over `CausedBy` (`IError.Reasons`), so a typed cause nested inside an untyped wrapper still
 localizes.
 
-Localization is applied at exactly **two panel seams**, both of which route their reasons through
+Localization is applied at exactly **three panel seams**, each of which routes its reasons through
 `ReasonLocalizer.Localize`:
 
-- `ResultReportingExtensions.ReportFailure` — the transient operation channel.
+- `ResultReportingExtensions.ReportFailure` — the transient operation channel, error side.
+- `ResultReportingExtensions.ReportWarnings` — the transient operation channel, warning side (the twin
+  of `ReportFailure`). Distinct from `RefreshReasons`: `ReportWarnings` carries the outcome of a single
+  operation, while `RefreshReasons` rebuilds the persistent snapshot-validity list.
 - `MessagePanelViewModel.RefreshReasons` — the persistent validation channel (both the error and the
   warning branch).
 
@@ -118,7 +128,8 @@ instead of `Result.Fail(string)`. `ImportedRecipeValidator` no longer raises its
 string — it forwards the registry's typed `ActionByIdNotFoundError`. With these typed, `Localize(Inner)`
 renders them localized rather than falling through to `.Message`.
 
-Still free-text (deferred to a later wave): clipboard/CSV producers, PLC, the style-editor, and the
+Still free-text (deferred to a later wave): clipboard/CSV producer errors (the CSV row-count warning is
+already typed — see above), PLC, the style-editor, and the
 five formula-internal free-text inners (null expression, evaluation exception, non-finite, Int32/float
 overflow), which stay English under `ru` because their inner is wrapped in a plain `new Error(text)`.
 

--- a/SemiStep/SemiStep.Core/Recipes/Import/CsvService.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Import/CsvService.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Extensions.Logging;
 
+using SemiStep.Core.Recipes.Import.Warnings;
 using SemiStep.Core.Shared;
 
 namespace SemiStep.Core.Recipes.Import;
@@ -52,8 +53,8 @@ public class CsvService
 
 		if (metadata.Rows > 0 && metadata.Rows != result.Value.StepCount)
 		{
-			okResult = okResult.WithWarning(
-				$"Row count mismatch in '{filePath}': metadata says {metadata.Rows}, actual is {result.Value.StepCount}");
+			okResult = okResult.WithSuccess(
+				new RowCountMismatchWarning(filePath, metadata.Rows, result.Value.StepCount));
 		}
 
 		_logger.LogInformation("Loaded recipe from {FilePath}: {StepCount} steps", filePath, result.Value.StepCount);

--- a/SemiStep/SemiStep.Core/Recipes/Import/Warnings/RowCountMismatchWarning.cs
+++ b/SemiStep/SemiStep.Core/Recipes/Import/Warnings/RowCountMismatchWarning.cs
@@ -1,0 +1,13 @@
+﻿using SemiStep.Core.Shared;
+
+namespace SemiStep.Core.Recipes.Import.Warnings;
+
+public sealed class RowCountMismatchWarning(string filePath, int metadataRows, int actualRows)
+	: Warning($"Row count mismatch in '{filePath}': metadata says {metadataRows}, actual is {actualRows}")
+{
+	public string FilePath { get; } = filePath;
+
+	public int MetadataRows { get; } = metadataRows;
+
+	public int ActualRows { get; } = actualRows;
+}

--- a/SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs
@@ -11,6 +11,7 @@ using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Analysis.Warnings;
 using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas.Errors;
+using SemiStep.Core.Recipes.Import.Warnings;
 using SemiStep.Core.Shared;
 
 using SemiStep.UI.Localization;
@@ -77,7 +78,9 @@ public sealed class CoreErrorLocalizationCoverageTests
 		[typeof(UnmatchedEndForWarning)] =
 			new UnmatchedEndForWarning(1),
 		[typeof(UnclosedForLoopWarning)] =
-			new UnclosedForLoopWarning(1)
+			new UnclosedForLoopWarning(1),
+		[typeof(RowCountMismatchWarning)] =
+			new RowCountMismatchWarning("recipe.csv", 5, 3)
 	};
 
 	[Fact]

--- a/SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs
@@ -11,8 +11,8 @@ using SemiStep.Core.Recipes;
 using SemiStep.Core.Recipes.Analysis.Warnings;
 using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas.Errors;
+using SemiStep.Core.Recipes.Import.Warnings;
 using SemiStep.Core.Shared;
-
 using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
 
@@ -89,6 +89,27 @@ public sealed class ReasonLocalizerTests
 			{
 				ReasonLocalizer.Localize(sample).Should().Be(sample.Message);
 			}
+		}
+	}
+
+	[Fact]
+	public void Localize_RowCountMismatchWarning_UnderRussianCulture_RendersRussianSentence()
+	{
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			ReasonLocalizer.Localize(new RowCountMismatchWarning("recipe.csv", 5, 3))
+				.Should().Be("Несоответствие количества строк в «recipe.csv»: метаданные указывают 5, фактически 3");
+		}
+	}
+
+	[Fact]
+	public void Localize_RowCountMismatchWarning_UnderEnglishCulture_MatchesOriginalMessage()
+	{
+		var sample = new RowCountMismatchWarning("recipe.csv", 5, 3);
+
+		using (ResourcesCultureScope.Use("en"))
+		{
+			ReasonLocalizer.Localize(sample).Should().Be(sample.Message);
 		}
 	}
 

--- a/SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 
 using FluentResults;
 
+using SemiStep.Core.Recipes.Import.Warnings;
 using SemiStep.Core.Shared;
 
 using SemiStep.Tests.UI.Localization;
@@ -234,5 +235,31 @@ public sealed class MessagePanelViewModelTests
 		}
 
 		panel.HasEntries.Should().BeTrue();
+	}
+
+	[AvaloniaFact]
+	public void ReportWarnings_TypedWarning_UnderRussianCulture_SurfacesRussianInOperationSlot()
+	{
+		var panel = new MessagePanelViewModel();
+		var result = Result.Ok().WithSuccess(new RowCountMismatchWarning("recipe.csv", 5, 3));
+
+		using (ResourcesCultureScope.Use("ru"))
+		{
+			panel.ReportWarnings(result);
+		}
+
+		var entry = panel.Entries.Should().ContainSingle().Subject;
+		entry.Severity.Should().Be(MessageSeverity.Warning);
+		entry.Message.Should().Be("Несоответствие количества строк в «recipe.csv»: метаданные указывают 5, фактически 3");
+	}
+
+	[AvaloniaFact]
+	public void ReportWarnings_ResultWithoutWarnings_ReportsNothing()
+	{
+		var panel = new MessagePanelViewModel();
+
+		panel.ReportWarnings(Result.Ok());
+
+		panel.Entries.Should().BeEmpty();
 	}
 }

--- a/SemiStep/SemiStep.Tests/UI/RecipeFile/RecipeFileViewModelLoadResultTests.cs
+++ b/SemiStep/SemiStep.Tests/UI/RecipeFile/RecipeFileViewModelLoadResultTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using SemiStep.Tests.Core.Helpers;
 using SemiStep.Tests.UI.Helpers;
+using SemiStep.Tests.UI.Localization;
 
 using SemiStep.UI.Localization;
 using SemiStep.UI.MessageService;
@@ -57,13 +58,16 @@ public sealed class RecipeFileViewModelLoadResultTests : IAsyncLifetime
 		await _fixture.CsvService.SaveAsync(driver.Recipe, _tempFilePath);
 		await PatchRowCountAsync(actualRows: 1, wrongRows: 99);
 
-		await _recipeFile.LoadRecipeCommand.Execute();
-		Dispatcher.UIThread.RunJobs();
+		using (ResourcesCultureScope.Use("en"))
+		{
+			await _recipeFile.LoadRecipeCommand.Execute();
+			Dispatcher.UIThread.RunJobs();
 
-		var entry = _fixture.MessagePanel.Entries.Should().ContainSingle().Subject;
-		entry.Severity.Should().Be(MessageSeverity.Warning,
-			"a hand-edited row-count mismatch must surface as a warning, not a plain success");
-		entry.Message.Should().Contain("Row count mismatch");
+			var entry = _fixture.MessagePanel.Entries.Should().ContainSingle().Subject;
+			entry.Severity.Should().Be(MessageSeverity.Warning,
+				"a hand-edited row-count mismatch must surface as a warning, not a plain success");
+			entry.Message.Should().Contain("Row count mismatch");
+		}
 	}
 
 	[AvaloniaFact]

--- a/SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs
+++ b/SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs
@@ -7,6 +7,7 @@ using SemiStep.Core.Plc.Sync.Ownership;
 using SemiStep.Core.Recipes.Analysis.Warnings;
 using SemiStep.Core.Recipes.Errors;
 using SemiStep.Core.Recipes.Formulas.Errors;
+using SemiStep.Core.Recipes.Import.Warnings;
 
 namespace SemiStep.UI.Localization;
 
@@ -68,6 +69,8 @@ public static class ReasonLocalizer
 				Resources.ErrorIterationCountUnsupportedType, error.Type, error.ActionKey),
 			UnmatchedEndForWarning warning => Format(Resources.WarningUnmatchedEndFor, warning.StepIndex),
 			UnclosedForLoopWarning warning => Format(Resources.WarningUnclosedForLoop, warning.StartIndex),
+			RowCountMismatchWarning warning => Format(
+				Resources.WarningRowCountMismatch, warning.FilePath, warning.MetadataRows, warning.ActualRows),
 			_ => null
 		};
 

--- a/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
+++ b/SemiStep/SemiStep.UI/Localization/Resources.Designer.cs
@@ -346,6 +346,8 @@ public class Resources
 
 	public static string WarningUnclosedForLoop => ResourceManager.GetString("WarningUnclosedForLoop", resourceCulture) ?? string.Empty;
 
+	public static string WarningRowCountMismatch => ResourceManager.GetString("WarningRowCountMismatch", resourceCulture) ?? string.Empty;
+
 	public static string CopyStepFailed => ResourceManager.GetString("CopyStepFailed", resourceCulture) ?? string.Empty;
 
 	public static string CutStepFailed => ResourceManager.GetString("CutStepFailed", resourceCulture) ?? string.Empty;

--- a/SemiStep/SemiStep.UI/Localization/Resources.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.resx
@@ -526,6 +526,9 @@
   <data name="WarningUnclosedForLoop" xml:space="preserve">
     <value>Unclosed For loop starting at step {0}</value>
   </data>
+  <data name="WarningRowCountMismatch" xml:space="preserve">
+    <value>Row count mismatch in '{0}': metadata says {1}, actual is {2}</value>
+  </data>
   <data name="CopyStepFailed" xml:space="preserve">
     <value>Copy failed</value>
   </data>

--- a/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
+++ b/SemiStep/SemiStep.UI/Localization/Resources.ru.resx
@@ -526,6 +526,9 @@
   <data name="WarningUnclosedForLoop" xml:space="preserve">
     <value>Незакрытый цикл For, начатый на шаге {0}</value>
   </data>
+  <data name="WarningRowCountMismatch" xml:space="preserve">
+    <value>Несоответствие количества строк в «{0}»: метаданные указывают {1}, фактически {2}</value>
+  </data>
   <data name="CopyStepFailed" xml:space="preserve">
     <value>Не удалось скопировать</value>
   </data>

--- a/SemiStep/SemiStep.UI/MessageService/ResultReportingExtensions.cs
+++ b/SemiStep/SemiStep.UI/MessageService/ResultReportingExtensions.cs
@@ -3,6 +3,8 @@ using System.Linq;
 
 using FluentResults;
 
+using SemiStep.Core.Shared;
+
 using SemiStep.UI.Localization;
 
 namespace SemiStep.UI.MessageService;
@@ -18,6 +20,15 @@ public static class ResultReportingExtensions
 	{
 		var message = Join(result.Errors.Select(ReasonLocalizer.Localize));
 		panel.ReportError(context is null ? message : $"{context}: {message}");
+	}
+
+	public static void ReportWarnings(this MessagePanelViewModel panel, IResultBase result)
+	{
+		var message = Join(result.Successes.OfType<Warning>().Select(ReasonLocalizer.Localize));
+		if (message.Length > 0)
+		{
+			panel.ReportWarning(message);
+		}
 	}
 
 	private static string Join(IEnumerable<string> parts)

--- a/SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs
+++ b/SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs
@@ -134,10 +134,9 @@ public class RecipeFileViewModel : ReactiveObject, IDisposable
 
 		CurrentFilePath = filePath;
 
-		var warnings = result.Successes.OfType<Warning>().ToList();
-		if (warnings.Count > 0)
+		if (result.Successes.OfType<Warning>().Any())
 		{
-			_messagePanel.ReportWarning(string.Join("; ", warnings.Select(warning => warning.Message)));
+			_messagePanel.ReportWarnings(result);
 		}
 		else
 		{

--- a/docs/plans/completed/20260730-warning-transient-seam.md
+++ b/docs/plans/completed/20260730-warning-transient-seam.md
@@ -1,0 +1,100 @@
+# Slice 5a — Transient-warning seam + typed CSV row-count warning
+
+## Overview
+
+The error track has a localizing transient seam (`ReportFailure` → `ReasonLocalizer.Localize` → the panel's operation
+slot). The warning track does not. Warnings only localize on the **snapshot-validity** channel
+(`RefreshReasons`, which already runs `OfType<Warning>()` through `ReasonLocalizer`); a **transient** warning has only
+the raw `ReportWarning(string)` sink, which shows its argument verbatim. So the one transient warning in the app — the
+CSV row-count-mismatch surfaced on file load — renders raw English regardless of culture, even after #153 made it
+surface at all.
+
+This slice builds the warning-side twin of `ReportFailure` and proves it on that warning:
+
+1. **`RowCountMismatchWarning`** (typed) replaces `CsvService`'s free-text `WithWarning($"…")`.
+2. **`ReportWarnings(this MessagePanelViewModel, IResultBase)`** — a new localizing extension mirroring `ReportFailure`
+   (without its `context` parameter — no caller needs it): maps `result.Successes.OfType<Warning>()` through
+   `ReasonLocalizer.Localize`, joins, and pushes to the transient slot. (Plural name — the existing raw
+   `ReportWarning(string)` member stays; this is the collection/localizing seam.)
+3. `RecipeFileViewModel.LoadRecipeAsync`'s raw `ReportWarning(string.Join(… warning.Message …))` becomes
+   `_messagePanel.ReportWarnings(result)` — the load-warning now localizes.
+
+It is the small mechanism cut of slice 5, before the CSV/clipboard error typing (5b/5c). The `ReportWarnings` seam is
+the roadmap's named "genuine new bit" — the transient-warning localizing path that did not exist.
+
+**Behavior-preserving for English.** `RowCountMismatchWarning`'s English base message equals today's exact string, and
+the resx en value equals it byte-for-byte. The raw-`.Message` test (`RecipeCoordinatorLoadRecipeTests`) stays green;
+only the localized-panel test needs a culture scope (below). Under `ru` the load warning now reads Russian.
+
+**Scope guard:** only the ONE transient warning (CSV row-count). The CSV/clipboard producer ERRORS
+(`CsvService`/`CsvFileSerializer`/`CsvRowConverter`/`ClipboardSerializer`) are 5b/5c. Config-loader warnings stay
+untyped English (out of the recipe scope). `RefreshReasons` (snapshot-validity warnings) already localizes and is not
+touched.
+
+## Acceptance
+
+1. `RowCountMismatchWarning` (public, `SemiStep.Core.Recipes.Import.Warnings`) carries `filePath`/`metadataRows`/`actualRows`
+   with an English base message identical to the pre-slice string; `CsvService` raises it instead of `WithWarning(string)`.
+2. `ReportWarnings(this MessagePanelViewModel, IResultBase)` localizes each `Successes.OfType<Warning>()` via
+   `ReasonLocalizer.Localize` and reports to the transient slot — the exact twin of `ReportFailure`.
+3. `RecipeFileViewModel.LoadRecipeAsync` uses `ReportWarnings(result)`; the CSV row-count warning renders Russian under `ru`.
+4. `ReasonLocalizer` localizes `RowCountMismatchWarning`; en unchanged, ru Russian. resx parity + coverage test green.
+5. `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test` green.
+
+## Task 1: Type the warning + build the seam + wire the call site
+
+**Files:**
+- Create: `SemiStep/SemiStep.Core/Recipes/Import/Warnings/RowCountMismatchWarning.cs` (public sealed, `Warning` base, `UnclosedForLoopWarning.cs`/`AtStepError.cs` as the shape precedent — fields + English base message).
+- Modify: `SemiStep/SemiStep.Core/Recipes/Import/CsvService.cs` (~55-56) — raise the typed warning.
+- Modify: `SemiStep/SemiStep.UI/MessageService/ResultReportingExtensions.cs` — add `ReportWarnings`.
+- Modify: `SemiStep/SemiStep.UI/RecipeFile/RecipeFileViewModel.cs` (~137-141) — call `ReportWarnings`.
+- Modify: `SemiStep/SemiStep.UI/Localization/ReasonLocalizer.cs` (arm + using), `Resources.resx`, `Resources.ru.resx`, `Resources.Designer.cs` (1 key + accessor), `SemiStep.Tests/UI/Localization/CoreErrorLocalizationCoverageTests.cs` (1 sample).
+- Modify (test fix): `SemiStep/SemiStep.Tests/UI/RecipeFile/RecipeFileViewModelLoadResultTests.cs` (~66).
+
+- [x] `RowCountMismatchWarning(string filePath, int metadataRows, int actualRows) : Warning($"Row count mismatch in '{filePath}': metadata says {metadataRows}, actual is {actualRows}")` exposing exactly these three get-only properties: `public string FilePath { get; } = filePath;`, `public int MetadataRows { get; } = metadataRows;`, `public int ActualRows { get; } = actualRows;` (these names are pinned — the `ReasonLocalizer` arm and coverage sample reference them). Namespace `SemiStep.Core.Recipes.Import.Warnings`. English base message byte-identical to the current `CsvService` string. Plain interpolation (ints, no `Invariant`). BOM on the new file.
+- [x] `CsvService.cs`: replace `okResult.WithWarning($"Row count mismatch in '{filePath}': metadata says {metadata.Rows}, actual is {result.Value.StepCount}")` with `okResult.WithSuccess(new RowCountMismatchWarning(filePath, metadata.Rows, result.Value.StepCount))` (`Warning : Success`, so `WithSuccess` carries it on `Successes` exactly as before — no new `WithWarning` overload needed). Add the `using`.
+- [x] `ResultReportingExtensions.cs`: add
+  `public static void ReportWarnings(this MessagePanelViewModel panel, IResultBase result)` that does
+  `var message = Join(result.Successes.OfType<Warning>().Select(ReasonLocalizer.Localize)); if (message.Length > 0) panel.ReportWarning(message);`
+  — mirrors `ReportFailure`, reuses the private `Join`, guards the empty case (no warning → no transient entry). `Warning` is `SemiStep.Core.Shared` — add the using.
+- [x] `RecipeFileViewModel.LoadRecipeAsync`: replace lines ~137-141's manual `result.Successes.OfType<Warning>()` filter + raw `ReportWarning(string.Join(… .Message …))` with the localizing `_messagePanel.ReportWarnings(result)`, keeping the `else` `ReportSuccess(Loaded)` branch. (The empty-guard lives in `ReportWarnings`, but keep the VM's `if warnings.Count > 0 … else ReportSuccess` shape so a clean load still shows "Loaded" — i.e. compute the warning list once, call `ReportWarnings(result)` in the `if`, `ReportSuccess` in the `else`.)
+- [x] `ReasonLocalizer`: arm `RowCountMismatchWarning warning => Format(Resources.WarningRowCountMismatch, warning.FilePath, warning.MetadataRows, warning.ActualRows)` + `using SemiStep.Core.Recipes.Import.Warnings;`.
+- [x] resx: `WarningRowCountMismatch` en `Row count mismatch in '{0}': metadata says {1}, actual is {2}` (== baked) + ru `Несоответствие количества строк в «{0}»: метаданные указывают {1}, фактически {2}` + hand-written Designer accessor. Coverage: 1 sample. BOM states preserved (Designer/resx as-is).
+- [x] **Culture-scope the localized-panel test.** `RecipeFileViewModelLoadResultTests.cs:66` asserts a panel entry `.Message.Should().Contain("Row count mismatch")` (Severity=Warning) with no scope; after the warning localizes via `ReportWarnings`, on this ru-locale machine the panel renders Russian → the assertion fails. Wrap the load+assert in `ResourcesCultureScope.Use("en")` (the test's intent is the English wording), OR update it to assert the ru render — pick the smaller edit; keep the "Loaded" success assertions (81-83/102-103) untouched. `ResourcesCultureScope` is `internal` in namespace `SemiStep.Tests.UI.Localization` (same assembly) — add the `using`. Confirm `RecipeCoordinatorLoadRecipeTests.cs:205-207` STAYS as-is: it reads the raw `Warning.Message` off `Successes` (English-preserved) and `OfType<Warning>()` still matches the subclass — do not touch it.
+- [x] `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` green.
+
+## Task 2: Cover the seam + doc + verify
+
+**Files:**
+- Modify: `SemiStep/SemiStep.Tests/UI/Localization/ReasonLocalizerTests.cs`, a MessagePanel/report test home, `Docs/architecture/error-reporting.md`.
+
+- [x] `ReasonLocalizerTests`: ru render case `new RowCountMismatchWarning("recipe.csv", 5, 3)` → `Несоответствие количества строк в «recipe.csv»: метаданные указывают 5, фактически 3` (under `ResourcesCultureScope.Use("ru")`) + an en `Localize(sample).Should().Be(sample.Message)` pin.
+- [x] **Seam end-to-end**: a `Result` carrying a `RowCountMismatchWarning` reported via `panel.ReportWarnings(result)` under `ResourcesCultureScope.Use("ru")` puts the Russian text in the transient operation slot (assert the panel entry is Severity=Warning + the ru string). Add an empty-result case: `ReportWarnings` on a result with no warnings reports NOTHING (no transient entry). Home it in `SemiStep/SemiStep.Tests/UI/MessagePanelViewModelTests.cs` (the transient-slot tests live there) — NOT a `MessagePanelReportingTests`, which does not exist.
+- [x] fragment sweep: grep the Tests tree for `Row count mismatch` — confirm only `RecipeCoordinatorLoadRecipeTests` (raw `.Message`, unchanged) and the now-scoped `RecipeFileViewModelLoadResultTests` remain; nothing else asserts it unscoped.
+- [x] `Docs/architecture/error-reporting.md`: document the transient-warning seam — `ReportWarnings` is the warning-side twin of `ReportFailure` (both localize into the transient slot), distinct from `RefreshReasons` (snapshot-validity, already localizing). Note `RowCountMismatchWarning` as the first typed transient warning.
+- [x] full `dotnet build SemiStep.slnx` 0 warnings; full `dotnet test` green; `dotnet format`.
+
+## Post-Completion
+
+**Next (slice 5b):** type the CSV producer chain — `CsvService` (not-found + IO exception-envelopes, Rule B),
+`CsvFileSerializer` (empty, header-mismatch, an `AtRowError` positional wrapper analogous to `AtStepError`),
+`CsvRowConverter` (action-column errors; turn the `Column '{k}': {inner.Message}` stringifier into a **composing**
+`ColumnParseError` envelope so the now-typed inner from 4b/4c localizes). Reuse `ActionByIdNotFoundError` (4b) for
+unknown-action where the semantics match. Then 5c (clipboard: `ClipboardParseFailedError` exception-envelope,
+`ColumnCountMismatchError`, `NoValidStepsError`, reusing 5b's shared `AtRowError`/action-column/`ColumnParseError`).
+After 5b/5c the clipboard+CSV ingress localizes; the config-load-culture boundary is the last English-by-design surface.
+
+---
+
+**Executed by exec:**
+- branch: warning-transient-seam
+- commits: 2d77a6e (typed warning + ReportWarnings seam + call-site swap) · 6131d86 (seam/render tests + doc) · d46a44f (review-1 fix: .Any() simplification + arch-doc clarifications)
+- review chain: comprehensive (5 agents, all OUTCOME ACHIEVED) → fixer d46a44f (2 LOW: VM double-filter, doc CSV-producers over-claim) → smells (clean, 1 no-fix MINOR) → comment audit (Ship) → critical ×2 (no critical/major). codex skipped (not installed).
+
+## Verify it yourself
+1. `dotnet build SemiStep.slnx` — 0 warnings.
+2. `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1608 passed, 0 failed.
+3. Row-count warning localizes: `--filter "FullyQualifiedName~ReasonLocalizer|FullyQualifiedName~CoreErrorLocalizationCoverage"` — coverage forces a case for every public Warning subclass; the ru render pins `Несоответствие количества строк в «recipe.csv»: метаданные указывают 5, фактически 3`.
+4. The transient seam: `--filter "FullyQualifiedName~MessagePanelViewModel"` — `ReportWarnings(result)` under ru puts the Russian warning in the transient slot (Severity=Warning); an empty result reports nothing.
+5. English preserved: `RecipeCoordinatorLoadRecipeTests` reads the raw `Warning.Message` off `Successes` unchanged; `RecipeFileViewModelLoadResultTests` is en-scoped and still asserts the English wording.
+6. Manual (optional): load a recipe CSV whose `# ROWS=` header disagrees with the body under a Russian UI — the panel shows the row-count mismatch in Russian (previously raw English).


### PR DESCRIPTION
## Problem

The error track has a localizing transient seam (`ReportFailure` → `ReasonLocalizer.Localize` → the panel's operation slot). The warning track did not: warnings localized only on the **snapshot-validity** channel (`RefreshReasons`), while a **transient** warning had only the raw `ReportWarning(string)` sink. So the one transient warning in the app — the CSV row-count mismatch surfaced on file load — rendered raw English regardless of culture, even after #153 made it surface at all.

## What changed

The warning-side twin of `ReportFailure`, proven on that one warning:

- **`RowCountMismatchWarning`** (typed, `SemiStep.Core.Recipes.Import.Warnings`) replaces `CsvService`'s free-text `WithWarning`. `CsvService` raises it via `WithSuccess`, so `Warning : Success` still rides the load result's `Successes` exactly as before.
- **`ReportWarnings(this MessagePanelViewModel, IResultBase)`** — a new localizing extension mirroring `ReportFailure`: maps `Successes.OfType<Warning>()` through `ReasonLocalizer.Localize`, joins, pushes to the transient operation slot (empty-guarded). It's the app's **third** panel seam, alongside `ReportFailure` and `RefreshReasons`.
- **`RecipeFileViewModel.LoadRecipeAsync`** routes the load warning through it; a clean load still shows "Loaded".

**Behavior-preserving for English**: the warning's base message equals today's exact string and the resx `en` value equals it byte-for-byte, so the raw-`.Message` test stays green. Under `ru` the load warning now reads Russian. **No double-display** — the warning rides the load result's `Successes`, not the snapshot channel `RefreshReasons` reads.

**Scope**: only the one transient warning. The CSV/clipboard producer *errors* are slices 5b/5c.

## Verification

- `dotnet build SemiStep.slnx` — 0 warnings.
- `dotnet test SemiStep/SemiStep.Tests/SemiStep.Tests.csproj` — 1608 passed, 0 failed.
- `ReasonLocalizerTests` pins the ru render + en `Localize == .Message`; the coverage test forces a case for the new public warning; `MessagePanelViewModelTests` drives `ReportWarnings(result)` under `ru` (Russian in the transient slot) and asserts the empty-result no-op.
- Review chain: comprehensive (5 agents, all OUTCOME ACHIEVED) → smells (clean) → comment audit (Ship) → critical ×2, clean after one LOW cleanup (`.Any()` + a doc clarification).
- **Manual test (operator):** loaded a recipe CSV whose `# ROWS` header disagreed with the body under the Russian UI — the row-count mismatch shows in Russian.

<details>
<summary>Per-task commits before collapse</summary>

```
f5bed2e docs(plans): record 5a exec branch and verification
d46a44f refactor(ui): simplify load-warning branch and clarify arch doc
6131d86 test(l10n): cover transient-warning seam and row-count render
2d77a6e feat(l10n): localize CSV row-count warning via transient seam
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
